### PR TITLE
Add ability to capture request headers & cookies

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -146,6 +146,16 @@ listen stats
 
 {{ if .BindPorts -}}
 frontend public
+
+    {{ range $idx,$value := split (env "CAPTURE_REQUEST_HEADERS") ":" }}
+  capture request header {{ $value }} len {{ env "CAPTURED_HEADER_LENGTH" "25" }}
+    {{- end }}
+    {{ range $idx,$value := split (env "CAPTURE_REQUEST_COOKIES") ":" }}
+  capture cookie {{ $value }} len {{ env "CAPTURED_COOKIE_LENGTH" "25" }}
+    {{- end }}
+    {{ range $idx,$value := split (env "CAPTURE_RESPONSE_HEADERS") ":" }}
+  capture response header {{ $value }} len {{ env "CAPTURED_HEADER_LENGTH" "25" }}
+    {{- end }}
     {{ if eq "v4v6" $router_ip_v4_v6_mode }}
   bind :::{{env "ROUTER_SERVICE_HTTP_PORT" "80"}} v4v6
     {{- else if eq "v6" $router_ip_v4_v6_mode }}
@@ -181,6 +191,16 @@ frontend public
 # determined by the next backend in the chain which may be an app backend (passthrough termination) or a backend
 # that terminates encryption in this router (edge)
 frontend public_ssl
+    {{ range $idx,$value := split (env "CAPTURE_REQUEST_HEADERS") ":" }}
+  capture request header {{ $value }} len {{ env "CAPTURED_HEADER_LENGTH" "25" }}
+    {{- end }}
+    {{ range $idx,$value := split (env "CAPTURE_REQUEST_COOKIES") ":" }}
+  capture cookie {{ $value }} len {{ env "CAPTURED_COOKIE_LENGTH" "25" }}
+    {{- end }}
+    {{ range $idx,$value := split (env "CAPTURE_RESPONSE_HEADERS") ":" }}
+  capture response header {{ $value }} len {{ env "CAPTURED_HEADER_LENGTH" "25" }}
+    {{- end }}
+
     {{- if ne (env "ROUTER_SYSLOG_ADDRESS") ""}}
   option tcplog
     {{- end }}

--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -294,4 +294,5 @@ var helperFunctions = template.FuncMap{
 	"generateHAProxyMap":           generateHAProxyMap,           //generates a haproxy map content
 	"validateHAProxyWhiteList":     validateHAProxyWhiteList,     //validates a haproxy whitelist (acl) content
 	"generateHAProxyWhiteListFile": generateHAProxyWhiteListFile, //generates a haproxy whitelist file for use in an acl
+	"split":                        strings.Split,                //split slices s into all substrings separated by sep and returns a slice of the substrings between those separators
 }


### PR DESCRIPTION
HAProxy allows to capture request/response headers and cookies, this PR make users able to capture these headers or cookies and print them in a log.
Also added strings.Split to template helpers functions that could be useful in a future.

more info: https://github.com/openshift/origin/pull/19704