### PR TITLE
Bug 1780794: unique_host: HandleRoute: No error if host claimed

### DIFF
--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -148,8 +148,6 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routev1.Route
 		return p.plugin.HandleRoute(eventType, route)
 
 	case watch.Added, watch.Modified:
-		removed := false
-
 		var nestedErr error
 		changes, newRoute := p.index.Add(route)
 
@@ -179,7 +177,6 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routev1.Route
 			}
 
 			// we were not added because another route is covering us
-			removed = true
 			var owner *routev1.Route
 			if old, ok := p.index.RoutesForHost(host); ok && len(old) > 0 {
 				owner = old[0]
@@ -203,16 +200,6 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routev1.Route
 			}
 		}
 
-		// // ensure we pass down modifications
-		// if !added && !removed {
-		// 	if err := p.plugin.HandleRoute(watch.Modified, route); err != nil {
-		// 		utilruntime.HandleError(fmt.Errorf("unable to modify route %s: %v", routeName, err))
-		// 	}
-		// }
-
-		if removed {
-			return fmt.Errorf("another route has claimed this host")
-		}
 		return nestedErr
 
 	default:

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -549,8 +549,8 @@ func TestHandleRoute(t *testing.T) {
 			},
 		},
 	}
-	if err := plugin.HandleRoute(watch.Added, fooDupe2); err == nil {
-		t.Fatal("unexpected non-error")
+	if err := plugin.HandleRoute(watch.Added, fooDupe2); err != nil {
+		t.Fatal("unexpected error")
 	}
 
 	if _, ok := router.FindServiceUnit(endpointsKeyFromParts("foo", "TestService2")); ok {


### PR DESCRIPTION
Change the unique_host plugin's `HandleRoute` method not to return an error because the host name is claimed.

Returning an error causes the controller to log an unhelpful error message:

    router_controller.go:244] another route has claimed this host

The plugin already logs the conflict, along with the host name and the claimants' names and namespaces, at a higher log level and updates the Route's status to indicate that it has been rejected because of a preëmpting claim.  Moreover, a conflicting claim does not logically represent an error condition for the plugin or controller, and in the absence of such, it makes more sense return a nil error value after logging the condition.

* `pkg/router/controller/unique_host.go`: Do not return a gratuitous error value for a preëmpting claim.
* `pkg/router/template/plugin_test.go` (`TestHandleRoute`): Expect a nil error value from the unique_host plugin when handling a valid Route for which a preëmpting claim exists.