### PR TITLE
Add support for generating and using tls ticket keys and rotation of the keys

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -233,6 +233,7 @@ frontend fe_sni
       {{- with (env "ROUTER_MUTUAL_TLS_AUTH_CA") }} ca-file {{.}} {{ else }} ca-file /etc/ssl/certs/ca-bundle.trust.crt {{ end }}
       {{- with (env "ROUTER_MUTUAL_TLS_AUTH_CRL") }} crl-file {{.}} {{ end }}
     {{- end }}
+    {{- with .SessionTicketKeys }} tls-ticket-keys {{.}} {{ end }}
     {{- if isTrue (env "ROUTER_ENABLE_HTTP2") }} alpn h2,http/1.1{{ end }}
   mode http
 
@@ -305,6 +306,7 @@ frontend fe_no_sni
       {{- with (env "ROUTER_MUTUAL_TLS_AUTH_CA") }} ca-file {{.}} {{ else }} ca-file /etc/ssl/certs/ca-bundle.trust.crt {{ end }}
       {{- with (env "ROUTER_MUTUAL_TLS_AUTH_CRL") }} crl-file {{.}} {{ end }}
     {{- end }}
+    {{- with .SessionTicketKeys }} tls-ticket-keys {{.}} {{ end }}
   mode http
 
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -43,12 +43,19 @@ import (
 	"github.com/openshift/router/pkg/router/writerlease"
 )
 
-// defaultReloadInterval is how often to do reloads in seconds.
-const defaultReloadInterval = 5
+const (
+	// defaultReloadInterval is how often to do reloads in seconds.
+	defaultReloadInterval = 5
 
-// defaultCommitInterval is how often (in seconds) to commit the "in-memory"
-// router changes made using the dynamic configuration manager.
-const defaultCommitInterval = 60 * 60
+	// defaultCommitInterval is how often (in seconds) to commit the
+	// "in-memory" router changes made using the dynamic configuration
+	// manager.
+	defaultCommitInterval = 60 * 60
+
+	// defaultTicketKeyRotateInterval is how often (in seconds) to rotate
+	// the keys used with TLS session tickets.
+	defaultTicketKeyRotateInterval = 12 * 60 * 60
+)
 
 var routerLong = heredoc.Doc(`
 	Start a router
@@ -108,6 +115,7 @@ type TemplateRouter struct {
 	DefaultCertificatePath   string
 	DefaultCertificateDir    string
 	DefaultDestinationCAPath string
+	TicketKeyRotateInterval  time.Duration
 	RouterService            *ktypes.NamespacedName
 	BindPortsAfterSync       bool
 	MaxConnections           string
@@ -162,6 +170,7 @@ func (o *TemplateRouter) Bind(flag *pflag.FlagSet) {
 	flag.StringVar(&o.MetricsType, "metrics-type", env("ROUTER_METRICS_TYPE", ""), "Specifies the type of metrics to gather. Supports 'haproxy'.")
 	flag.BoolVar(&o.UseHAProxyConfigManager, "haproxy-config-manager", isTrue(env("ROUTER_HAPROXY_CONFIG_MANAGER", "")), "Use the the haproxy config manager (and dynamic configuration API) to configure route and endpoint changes. Reduces the number of haproxy reloads needed on configuration changes.")
 	flag.DurationVar(&o.CommitInterval, "commit-interval", getIntervalFromEnv("COMMIT_INTERVAL", defaultCommitInterval), "Controls how often to commit (to the actual config) all the changes made using the router specific dynamic configuration manager.")
+	flag.DurationVar(&o.TicketKeyRotateInterval, "tls-ticket-key-rotate-interval", getIntervalFromEnv("TLS_TICKET_KEY_ROTATE_INTERVAL", defaultTicketKeyRotateInterval), "Controls how often to rotate the TLS session ticket keys. These keys are used with TLS session tickets for RFC5077 support - reuse TLS sessions.")
 	flag.StringVar(&o.BlueprintRouteNamespace, "blueprint-route-namespace", env("ROUTER_BLUEPRINT_ROUTE_NAMESPACE", ""), "Specifies the namespace which contains the routes that serve as blueprints for the dynamic configuration manager.")
 	flag.StringVar(&o.BlueprintRouteLabelSelector, "blueprint-route-labels", env("ROUTER_BLUEPRINT_ROUTE_LABELS", ""), "A label selector to apply to the routes in the blueprint route namespace. These selected routes will serve as blueprints for the dynamic dynamic configuration manager.")
 	flag.IntVar(&o.BlueprintRoutePoolSize, "blueprint-route-pool-size", int(envInt("ROUTER_BLUEPRINT_ROUTE_POOL_SIZE", 10, 1)), "Specifies the size of the pre-allocated pool for each route blueprint managed by the router specific dynamic configuration manager. This can be overriden by an annotation router.openshift.io/pool-size on an individual route.")
@@ -261,6 +270,10 @@ func (o *TemplateRouterOptions) Complete() error {
 
 	if nsecs := int(o.ReloadInterval.Seconds()); nsecs < 1 {
 		return fmt.Errorf("invalid reload interval: %v - must be a positive duration", nsecs)
+	}
+
+	if nsecs := int(o.TicketKeyRotateInterval.Seconds()); nsecs < 1 {
+		return fmt.Errorf("invalid TLS ticket key rotate interval: %v - must be a positive duration", nsecs)
 	}
 
 	if nsecs := int(o.CommitInterval.Seconds()); nsecs < 1 {
@@ -488,6 +501,7 @@ func (o *TemplateRouterOptions) Run() error {
 		DefaultCertificatePath:   o.DefaultCertificatePath,
 		DefaultCertificateDir:    o.DefaultCertificateDir,
 		DefaultDestinationCAPath: o.DefaultDestinationCAPath,
+		TicketKeyRotateInterval:  o.TicketKeyRotateInterval,
 		StatsPort:                statsPort,
 		StatsUsername:            o.StatsUsername,
 		StatsPassword:            o.StatsPassword,

--- a/pkg/router/template/configmanager/haproxy/blueprint_plugin_test.go
+++ b/pkg/router/template/configmanager/haproxy/blueprint_plugin_test.go
@@ -24,7 +24,8 @@ func newFakeConfigManager() *fakeConfigManager {
 	}
 }
 
-func (cm *fakeConfigManager) Initialize(router templaterouter.RouterInterface, certPath string) {
+func (cm *fakeConfigManager) Initialize(router templaterouter.RouterInterface, certPath string) error {
+	return nil
 }
 
 func (cm *fakeConfigManager) AddBlueprint(route *routev1.Route) {
@@ -56,6 +57,10 @@ func (cm *fakeConfigManager) ReplaceRouteEndpoints(id string, oldEndpoints, newE
 }
 
 func (cm *fakeConfigManager) RemoveRouteEndpoints(id string, endpoints []templaterouter.Endpoint) error {
+	return nil
+}
+
+func (cm *fakeConfigManager) UpdateTLSKeys(id string, keys []string) error {
 	return nil
 }
 

--- a/pkg/router/template/configmanager/haproxy/client.go
+++ b/pkg/router/template/configmanager/haproxy/client.go
@@ -28,8 +28,9 @@ type Client struct {
 	socketAddress string
 	timeout       int
 
-	backends []*Backend
-	maps     map[string]*HAProxyMap
+	backends     []*Backend
+	maps         map[string]*HAProxyMap
+	tlsKeyGroups []*TLSKeyGroup
 }
 
 // NewClient returns a client used to dynamically change the haproxy config.
@@ -44,6 +45,7 @@ func NewClient(socketName string, timeout int) *Client {
 		timeout:       timeout,
 		backends:      make([]*Backend, 0),
 		maps:          make(map[string]*HAProxyMap),
+		tlsKeyGroups:  make([]*TLSKeyGroup, 0),
 	}
 }
 
@@ -158,6 +160,19 @@ func (c *Client) FindMap(name string) (*HAProxyMap, error) {
 	}
 
 	return nil, fmt.Errorf("no map found for name: %s", name)
+}
+
+// TLSKeyGroups returns the list of configured haproxy TLS keys groups.
+func (c *Client) TLSKeyGroups() ([]*TLSKeyGroup, error) {
+	if len(c.tlsKeyGroups) == 0 {
+		if groupings, err := buildTLSKeyGroups(c); err != nil {
+			return nil, err
+		} else {
+			c.tlsKeyGroups = groupings
+		}
+	}
+
+	return c.tlsKeyGroups, nil
 }
 
 // runCommandWithRetries retries a haproxy command upto the retry limit

--- a/pkg/router/template/configmanager/haproxy/tlskeys.go
+++ b/pkg/router/template/configmanager/haproxy/tlskeys.go
@@ -1,0 +1,144 @@
+package haproxy
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	// showTLSKeysListHeader is a header added if needed to "show tls-keys"
+	// command output from haproxy, so that we can parse the CSV output.
+	// Note: This should match the CSV tags used in tlsKeysListEntry.
+	showTLSKeysListHeader = "id (file)"
+
+	// showTLSKeysGroupHeader is the header added to "show tls-keys #<id>"
+	// output from haproxy, so that we can parse the CSV output.
+	// Note: This should match the CSV tags used in TLSKeyEntry.
+	showTLSKeysGroupHeader = "id secret"
+)
+
+type tlsKeysListEntry struct {
+	ID   string `csv:"id"`
+	Name string `csv:"(file)"`
+}
+
+// TLSKeyEntry is an entry in the TLS keys group.
+type TLSKeyEntry struct {
+	// ID is the internal haproxy id associated with this TLS key entry.
+	// It is required for deleting entries.
+	ID string `csv:"id"`
+
+	// Secret is the TLS ticket key value.
+	Secret string `csv:"secret"`
+}
+
+// TLSKeyGroup is a structure representing TLS keys as grouped in haproxy.
+type TLSKeyGroup struct {
+	// id is the haproxy specific id for this TLS keys group.
+	id string
+
+	// name is the haproxy specific name for this TLS keys group.
+	name string
+
+	// client is the haproxy dynamic API client.
+	client *Client
+
+	// entries are the TLS key entries.
+	entries []*TLSKeyEntry
+
+	// dirty indicates the state of this grouping.
+	dirty bool
+}
+
+// buildTLSKeyGroups builds and returns a list of grouped TLS keys.
+// Note: TLS keys are lazily populated based on their usage.
+func buildTLSKeyGroups(c *Client) ([]*TLSKeyGroup, error) {
+	entries := []*tlsKeysListEntry{}
+	converter := NewCSVConverter(showTLSKeysListHeader, &entries, fixupTLSKeysListOutput)
+
+	if _, err := c.RunCommand("show tls-keys", converter); err != nil {
+		return []*TLSKeyGroup{}, err
+	}
+
+	groups := make([]*TLSKeyGroup, len(entries))
+	for k, v := range entries {
+		m := newTLSKeyGroup(v.ID, v.Name, c)
+		groups[k] = m
+	}
+
+	return groups, nil
+}
+
+// newTLSKeyGroup returns a new TLS keys grouping.
+func newTLSKeyGroup(id, name string, client *Client) *TLSKeyGroup {
+	return &TLSKeyGroup{
+		id:      id,
+		name:    name,
+		client:  client,
+		entries: make([]*TLSKeyEntry, 0),
+		dirty:   true,
+	}
+}
+
+// Refresh refreshes the data in this TLS keys grouping.
+func (m *TLSKeyGroup) Refresh() error {
+	cmd := fmt.Sprintf("show tls-keys #%s", m.id)
+
+	converter := NewCSVConverter(showTLSKeysGroupHeader, &m.entries, fixupTLSKeysGroupOutput)
+	if _, err := m.client.RunCommand(cmd, converter); err != nil {
+		return err
+	}
+
+	m.dirty = false
+	return nil
+}
+
+// Commit commits all the pending changes made to this haproxy TLS keys group.
+// We do TLS keys group changes "in-band" as that's handled dynamically by
+// haproxy.
+func (m *TLSKeyGroup) Commit() error {
+	// noop
+	return nil
+}
+
+// Name returns the name of this TLS keys group.
+func (m *TLSKeyGroup) Name() string {
+	return m.name
+}
+
+// UpdateKeys updates the keys in this TLS keys group.
+func (m *TLSKeyGroup) UpdateKeys(keys []string) error {
+	for _, v := range keys {
+		cmd := fmt.Sprintf("set ssl tls-key %s %s", m.name, v)
+		responseBytes, err := m.client.Execute(cmd)
+		if err != nil {
+			return err
+		}
+
+		response := strings.TrimSpace(string(responseBytes))
+		if len(response) > 0 && !strings.HasPrefix(response, "TLS ticket key updated") {
+			return fmt.Errorf("set ssl tls-key %s: %v", m.name, string(response))
+		}
+
+	}
+	return nil
+}
+
+// Regular expression to fixup TLS keys list output.
+var listTLSKeysOutputRE *regexp.Regexp = regexp.MustCompile(`(?m)^([0-9]+)\s+\((.*)?\)\s*$`)
+
+// fixupTLSKeysListOutput fixes up the output haproxy "show tls-keys" returns.
+func fixupTLSKeysListOutput(data []byte) ([]byte, error) {
+	replacement := []byte(`$1 $2`)
+	return listTLSKeysOutputRE.ReplaceAll(data, replacement), nil
+}
+
+// Regular expression to fixup TLS keys group output.
+var tlsKeysGroupsOutputRE *regexp.Regexp = regexp.MustCompile(`(?m)^#\s*[0-9]+\s*.*?$[\r\n]+`)
+
+// fixupTLSKeysGroupOutput fixes up the output of haproxy "show tls-keys #<id>".
+func fixupTLSKeysGroupOutput(data []byte) ([]byte, error) {
+	replacement := []byte("")
+	return tlsKeysGroupsOutputRE.ReplaceAll(data, replacement), nil
+}

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -46,6 +46,7 @@ type TemplatePluginConfig struct {
 	TemplatePath             string
 	ReloadScriptPath         string
 	ReloadInterval           time.Duration
+	TicketKeyRotateInterval  time.Duration
 	ReloadCallbacks          []func()
 	DefaultCertificate       string
 	DefaultCertificatePath   string
@@ -150,6 +151,7 @@ func NewTemplatePlugin(cfg TemplatePluginConfig, lookupSvc ServiceLookup) (*Temp
 		defaultCertificatePath:   cfg.DefaultCertificatePath,
 		defaultCertificateDir:    cfg.DefaultCertificateDir,
 		defaultDestinationCAPath: cfg.DefaultDestinationCAPath,
+		ticketKeyRotateInterval:  cfg.TicketKeyRotateInterval,
 		statsUser:                cfg.StatsUsername,
 		statsPassword:            cfg.StatsPassword,
 		statsPort:                cfg.StatsPort,

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -181,7 +181,7 @@ type ConfigManagerOptions struct {
 // requirement for a ConfigManager "provider".
 type ConfigManager interface {
 	// Initialize initializes the config manager.
-	Initialize(router RouterInterface, certPath string)
+	Initialize(router RouterInterface, certPath string) error
 
 	// AddBlueprint adds a new (or replaces an existing) route blueprint.
 	AddBlueprint(route *routev1.Route)
@@ -204,6 +204,9 @@ type ConfigManager interface {
 
 	// RemoveRouteEndpoints removes a set of endpoints from a route.
 	RemoveRouteEndpoints(id string, endpoints []Endpoint) error
+
+	// UpdateTLSKeys updates the TLS keys for a specific TLS key group.
+	UpdateTLSKeys(id string, keys []string) error
 
 	// Notify notifies a configuration manager of a router event.
 	// Currently the only ones that are received are on reload* events,


### PR DESCRIPTION
Works with and without the haproxy config manager.

Ref to the original trello card: https://trello.com/c/CNOvI2u2/79-implement-tls-ticket-keys-for-haproxy