### PR TITLE
Bug 1679941: shouldWriteCerts: Fix check for default certificate

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -1030,7 +1030,7 @@ func (r *templateRouter) shouldWriteCerts(cfg *ServiceAliasConfig) bool {
 			cfg.TLSTermination, cfg.Host)
 		// if a default cert is configured we'll assume it is meant to be a wildcard and only log info
 		// otherwise we'll consider this a warning
-		if len(r.defaultCertificate) > 0 {
+		if len(r.defaultCertificatePath) > 0 {
 			glog.V(4).Info(msg)
 		} else {
 			glog.Warning(msg)


### PR DESCRIPTION
When writing out routes' certificates, the template router logs a message for each edge or reencrypt route that does not specify certificates.  If the router has a default certificate, this message is supposed to be logged to INFO.  If the router does not have a default certificate, this message is supposed to be logged to WARNING.

Before this commit, the relevant check for the default certificate was using the wrong value (namely the `defaultCertificate` value, which is set only if the default certificate is passed to the router on the command-line or in an environment variable).  Consequently, the router was logging the message to WARNING in some cases when the router had a default certificate.

After this commit, the check uses the correct value (namely the `defaultCertificatePath` value, which is set if the default certificate is passed to the router on the command-line, in an environment variable, or in a file).  Thus the router now logs the message to INFO or WARNING as appropriate.

* `pkg/router/template/router.go` (`shouldWriteCerts`): Check `defaultCertificatePath`, not `defaultCertificate`.