### PR TITLE
Delete tracking of peer endpoints

### DIFF
--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -17,7 +17,6 @@ import (
 	"github.com/spf13/pflag"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/authenticatorfactory"
@@ -108,7 +107,6 @@ type TemplateRouter struct {
 	DefaultCertificatePath   string
 	DefaultCertificateDir    string
 	DefaultDestinationCAPath string
-	RouterService            *ktypes.NamespacedName
 	BindPortsAfterSync       bool
 	MaxConnections           string
 	Ciphers                  string
@@ -228,10 +226,6 @@ func (o *TemplateRouterOptions) Complete() error {
 	if len(routerSvcName) > 0 {
 		if len(routerSvcNamespace) == 0 {
 			return fmt.Errorf("ROUTER_SERVICE_NAMESPACE is required when ROUTER_SERVICE_NAME is specified")
-		}
-		o.RouterService = &ktypes.NamespacedName{
-			Namespace: routerSvcNamespace,
-			Name:      routerSvcName,
 		}
 	}
 
@@ -491,7 +485,6 @@ func (o *TemplateRouterOptions) Run() error {
 		StatsPort:                statsPort,
 		StatsUsername:            o.StatsUsername,
 		StatsPassword:            o.StatsPassword,
-		PeerService:              o.RouterService,
 		BindPortsAfterSync:       o.BindPortsAfterSync,
 		IncludeUDP:               o.RouterSelection.IncludeUDP,
 		AllowWildcardRoutes:      o.RouterSelection.AllowWildcardRoutes,

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	kapi "k8s.io/api/core/v1"
-	ktypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
@@ -55,7 +54,6 @@ type TemplatePluginConfig struct {
 	StatsPassword            string
 	IncludeUDP               bool
 	AllowWildcardRoutes      bool
-	PeerService              *ktypes.NamespacedName
 	BindPortsAfterSync       bool
 	MaxConnections           string
 	Ciphers                  string
@@ -134,11 +132,6 @@ func NewTemplatePlugin(cfg TemplatePluginConfig, lookupSvc ServiceLookup) (*Temp
 		templates[template.Name()] = templateWithHelper
 	}
 
-	peerKey := ""
-	if cfg.PeerService != nil {
-		peerKey = peerEndpointsKey(*cfg.PeerService)
-	}
-
 	templateRouterCfg := templateRouterCfg{
 		dir:                      cfg.WorkingDir,
 		templates:                templates,
@@ -153,7 +146,6 @@ func NewTemplatePlugin(cfg TemplatePluginConfig, lookupSvc ServiceLookup) (*Temp
 		statsPassword:            cfg.StatsPassword,
 		statsPort:                cfg.StatsPort,
 		allowWildcardRoutes:      cfg.AllowWildcardRoutes,
-		peerEndpointsKey:         peerKey,
 		bindPortsAfterSync:       cfg.BindPortsAfterSync,
 		dynamicConfigManager:     cfg.DynamicConfigManager,
 	}
@@ -240,13 +232,6 @@ func getPartsFromEndpointsKey(key string) (string, string) {
 	namespace := tokens[0]
 	name := tokens[1]
 	return namespace, name
-}
-
-// peerServiceKey may be used by the underlying router when handling endpoints to identify
-// endpoints that belong to its peers.  THIS MUST FOLLOW THE KEY STRATEGY OF endpointsKey.  It
-// receives a NamespacedName that is created from the service that is added by the oadm command
-func peerEndpointsKey(namespacedName ktypes.NamespacedName) string {
-	return endpointsKeyFromParts(namespacedName.Namespace, namespacedName.Name)
 }
 
 // createRouterEndpoints creates openshift router endpoints based on k8s endpoints


### PR DESCRIPTION
Before this commit, the router used the endpoints of a "peer" service to discover peer router instances and made a list of these peer endpoints available to the configuration template.  However, the default template does not use peer endpoints, and the feature is not documented.

The feature is left over from an early implementation of sticky sessions (https://github.com/openshift/origin/pull/2105/commits/4c52fd188166cb5788f0bd249385b49cd5d9a7ff), which used peer endpoints to configure peers in `haproxy`.config.  However, the implementation of sticky sessions that was merged did not use peers, and no other users exist.

* `pkg/cmd/infra/router/template.go` (`Complete`, `Run`): Delete the router peer service from the template-router options.
* `pkg/router/template/plugin.go` (`TemplatePluginConfig`, `NewTemplatePlugin`): Delete logic to get the peer endpoints key from the peer service.
(`peerEndpointsKey`): Delete function.
* `pkg/router/template/router.go` (`templateRouter`, `templateRouterCfg`, `newTemplateRouter`): Delete the peer endpoints and peer endpoints key from the template router state.
(`templateData`, `writeConfig`): Delete peer endpoints from the template data.
(`DeleteEndpoints`, `AddEndpoints`): Delete logic to update the list of peer endpoints.