### PR TITLE
Add toleration to allow pods to schedule to edge nodes

### DIFF
--- a/deploy/router.yaml
+++ b/deploy/router.yaml
@@ -14,6 +14,11 @@ spec:
       labels:
         k8s-app: ingress-router
     spec:
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "edge"
+          effect: NoSchedule
       serviceAccountName: ingress-router
       containers:
       - env:


### PR DESCRIPTION
I would like to add the default behavior to allow for scheduling of the router pods to edge nodes. It is a way for us to restrict traffic to just these nodes https://cloud.ibm.com/docs/containers?topic=containers-edge.