### PR TITLE
Remove 'option tcplog' from passthrough backend in template router

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -508,9 +508,6 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
 
 # Secure backend, pass through
 backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
-{{- if ne (env "ROUTER_SYSLOG_ADDRESS") ""}}
-  option tcplog
-{{- end }}
     {{- with $balanceAlgo := firstMatch "roundrobin|leastconn|source" (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME" (env "ROUTER_LOAD_BALANCE_ALGORITHM")) }}
   balance {{ $balanceAlgo }}
     {{- else }}


### PR DESCRIPTION
Starting in HAProxy 1.8 the 'option tcplog' cannot be used in the
backends any more. I removed 'option tcplog' from the backend, the
logging option is appropriately selected in the frontend already

https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#option%20tcplog

Fixes
bug 1579729
https://bugzilla.redhat.com/show_bug.cgi?id=1579729