### PR TITLE
remove an extra brace from the template

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -546,7 +546,7 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
   hash-type consistent
   timeout check 5000ms
     {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
-      {{- if ne $weight 0 }}}{{/* drop connections where weight=0 as we can't use cookies, leaving only r-r and src-ip as dispatch methods and weight make no sense there */}}
+      {{- if ne $weight 0 }}{{/* drop connections where weight=0 as we can't use cookies, leaving only r-r and src-ip as dispatch methods and weight make no sense there */}}
         {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
           {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
   server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} weight {{$weight}}


### PR DESCRIPTION
Always seeing an extra `}` after the `timeout check 5000ms` and affecting all pass through route, so remove it from the template.

here is example of haproxy.config
```
# Secure backend, pass through
backend be_tcp:openshift-authentication:openshift-authentication
  balance source

  hash-type consistent
  timeout check 5000ms}
```