### PR TITLE
reload-haproxy: Delete unused haproxy_conf_dir var

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -4,7 +4,6 @@ set -o nounset
 
 config_file=/var/lib/haproxy/conf/haproxy.config
 pid_file=/var/lib/haproxy/run/haproxy.pid
-haproxy_conf_dir=/var/lib/haproxy/conf
 readonly max_wait_time=30
 readonly timeout_opts="-m 1 --connect-timeout 1"
 readonly numeric_re='^[0-9]+$'


### PR DESCRIPTION
Delete the `haproxy_conf_dir` variable, which is no longer used as of https://github.com/openshift/origin/pull/19219.

* `images/router/haproxy/reload-haproxy`: Delete unused variable.