### PR TITLE
Add shell script for graceful shutdown

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -66,6 +66,10 @@ function haproxyHealthCheck() {
 }
 
 
+if [[ -e ${TERMINATE_MARKER:-'/var/lib/haproxy/run/terminating'} ]]; then
+  exit 0
+fi
+
 old_pids=$(pidof haproxy)
 
 reload_status=0

--- a/images/router/haproxy/shutdown-haproxy
+++ b/images/router/haproxy/shutdown-haproxy
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# DRAIN_MARKER is the path to a file that indicates that proxies or load
+# balancers should be draining connections to the router.  The router's health
+# check for load balancers checks for this file, and if the file is present, the
+# health check fails in order to cause load balancers to drain connections to
+# the router.
+: ${DRAIN_MARKER:='/var/lib/haproxy/run/draining'}
+
+# DRAIN_PERIOD is the number of seconds that this script will wait for
+# connections to drain before it sends the SIGUSR1 signal to terminate HAProxy
+# processes.
+: ${DRAIN_PERIOD:=90}
+
+# TERMINATE_MARKER is the path to a file that indicates that this router is
+# terminating.  The reload-haproxy script exits immediately if this marker is
+# present.
+: ${TERMINATE_MARKER:='/var/lib/haproxy/run/terminating'}
+
+# GRACE_PERIOD is the number of seconds that this script will wait for HAProxy
+# processes to terminate after it sends the SIGUSR1 signal, before it sends
+# SIGTERM to any remaining HAProxy processes.
+: ${GRACE_PERIOD:=30}
+
+echo " - Setting drain marker..."
+: > "$DRAIN_MARKER"
+
+echo " - Sleeping $DRAIN_PERIOD seconds to let connections drain..."
+sleep "$DRAIN_PERIOD"
+
+echo " - Sending SIGUSR1 to HAProxy processes and waiting up to $GRACE_PERIOD seconds for processes to terminate..."
+stop=$((SECONDS + GRACE_PERIOD))
+while pkill -USR1 haproxy; rc=$?; [[ $rc -ne 1 ]] && ((SECONDS < stop)); do
+    sleep 1
+done
+
+if [[ "$rc" -eq 1 ]]; then
+    echo ' - Done.  All processes have exited.'
+    exit 0
+fi
+
+: > "$TERMINATE_MARKER"
+echo ' - Sending SIGTERM to HAProxy processes...'
+while pkill -TERM haproxy; [[ $? -ne 1 ]]; do
+    sleep 1
+done
+echo ' - Done.  All processes have been terminated.'

--- a/pkg/router/metrics/metrics.go
+++ b/pkg/router/metrics/metrics.go
@@ -31,14 +31,16 @@ type Listener struct {
 	Authorizer    authorizer.Authorizer
 	Record        authorizer.AttributesRecord
 
-	LiveChecks  []healthz.HealthzChecker
-	ReadyChecks []healthz.HealthzChecker
+	LBReadyChecks []healthz.HealthzChecker
+	PodLiveChecks  []healthz.HealthzChecker
+	PodReadyChecks []healthz.HealthzChecker
 }
 
 func (l Listener) handler() http.Handler {
 	mux := http.NewServeMux()
-	healthz.InstallHandler(mux, l.LiveChecks...)
-	healthz.InstallPathHandler(mux, "/healthz/ready", l.ReadyChecks...)
+	healthz.InstallHandler(mux, l.LBReadyChecks...)
+	healthz.InstallPathHandler(mux, "/healthz/live", l.PodLiveChecks...)
+	healthz.InstallPathHandler(mux, "/healthz/ready", l.PodReadyChecks...)
 
 	if l.Authenticator != nil {
 		protected := http.NewServeMux()


### PR DESCRIPTION
Add a `shutdown-haproxy` shell script, which can be used in as the pre-stop handler for a router deployment in order to provide graceful shutdown.

Whereas a hard shutdown simply sends a SIGTERM signal to all haproxy processes to make them immediately shut down, a graceful shutdown does the following:

1. Create a marker file that tells the `reload-haproxy` script to exit immediately.

2. Sleep for 30 seconds to allow other proxies such as kube-proxy and any cloud load-balancers to drain connections.

3. Send a SIGUSR1 signal to all HAProxy processes to make them stop accepting new connections.

4. Wait up to 30 seconds for all HAProxy processes to terminate.

5. Perform a hard shutdown of any remaining HAProxy processes.

This commit is related to bug 1709958.

https://bugzilla.redhat.com/show_bug.cgi?id=1709958

* `images/router/haproxy/reload-haproxy`: Exit immediately if the file `/var/lib/haproxy/run/terminating` is present.
* `images/router/haproxy/shutdown-haproxy`: New file.  If the file `/var/lib/haproxy/run/terminating` is present, perform a hard shutdown, or else perform a graceful shutdown as described above.