### PR TITLE
images/router/haproxy: switch to haproxy 2.0

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy18 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy20 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy18 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy20 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
Move to haproxy 2.x which is packaged here:

https://pkgs.devel.redhat.com/cgit/rpms/haproxy/log/?h=rhaos-4.4-rhel-7