### PR TITLE
Add unified Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+WORKDIR /go/src/github.com/openshift/router
+COPY . .
+RUN make
+
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+COPY --from=builder /go/src/github.com/openshift/router/openshift-router /usr/bin/
+
+RUN INSTALL_PKGS="haproxy18 rsyslog sysvinit-tools" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /var/lib/haproxy/router/{certs,cacerts,whitelists} && \
+    mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log} && \
+    touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
+    setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
+    chown -R :0 /var/lib/haproxy && \
+    chmod -R g+w /var/lib/haproxy
+COPY images/router/haproxy/* /var/lib/haproxy/
+LABEL io.k8s.display-name="OpenShift HAProxy Router" \
+      io.k8s.description="This component offers ingress to an OpenShift cluster via Ingress and Route rules." \
+      io.openshift.tags="openshift,router,haproxy"
+USER 1001
+EXPOSE 80 443
+WORKDIR /var/lib/haproxy/conf
+ENV TEMPLATE_FILE=/var/lib/haproxy/conf/haproxy-config.template \
+    RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy
+ENTRYPOINT ["/usr/bin/openshift-router"]

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,27 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
+WORKDIR /go/src/github.com/openshift/router
+COPY . .
+RUN make
+
+FROM registry.svc.ci.openshift.org/ocp/4.0:base
+COPY --from=builder /go/src/github.com/openshift/router/openshift-router /usr/bin/
+RUN INSTALL_PKGS="haproxy18 rsyslog sysvinit-tools" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /var/lib/haproxy/router/{certs,cacerts,whitelists} && \
+    mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log} && \
+    touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
+    setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
+    chown -R :0 /var/lib/haproxy && \
+    chmod -R g+w /var/lib/haproxy
+COPY images/router/haproxy/* /var/lib/haproxy/
+LABEL io.k8s.display-name="OpenShift HAProxy Router" \
+      io.k8s.description="This component offers ingress to an OpenShift cluster via Ingress and Route rules." \
+      io.openshift.tags="openshift,router,haproxy"
+USER 1001
+EXPOSE 80 443
+WORKDIR /var/lib/haproxy/conf
+ENV TEMPLATE_FILE=/var/lib/haproxy/conf/haproxy-config.template \
+    RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy
+ENTRYPOINT ["/usr/bin/openshift-router"]


### PR DESCRIPTION
Add unified Dockerfiles. The base image is no longer required since the
v4 router is only supported with the haproxy template. With this commit,
the builds can be refactored to point at the new Dockerfiles, and then
in a followup the images directory can be freely refactored and pruned.