### PR TITLE
Default to v4v6 mode in haproxy template

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -7,7 +7,7 @@
 {{- $workingDir := .WorkingDir }}
 {{- $defaultDestinationCA := .DefaultDestinationCA }}
 {{- $dynamicConfigManager := .DynamicConfigManager }}
-{{- $router_ip_v4_v6_mode := env "ROUTER_IP_V4_V6_MODE" "v4" }}
+{{- $router_ip_v4_v6_mode := env "ROUTER_IP_V4_V6_MODE" "v4v6" }}
 
 
 {{- /* A bunch of regular expressions.  Each should be wrapped in (?:) so that it is safe to include bare */}}


### PR DESCRIPTION
The previous default was IPv4 only.  This new default allows both IPv4
and IPv6 to work.

This should be a safe default value. The case where this
would break would be a RHEL node with IPv6 completely disabled.  I'm
not sure if that's a realistic case to worry about, though.

Otherwise, we'll have to make this driven by the ingress operator
based on the configuration of the cluster.