### PR TITLE
Stop base64-encoding "router reloaded" log output

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -545,7 +545,7 @@ func (r *templateRouter) reloadRouter() error {
 	if err != nil {
 		return fmt.Errorf("error reloading router: %v\n%s", err, string(out))
 	}
-	log.V(0).Info("router reloaded", "output", out)
+	log.V(0).Info("router reloaded", "output", string(out))
 	return nil
 }
 


### PR DESCRIPTION
Convert the reload script's output from a byte slice to a string before logging it so that it is displayed properly.  Before https://github.com/openshift/router/pull/47/commits/dc68ebfcbd9fdc600391ebe050228534dd2b07c3, log messages looked like the following:

    Router reloaded:
     - Proxy protocol on, checking http://localhost:80 ...
     - Health check ok : 0 retry attempt(s).

Since that change, the reload script's output is base64-encoded in logs:

    router reloaded	{"output": "IC0gUHJveHkgcHJvdG9jb2wgb24sIGNoZWNraW5nIGh0dHA6Ly9sb2NhbGhvc3Q6ODAgLi4uCiAtIEhlYWx0aCBjaGVjayBvayA6IDAgcmV0cnkgYXR0ZW1wdChzKS4K"}

This PR restores the previous, non-encoded log messages.

* `pkg/router/template/router.go` (`reloadRouter`): Convert `out` to string.

----

- [ ] Check CI output to verify that it looks as expected.