### PR TITLE
Fix for routes update broken while doing Green/Blue deployment

### DIFF
--- a/pkg/router/controller/hostindex/hostindex.go
+++ b/pkg/router/controller/hostindex/hostindex.go
@@ -105,6 +105,10 @@ func (hi *hostIndex) add(route *routev1.Route, changes *routeChanges) bool {
 			// another route. Remove the existing state to avoid maintaining a
 			// duplicate claim in the index.
 			hi.remove(existing, false, changes)
+		case existing.Spec.To != route.Spec.To:
+			// target svc changed, remove the existing state to avoid maintaining a
+			// duplicate claim in the index.
+			hi.remove(existing, false, changes)
 		default:
 			// if no changes have been made, we don't need to note a change
 			if existing.ResourceVersion == route.ResourceVersion {

--- a/pkg/router/controller/hostindex/hostindex_test.go
+++ b/pkg/router/controller/hostindex/hostindex_test.go
@@ -247,6 +247,34 @@ func Test_hostIndex(t *testing.T) {
 			activates: map[string]struct{}{"001": {}},
 		},
 		{
+			name:       "multiple changes to target svc of same route",
+			activateFn: SameNamespace,
+			steps: []step{
+				{route: newRoute("test", "1", 1, 1, routev1.RouteSpec{Host: "test.com", To: routev1.RouteTargetReference{
+					Name:   "TestSvcBlue",
+					Weight: new(int32),
+				}})},
+				{route: newRoute("test", "1", 1, 2, routev1.RouteSpec{Host: "test.com", To: routev1.RouteTargetReference{
+					Name:   "TestSvcGreen",
+					Weight: new(int32),
+				}})},
+				{route: newRoute("test", "1", 1, 3, routev1.RouteSpec{Host: "test.com", To: routev1.RouteTargetReference{
+					Name:   "TestSvcBlue",
+					Weight: new(int32),
+				}})},
+				{route: newRoute("test", "1", 1, 4, routev1.RouteSpec{Host: "test.com", To: routev1.RouteTargetReference{
+					Name:   "TestSvcGreen",
+					Weight: new(int32),
+				}})},
+				{route: newRoute("test", "1", 1, 5, routev1.RouteSpec{Host: "test.com", To: routev1.RouteTargetReference{
+					Name:   "TestSvcBlue",
+					Weight: new(int32),
+				}})},
+			},
+			active:    map[string][]string{"test.com": {"001"}},
+			activates: map[string]struct{}{"001": {}},
+		},
+		{
 			name:       "remove unchanged path-based route",
 			activateFn: SameNamespace,
 			steps: []step{
@@ -286,6 +314,31 @@ func Test_hostIndex(t *testing.T) {
 				{route: newRoute("test", "2", 2, 1, routev1.RouteSpec{Host: "test.com", Path: "/foo"})},
 				{route: newRoute("test", "2", 2, 2, routev1.RouteSpec{Host: "test.com", Path: "/bar"})},
 				{route: newRoute("test", "2", 2, 3, routev1.RouteSpec{Host: "test.com", Path: "/x/y/z"})},
+			},
+			active:    map[string][]string{"test.com": {"001"}},
+			displaces: map[string]struct{}{"002": {}},
+			inactive:  map[string][]string{"test.com": {"002"}},
+		},
+		{
+			name:       "to target svc route rejection",
+			activateFn: SameNamespace,
+			steps: []step{
+				{route: newRoute("test", "1", 1, 1, routev1.RouteSpec{Host: "test.com", To: routev1.RouteTargetReference{
+					Name:   "TestSvcBlue",
+					Weight: new(int32),
+				}})},
+				{route: newRoute("test", "2", 2, 1, routev1.RouteSpec{Host: "test.com", To: routev1.RouteTargetReference{
+					Name:   "TestSvcGreen",
+					Weight: new(int32),
+				}})},
+				{route: newRoute("test", "2", 2, 2, routev1.RouteSpec{Host: "test.com", To: routev1.RouteTargetReference{
+					Name:   "TestSvcRed",
+					Weight: new(int32),
+				}})},
+				{route: newRoute("test", "2", 2, 3, routev1.RouteSpec{Host: "test.com", To: routev1.RouteTargetReference{
+					Name:   "TestSvcBlue",
+					Weight: new(int32),
+				}})},
 			},
 			active:    map[string][]string{"test.com": {"001"}},
 			displaces: map[string]struct{}{"002": {}},


### PR DESCRIPTION
 when apply Green/Blue deployment strategy, the route to svc will need switch every deployment
 - after some switches, will get failed in router logs `another route has claimed this host`
 - the inconsistent state need clean up