### PR TITLE
Fix ignoring non-server records when server threshold is exceeded

### DIFF
--- a/pkg/router/metrics/haproxy/haproxy.go
+++ b/pkg/router/metrics/haproxy/haproxy.go
@@ -429,9 +429,9 @@ loop:
 		// displaying only backends and frontends.
 		if row[32] == serverType {
 			servers++
-		}
-		if servers > e.opts.ServerThreshold {
-			continue
+			if servers > e.opts.ServerThreshold {
+				continue
+			}
 		}
 
 		rows++


### PR DESCRIPTION
When `ServerThreshold` is exceeded, it doesn't ignore the rest of the servers, it ignores the rest of the records including backend, frontend and server records. 

```go
		// If we exceed the server threshold, ignore the rest of the servers because we will be
		// displaying only backends and frontends.
		if row[32] == serverType {
			servers++
		}

        // --> Issue is here:
		if servers > e.opts.ServerThreshold {
			continue 
		}

		rows++
		e.parseRow(row, targetValues)
```

This PR fixes this issue. 

BTW, the older versions also have this issue, do you think I can backport this fix to those versions as well? 

3.10.0: https://github.com/openshift/origin/blob/v3.10.0/pkg/router/metrics/haproxy/haproxy.go#L428-L438
3.11.0: https://github.com/openshift/origin/blob/v3.11.0/pkg/router/metrics/haproxy/haproxy.go#L428-L438