### PR TITLE
Bug 1771783: Dynamically reload metrics certificate/key file changes

### DIFF
--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -583,7 +583,20 @@ func makeTLSConfig() (*tls.Config, error) {
 		return nil, err
 	}
 
-	// Safely reload the certificate as requested.
+	// Reload when the files change or when the fixed timer fires
+	ticker := time.NewTicker(5 * time.Minute)
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	if err := watcher.Add(certFile); err != nil {
+		return nil, err
+	}
+	if err := watcher.Add(keyFile); err != nil {
+		return nil, err
+	}
+
+	// Safely reload the certificate when signaled.
 	var lock sync.Mutex
 	reload := make(chan bool) // value will be false for an unscheduled reload
 	go func() {
@@ -609,18 +622,7 @@ func makeTLSConfig() (*tls.Config, error) {
 		}
 	}()
 
-	// Reload when the files change or when the fixed timer fires
-	ticker := time.NewTicker(5 * time.Minute)
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return nil, err
-	}
-	if err := watcher.Add(certFile); err != nil {
-		return nil, err
-	}
-	if err := watcher.Add(keyFile); err != nil {
-		return nil, err
-	}
+	// Watch events and trigger reloads.
 	go func() {
 		for {
 			select {

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -615,13 +615,13 @@ func makeTLSConfig(reloadPeriod time.Duration) (*tls.Config, error) {
 				}
 
 				// Something changed, reload the certificate.
-				certBytes = latestCertBytes
-				keyBytes = latestKeyBytes
 				latest, err := tls.X509KeyPair(certBytes, keyBytes)
 				if err != nil {
 					log.Error(err, "failed to reload certificate", "cert", certFile, "key", keyFile)
 					break
 				}
+				certBytes = latestCertBytes
+				keyBytes = latestKeyBytes
 
 				lock.Lock()
 				certificate = latest

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -598,7 +598,6 @@ func makeTLSConfig(reloadPeriod time.Duration) (*tls.Config, error) {
 		for {
 			select {
 			case <-ticker.C:
-				// Check for certificate or key content changes.
 				latestCertBytes, err := ioutil.ReadFile(certFile)
 				if err != nil {
 					log.Error(err, "failed to read certificate file", "cert", certFile, "key", keyFile)
@@ -615,17 +614,19 @@ func makeTLSConfig(reloadPeriod time.Duration) (*tls.Config, error) {
 					break
 				}
 
-				// Something changed, refresh the certificate.
-				latest, err := tls.X509KeyPair(latestCertBytes, latestKeyBytes)
+				// Something changed, reload the certificate.
+				certBytes = latestCertBytes
+				keyBytes = latestKeyBytes
+				latest, err := tls.X509KeyPair(certBytes, keyBytes)
 				if err != nil {
 					log.Error(err, "failed to reload certificate", "cert", certFile, "key", keyFile)
 					break
 				}
+
 				lock.Lock()
 				certificate = latest
-				certBytes = latestCertBytes
-				keyBytes = latestKeyBytes
 				lock.Unlock()
+
 				log.V(0).Info("reloaded metrics certificate", "cert", certFile, "key", keyFile)
 			}
 		}

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -1,9 +1,11 @@
 package router
 
 import (
+	"bytes"
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -16,8 +18,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-
-	"github.com/fsnotify/fsnotify"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -422,7 +422,7 @@ func (o *TemplateRouterOptions) Run() error {
 			ReadyChecks: []healthz.HealthChecker{checkBackend, checkSync},
 		}
 
-		if tlsConfig, err := makeTLSConfig(); err != nil {
+		if tlsConfig, err := makeTLSConfig(30 * time.Second); err != nil {
 			return err
 		} else {
 			l.TLSConfig = tlsConfig
@@ -569,77 +569,64 @@ func (o *TemplateRouterOptions) blueprintRoutes(routeclient *routeclientset.Clie
 
 // makeTLSConfig checks whether metrics TLS is configured and
 // if so returns a tls.Config whose certificate is automatically
-// reloaded every 5 minutes or in response to file changes.
-func makeTLSConfig() (*tls.Config, error) {
+// reloaded on the given period.
+func makeTLSConfig(reloadPeriod time.Duration) (*tls.Config, error) {
 	certFile := env("ROUTER_METRICS_TLS_CERT_FILE", "")
 	if len(certFile) == 0 {
 		return nil, nil
 	}
 	keyFile := env("ROUTER_METRICS_TLS_KEY_FILE", "")
 
-	// Make sure we have something useful to start with
-	certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
+	// Load the initial certificate contents.
+	certBytes, err := ioutil.ReadFile(certFile)
+	if err != nil {
+		return nil, err
+	}
+	keyBytes, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+	certificate, err := tls.X509KeyPair(certBytes, keyBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	// Reload when the files change or when the fixed timer fires
-	ticker := time.NewTicker(5 * time.Minute)
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return nil, err
-	}
-	if err := watcher.Add(certFile); err != nil {
-		return nil, err
-	}
-	if err := watcher.Add(keyFile); err != nil {
-		return nil, err
-	}
-
-	// Safely reload the certificate when signaled.
+	// Safely reload the certificate on a fixed period for simplicity.
+	ticker := time.NewTicker(reloadPeriod)
 	var lock sync.Mutex
-	reload := make(chan bool) // value will be false for an unscheduled reload
 	go func() {
 		for {
 			select {
-			case scheduled := <-reload:
-				latest, err := tls.LoadX509KeyPair(certFile, keyFile)
+			case <-ticker.C:
+				// Check for certificate or key content changes.
+				latestCertBytes, err := ioutil.ReadFile(certFile)
 				if err != nil {
-					// TODO: add a prometheus metric? Fail a health check? This should surface somehow...
+					log.Error(err, "failed to read certificate file", "cert", certFile, "key", keyFile)
+					break
+				}
+				latestKeyBytes, err := ioutil.ReadFile(keyFile)
+				if err != nil {
+					log.Error(err, "failed to read key file", "cert", certFile, "key", keyFile)
+					break
+				}
+
+				if bytes.Equal(latestCertBytes, certBytes) && bytes.Equal(latestKeyBytes, keyBytes) {
+					// Nothing changed, try later.
+					break
+				}
+
+				// Something changed, refresh the certificate.
+				latest, err := tls.X509KeyPair(latestCertBytes, latestKeyBytes)
+				if err != nil {
 					log.Error(err, "failed to reload certificate", "cert", certFile, "key", keyFile)
 					break
 				}
 				lock.Lock()
 				certificate = latest
+				certBytes = latestCertBytes
+				keyBytes = latestKeyBytes
 				lock.Unlock()
-				// TODO: add a prometheus metric instead?
-				if scheduled {
-					log.V(4).Info("reloaded certificate on fixed schedule", "cert", certFile, "key", keyFile)
-				} else {
-					log.V(0).Info("reloaded modified certificate", "cert", certFile, "key", keyFile)
-				}
-			}
-		}
-	}()
-
-	// Watch events and trigger reloads.
-	go func() {
-		for {
-			select {
-			case <-ticker.C:
-				reload <- true
-			case _, ok := <-watcher.Events:
-				if ok {
-					// Ignoring the event type for now to avoid any portability
-					// issues at the expense of potentially spurious reloads on
-					// irrelevant events (which should be rare, this is a mounted
-					// secret).
-					reload <- false
-				}
-			case err, _ := <-watcher.Errors:
-				if err != nil {
-					log.Error(err, "file watch error")
-				}
+				log.V(0).Info("reloaded metrics certificate", "cert", certFile, "key", keyFile)
 			}
 		}
 	}()


### PR DESCRIPTION
The metrics certificate can be rotated. Add support to dynamically reload
the certificate and key file when they change. This enables certificate
rotation without incurring an expensive restart.

Before this change, metrics scraping can begin failing when the metrics
endpoint's certificate is invalidated and can't be fixed without restarting
the controller.