### PR TITLE
[WIP] DO NOT MERGE - 4.4: test/validate haproxy20-optimized-2.0.13-2.el7.x86_64.rpm

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,9 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy20 rsyslog sysvinit-tools" && \
+
+RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy20-optimized-2.0.13-1.el7.x86_64.rpm
+RUN haproxy -vv
+
+RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
 
-RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy20-optimized-2.0.13-1.el7.x86_64.rpm
+RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy20-2.0.13-2.el7.x86_64.rpm
 RUN haproxy -vv
 
 RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,6 +1,6 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
 
-RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy20-optimized-2.0.13-1.el7.x86_64.rpm
+RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy20-2.0.13-2.el7.x86_64.rpm
 RUN haproxy -vv
 
 RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,9 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy20 rsyslog sysvinit-tools" && \
+
+RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy20-optimized-2.0.13-1.el7.x86_64.rpm
+RUN haproxy -vv
+
+RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
This is 2.0.13 plus this WIP patch:

  https://github.com/chlunde/haproxy/commit/2fccb7d8d7b31ee795725fa883f2167707705490

which speeds up parsing the configuration file.

Assuming a configuration file with 20,000 entries similar to: 

```console
 http-request set-header X-Forwarded-Port 3691 if { path_beg -i foo3691 }
 http-request set-header X-Forwarded-Port 3692 if { path_beg -i foo3692 }
 http-request set-header X-Forwarded-Port 3693 if { path_beg -i foo3693 }
 http-request set-header X-Forwarded-Port 3694 if { path_beg -i foo3694 }
 http-request set-header X-Forwarded-Port 3695 if { path_beg -i foo3695 }
 http-request set-header X-Forwarded-Port 3696 if { path_beg -i foo3696 }
 http-request set-header X-Forwarded-Port 3697 if { path_beg -i foo3697 }
...
```
I see the following parse/check times for the configuration file:

```console
$ time ~/haproxy-2.0.13 -f ~/haproxy-hacks/prometheus/haproxy.cfg -c
Configuration file is valid

real    0m5.424s
user    0m5.401s
sys     0m0.012s

$ time ~/haproxy-2.0.13-d3a876-1 -f ~/haproxy-hacks/prometheus/haproxy.cfg -c
Configuration file is valid

real    0m0.070s
user    0m0.059s
sys     0m0.011s
```