### PR TITLE
Add ServiceUnitKey and ServiceAliasConfigKey types

### DIFF
--- a/pkg/router/template/configmanager/haproxy/blueprint_plugin_test.go
+++ b/pkg/router/template/configmanager/haproxy/blueprint_plugin_test.go
@@ -15,12 +15,12 @@ import (
 )
 
 type fakeConfigManager struct {
-	blueprints map[string]*routev1.Route
+	blueprints map[templaterouter.ServiceAliasConfigKey]*routev1.Route
 }
 
 func newFakeConfigManager() *fakeConfigManager {
 	return &fakeConfigManager{
-		blueprints: make(map[string]*routev1.Route),
+		blueprints: make(map[templaterouter.ServiceAliasConfigKey]*routev1.Route),
 	}
 }
 
@@ -36,27 +36,27 @@ func (cm *fakeConfigManager) RemoveBlueprint(route *routev1.Route) {
 	delete(cm.blueprints, routeKey(route))
 }
 
-func (cm *fakeConfigManager) FindBlueprint(id string) (*routev1.Route, bool) {
+func (cm *fakeConfigManager) FindBlueprint(id templaterouter.ServiceAliasConfigKey) (*routev1.Route, bool) {
 	route, ok := cm.blueprints[id]
 	return route, ok
 }
 
-func (cm *fakeConfigManager) Register(id string, route *routev1.Route) {
+func (cm *fakeConfigManager) Register(id templaterouter.ServiceAliasConfigKey, route *routev1.Route) {
 }
 
-func (cm *fakeConfigManager) AddRoute(id, routingKey string, route *routev1.Route) error {
+func (cm *fakeConfigManager) AddRoute(id templaterouter.ServiceAliasConfigKey, routingKey string, route *routev1.Route) error {
 	return nil
 }
 
-func (cm *fakeConfigManager) RemoveRoute(id string, route *routev1.Route) error {
+func (cm *fakeConfigManager) RemoveRoute(id templaterouter.ServiceAliasConfigKey, route *routev1.Route) error {
 	return nil
 }
 
-func (cm *fakeConfigManager) ReplaceRouteEndpoints(id string, oldEndpoints, newEndpoints []templaterouter.Endpoint, weight int32) error {
+func (cm *fakeConfigManager) ReplaceRouteEndpoints(id templaterouter.ServiceAliasConfigKey, oldEndpoints, newEndpoints []templaterouter.Endpoint, weight int32) error {
 	return nil
 }
 
-func (cm *fakeConfigManager) RemoveRouteEndpoints(id string, endpoints []templaterouter.Endpoint) error {
+func (cm *fakeConfigManager) RemoveRouteEndpoints(id templaterouter.ServiceAliasConfigKey, endpoints []templaterouter.Endpoint) error {
 	return nil
 }
 
@@ -75,8 +75,8 @@ func (cm *fakeConfigManager) GenerateDynamicServerNames(id string) []string {
 	return []string{}
 }
 
-func routeKey(route *routev1.Route) string {
-	return fmt.Sprintf("%s:%s", route.Name, route.Namespace)
+func routeKey(route *routev1.Route) templaterouter.ServiceAliasConfigKey {
+	return templaterouter.ServiceAliasConfigKey(fmt.Sprintf("%s:%s", route.Name, route.Namespace))
 }
 
 // TestHandleRoute test route watch events

--- a/pkg/router/template/configmanager/haproxy/client.go
+++ b/pkg/router/template/configmanager/haproxy/client.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	templaterouter "github.com/openshift/router/pkg/router/template"
+
 	haproxy "github.com/bcicen/go-haproxy"
 
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
@@ -107,7 +109,7 @@ func (c *Client) Backends() ([]*Backend, error) {
 }
 
 // FindBackend returns a specific haproxy backend if it is configured.
-func (c *Client) FindBackend(id string) (*Backend, error) {
+func (c *Client) FindBackend(id templaterouter.ServiceAliasConfigKey) (*Backend, error) {
 	if _, err := c.Backends(); err != nil {
 		return nil, err
 	}

--- a/pkg/router/template/configmanager/haproxy/client_test.go
+++ b/pkg/router/template/configmanager/haproxy/client_test.go
@@ -3,6 +3,7 @@ package haproxy
 import (
 	"testing"
 
+	templaterouter "github.com/openshift/router/pkg/router/template"
 	haproxytesting "github.com/openshift/router/pkg/router/template/configmanager/haproxy/testing"
 )
 
@@ -406,7 +407,7 @@ func TestClientCommit(t *testing.T) {
 
 	server.Reset()
 	for _, be := range backends {
-		if _, ok := skipNames[be.Name()]; ok {
+		if _, ok := skipNames[string(be.Name())]; ok {
 			continue
 		}
 
@@ -423,7 +424,7 @@ func TestClientCommit(t *testing.T) {
 
 	server.Reset()
 	for _, be := range backends {
-		if _, ok := skipNames[be.Name()]; ok {
+		if _, ok := skipNames[string(be.Name())]; ok {
 			continue
 		}
 
@@ -458,7 +459,7 @@ func TestClientBackends(t *testing.T) {
 func TestClientFindBackend(t *testing.T) {
 	testCases := []struct {
 		name            string
-		backendName     string
+		backendName     templaterouter.ServiceAliasConfigKey
 		failureExpected bool
 	}{
 		{

--- a/pkg/router/template/configmanager/haproxy/map.go
+++ b/pkg/router/template/configmanager/haproxy/map.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	templaterouter "github.com/openshift/router/pkg/router/template"
 )
 
 const (
@@ -133,7 +135,7 @@ func (m *HAProxyMap) Find(k string) ([]HAProxyMapEntry, error) {
 
 // Add adds a new key and value to the haproxy map and allows all previous
 // entries in the map to be deleted (replaced).
-func (m *HAProxyMap) Add(k, v string, replace bool) error {
+func (m *HAProxyMap) Add(k string, v templaterouter.ServiceAliasConfigKey, replace bool) error {
 	if replace {
 		if err := m.Delete(k); err != nil {
 			return err
@@ -165,8 +167,8 @@ func (m *HAProxyMap) DeleteEntry(id string) error {
 }
 
 // addEntry adds a new haproxy map entry.
-func (m *HAProxyMap) addEntry(k, v string) error {
-	keyExpr := escapeKeyExpr(k)
+func (m *HAProxyMap) addEntry(k string, v templaterouter.ServiceAliasConfigKey) error {
+	keyExpr := escapeKeyExpr(string(k))
 	cmd := fmt.Sprintf("add map %s %s %s", m.name, keyExpr, v)
 	responseBytes, err := m.client.Execute(cmd)
 	if err != nil {

--- a/pkg/router/template/configmanager/haproxy/map_test.go
+++ b/pkg/router/template/configmanager/haproxy/map_test.go
@@ -3,6 +3,7 @@ package haproxy
 import (
 	"testing"
 
+	templaterouter "github.com/openshift/router/pkg/router/template"
 	haproxytesting "github.com/openshift/router/pkg/router/template/configmanager/haproxy/testing"
 )
 
@@ -451,7 +452,7 @@ func TestHAProxyMapAdd(t *testing.T) {
 		sockFile        string
 		mapName         string
 		keyName         string
-		value           string
+		value           templaterouter.ServiceAliasConfigKey
 		replace         bool
 		failureExpected bool
 	}{

--- a/pkg/router/template/fake.go
+++ b/pkg/router/template/fake.go
@@ -5,8 +5,8 @@ package templaterouter
 func NewFakeTemplateRouter() *templateRouter {
 	fakeCertManager, _ := newSimpleCertificateManager(newFakeCertificateManagerConfig(), &fakeCertWriter{})
 	return &templateRouter{
-		state:                     map[string]ServiceAliasConfig{},
-		serviceUnits:              make(map[string]ServiceUnit),
+		state:                     map[ServiceAliasConfigKey]ServiceAliasConfig{},
+		serviceUnits:              make(map[ServiceUnitKey]ServiceUnit),
 		certManager:               fakeCertManager,
 		rateLimitedCommitFunction: nil,
 	}

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -72,14 +72,14 @@ type RouterInterface interface {
 	SyncedAtLeastOnce() bool
 
 	// CreateServiceUnit creates a new service named with the given id.
-	CreateServiceUnit(id string)
+	CreateServiceUnit(id ServiceUnitKey)
 	// FindServiceUnit finds the service with the given id.
-	FindServiceUnit(id string) (v ServiceUnit, ok bool)
+	FindServiceUnit(id ServiceUnitKey) (v ServiceUnit, ok bool)
 
 	// AddEndpoints adds new Endpoints for the given id.
-	AddEndpoints(id string, endpoints []Endpoint)
+	AddEndpoints(id ServiceUnitKey, endpoints []Endpoint)
 	// DeleteEndpoints deletes the endpoints for the frontend with the given id.
-	DeleteEndpoints(id string)
+	DeleteEndpoints(id ServiceUnitKey)
 
 	// AddRoute attempts to add a route to the router.
 	AddRoute(route *routev1.Route)
@@ -216,16 +216,16 @@ func (p *TemplatePlugin) Commit() error {
 }
 
 // endpointsKey returns the internal router key to use for the given Endpoints.
-func endpointsKey(endpoints *kapi.Endpoints) string {
+func endpointsKey(endpoints *kapi.Endpoints) ServiceUnitKey {
 	return endpointsKeyFromParts(endpoints.Namespace, endpoints.Name)
 }
 
-func endpointsKeyFromParts(namespace, name string) string {
-	return fmt.Sprintf("%s%s%s", namespace, endpointsKeySeparator, name)
+func endpointsKeyFromParts(namespace, name string) ServiceUnitKey {
+	return ServiceUnitKey(fmt.Sprintf("%s%s%s", namespace, endpointsKeySeparator, name))
 }
 
-func getPartsFromEndpointsKey(key string) (string, string) {
-	tokens := strings.SplitN(key, endpointsKeySeparator, 2)
+func getPartsFromEndpointsKey(key ServiceUnitKey) (string, string) {
+	tokens := strings.SplitN(string(key), endpointsKeySeparator, 2)
 	if len(tokens) != 2 {
 		log.Error(nil, "expected separator not found in endpoints key", "separator", endpointsKeySeparator, "key", key)
 	}

--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -172,7 +172,7 @@ func generateHAProxyCertConfigMap(td templateData) []string {
 			hascert = ok && len(cert.Contents) > 0
 		}
 
-		backendConfig := backendConfig(k, cfg, hascert)
+		backendConfig := backendConfig(string(k), cfg, hascert)
 		if entry := haproxyutil.GenerateMapEntry(certConfigMap, backendConfig); entry != nil {
 			fqCertPath := path.Join(td.WorkingDir, "certs", entry.Key)
 			lines = append(lines, fmt.Sprintf("%s %s", fqCertPath, entry.Value))
@@ -203,8 +203,8 @@ func generateHAProxyWhiteListFile(workingDir, id, value string) string {
 }
 
 // getHTTPAliasesGroupedByHost returns HTTP(S) aliases grouped by their host.
-func getHTTPAliasesGroupedByHost(aliases map[string]ServiceAliasConfig) map[string]map[string]ServiceAliasConfig {
-	result := make(map[string]map[string]ServiceAliasConfig)
+func getHTTPAliasesGroupedByHost(aliases map[ServiceAliasConfigKey]ServiceAliasConfig) map[string]map[ServiceAliasConfigKey]ServiceAliasConfig {
+	result := make(map[string]map[ServiceAliasConfigKey]ServiceAliasConfig)
 
 	for k, a := range aliases {
 		if a.TLSTermination == routev1.TLSTerminationPassthrough {
@@ -212,7 +212,7 @@ func getHTTPAliasesGroupedByHost(aliases map[string]ServiceAliasConfig) map[stri
 		}
 
 		if _, exists := result[a.Host]; !exists {
-			result[a.Host] = make(map[string]ServiceAliasConfig)
+			result[a.Host] = make(map[ServiceAliasConfigKey]ServiceAliasConfig)
 		}
 		result[a.Host][k] = a
 	}
@@ -262,7 +262,7 @@ func generateHAProxyMap(name string, td templateData) []string {
 
 	lines := make([]string, 0)
 	for k, cfg := range td.State {
-		backendConfig := backendConfig(k, cfg, false)
+		backendConfig := backendConfig(string(k), cfg, false)
 		if entry := haproxyutil.GenerateMapEntry(name, backendConfig); entry != nil {
 			lines = append(lines, fmt.Sprintf("%s %s", entry.Key, entry.Value))
 		}

--- a/pkg/router/template/template_helper_test.go
+++ b/pkg/router/template/template_helper_test.go
@@ -33,8 +33,8 @@ func buildServiceAliasConfig(name, namespace, host, path string, termination rou
 	}
 }
 
-func buildTestTemplateState() map[string]ServiceAliasConfig {
-	state := make(map[string]ServiceAliasConfig)
+func buildTestTemplateState() map[ServiceAliasConfigKey]ServiceAliasConfig {
+	state := make(map[ServiceAliasConfigKey]ServiceAliasConfig)
 
 	state["stg:api-route"] = buildServiceAliasConfig("api-route", "stg", "api-stg.127.0.0.1.nip.io", "", routev1.TLSTerminationEdge, routev1.InsecureEdgeTerminationPolicyRedirect, false)
 	state["prod:api-route"] = buildServiceAliasConfig("api-route", "prod", "api-prod.127.0.0.1.nip.io", "", routev1.TLSTerminationEdge, routev1.InsecureEdgeTerminationPolicyRedirect, false)
@@ -402,7 +402,7 @@ func TestGenerateHAProxyCertConfigMap(t *testing.T) {
 	td := templateData{
 		WorkingDir:   "/path/to",
 		State:        buildTestTemplateState(),
-		ServiceUnits: make(map[string]ServiceUnit),
+		ServiceUnits: make(map[ServiceUnitKey]ServiceUnit),
 	}
 
 	expectedOrder := []string{
@@ -430,7 +430,7 @@ func TestGenerateHAProxyMap(t *testing.T) {
 	td := templateData{
 		WorkingDir:   "/path/to",
 		State:        buildTestTemplateState(),
-		ServiceUnits: make(map[string]ServiceUnit),
+		ServiceUnits: make(map[ServiceUnitKey]ServiceUnit),
 	}
 
 	wildcardDomainOrder := []string{
@@ -532,7 +532,7 @@ func TestGenerateHAProxyMap(t *testing.T) {
 }
 
 func TestGetHTTPAliasesGroupedByHost(t *testing.T) {
-	aliases := map[string]ServiceAliasConfig{
+	aliases := map[ServiceAliasConfigKey]ServiceAliasConfig{
 		"project1:route1": {
 			Host: "example.com",
 			Path: "/",
@@ -551,7 +551,7 @@ func TestGetHTTPAliasesGroupedByHost(t *testing.T) {
 		},
 	}
 
-	expected := map[string]map[string]ServiceAliasConfig{
+	expected := map[string]map[ServiceAliasConfigKey]ServiceAliasConfig{
 		"example.com": {
 			"project1:route1": {
 				Host: "example.com",

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -18,8 +18,10 @@ type ServiceUnit struct {
 	EndpointTable []Endpoint
 	// ServiceAliasAssociations indicates what service aliases are
 	// associated with this service unit.
-	ServiceAliasAssociations map[string]bool
+	ServiceAliasAssociations map[ServiceAliasConfigKey]bool
 }
+
+type ServiceUnitKey string
 
 // ServiceAliasConfig is a route for a service.  Uniquely identified by host + path.
 type ServiceAliasConfig struct {
@@ -58,14 +60,14 @@ type ServiceAliasConfig struct {
 	// Annotations attached to this route
 	Annotations map[string]string
 
-	// ServiceUnits is the weight for each service assigned to the route keyed by service name.
+	// ServiceUnits is the weight for each service assigned to the route.
 	// It is used in calculating the weight for the server that is found in ServiceUnitNames
-	ServiceUnits map[string]int32
+	ServiceUnits map[ServiceUnitKey]int32
 
 	// ServiceUnitNames is the weight to apply to each endpoint of each service supporting this route.
-	// The key is the service name, the value is the scaled portion of the service weight to assign
+	// The value is the scaled portion of the service weight to assign
 	// to each endpoint in the service.
-	ServiceUnitNames map[string]int32
+	ServiceUnitNames map[ServiceUnitKey]int32
 
 	// ActiveServiceUnits is a count of the service units with a non-zero weight
 	ActiveServiceUnits int
@@ -81,6 +83,8 @@ const (
 	// been persisted to disk.
 	ServiceAliasConfigStatusSaved ServiceAliasConfigStatus = "saved"
 )
+
+type ServiceAliasConfigKey string
 
 // Certificate represents a pub/private key pair.  It is identified by ID which will become the file name.
 // A CA certificate will not have a PrivateKey set.
@@ -190,20 +194,20 @@ type ConfigManager interface {
 	RemoveBlueprint(route *routev1.Route)
 
 	// Register registers an id to be associated with a route.
-	Register(id string, route *routev1.Route)
+	Register(id ServiceAliasConfigKey, route *routev1.Route)
 
 	// AddRoute adds a new route or updates an existing route.
-	AddRoute(id, routingKey string, route *routev1.Route) error
+	AddRoute(id ServiceAliasConfigKey, routingKey string, route *routev1.Route) error
 
 	// RemoveRoute removes a route.
-	RemoveRoute(id string, route *routev1.Route) error
+	RemoveRoute(id ServiceAliasConfigKey, route *routev1.Route) error
 
 	// ReplaceRouteEndpoints replaces a subset (the ones associated with
 	// a single service unit) of a route endpoints.
-	ReplaceRouteEndpoints(id string, oldEndpoints, newEndpoints []Endpoint, weight int32) error
+	ReplaceRouteEndpoints(id ServiceAliasConfigKey, oldEndpoints, newEndpoints []Endpoint, weight int32) error
 
 	// RemoveRouteEndpoints removes a set of endpoints from a route.
-	RemoveRouteEndpoints(id string, endpoints []Endpoint) error
+	RemoveRouteEndpoints(id ServiceAliasConfigKey, endpoints []Endpoint) error
 
 	// Notify notifies a configuration manager of a router event.
 	// Currently the only ones that are received are on reload* events,


### PR DESCRIPTION
Define and use the `ServiceUnitKey` and `ServiceAliasConfigKey` types for key values of maps of `ServiceUnit` values and of `ServiceAliasConfig` values, respectively, in order to make code dealing with such maps clearer and reduce risk of mixing key values.

* `pkg/router/template/configmanager/haproxy/backend.go` (`Backend`): Use `ServiceAliasConfigKey` for the name.
(`buildHAProxyBackends`, `newBackend`, `Name`, `ApplyChanges`): Adapt to use the new `ServiceAliasConfigKey` type.
* `pkg/router/template/configmanager/haproxy/blueprint_plugin_test.go` (`fakeConfigManager`): Use `ServiceAliasConfigKey` for the `blueprints` map.
(`newFakeConfigManager`, `FindBlueprint`, `Register`, `AddRoute`, `RemoveRoute`, `ReplaceRouteEndpoints`, `RemoveRouteEndpoints`, `routeKey`):
* `pkg/router/template/configmanager/haproxy/client.go` (`FindBackend`):
* `pkg/router/template/configmanager/haproxy/client_test.go` (`TestClientCommit`, `TestClientBackends`): Adapt to use the
`ServiceAliasConfigKey` type.
* `pkg/router/template/configmanager/haproxy/manager.go` (`configEntryMap`): Use the `ServiceAliasConfigKey` type for the map's values.
(`routeBackendEntry`): Use the `ServiceAliasConfigKey` type for `backendName` and the `poolRouteBackendName`, `backendEntries`, and `poolUsage` maps' keys.
(`NewHAProxyConfigManager`, `Register`, `AddRoute`, `RemoveRoute`, `ReplaceRouteEndpoints`, `RemoveRouteEndpoints`, `findFreeBackendPoolSlot`, `reset`, `BackendName`, `BuildMapAssociations`, `routeBackendName`, `applyMapAssociations`):
* `pkg/router/template/configmanager/haproxy/map.go` (`Add`, `addEntry`):
* `pkg/router/template/configmanager/haproxy/map_test.go` (`TestHAProxyMapAdd`): Adapt to use the `ServiceAliasConfigKey` type.
* `pkg/router/template/fake.go` (`NewFakeTemplateRouter`): Adapt to use `ServiceUnitKey` and `ServiceAliasConfigKey`.
* `pkg/router/template/plugin.go` (`RouterInterface`, `endpointsKey`, `endpointsKeyFromParts`, `getPartsFromEndpointsKey`): Adapt to use `ServiceUnitKey`.
* `pkg/router/template/plugin_test.go` (`TestRouter`, `newTestRouter`, `CreateServiceUnit`, `FindServiceUnit`, `AddEndpoints`, `DeleteEndpoints`, `calculateServiceWeights`, `FilterNamespaces`, `getKey`, `TestHandleEndpoints`, `TestHandleTCPEndpoints`, `TestHandleRouteExtendedValidation`, `TestHandleRoute`, `TestNamespaceScopingFromEmpty`):
* `pkg/router/template/router.go` (`templateRouter`, `templateData`, `newTemplateRouter`, `readState`, `FilterNamespaces`, `CreateServiceUnit`, `createServiceUnitInternal`, `findMatchingServiceUnit`, `FindServiceUnit`, `DeleteServiceUnit`, `addServiceAliasAssociation`, `removeServiceAliasAssociation`, `dynamicallyAddRoute`, `dynamicallyRemoveRoute`, `dynamicallyReplaceEndpoints`, `DeleteEndpoints`, `routeKey`, `routeKeyFromParts`, `getPartsFromRouteKey`, `createServiceAliasConfig`, `numberOfEndpoints`, `AddEndpoints`, `getServiceUnits`, `getActiveEndpoints`, `calculateServiceWeights`):
* `pkg/router/template/router_test.go` (`TestCreateServiceUnit`, `TestDeleteServiceUnit`, `TestAddEndpoints`, `TestAddEndpointDuplicates`, `TestDeleteEndpoints`, `TestCreateServiceAliasConfig`, `TestAddRoute`, `TestFilterNamespaces`):
* `pkg/router/template/template_helper.go` (`generateHAProxyCertConfigMap`, `getHTTPAliasesGroupedByHost`, `generateHAProxyMap`):
* `pkg/router/template/template_helper_test.go` (`buildTestTemplateState`, `TestGenerateHAProxyCertConfigMap`, `TestGenerateHAProxyMap`, `TestGetHTTPAliasesGroupedByHost`): Adapt to use `ServiceAliasConfigKey` and
`ServiceUnitKey`.
* `pkg/router/template/types.go` (`ServiceUnit`): Use `ServiceAliasConfigKey` for the `ServiceAliasAssociations` map.
(`ServiceUnitKey`): New type.
(`ServiceAliasConfig`): Use `ServiceUnitKey` for the `ServiceUnits` and `ServiceUnitNames` maps.
(`ServiceAliasConfigKey`): New type.
(`ConfigManager`): Adapt to use `ServiceAliasConfigKey`.