### PR TITLE
Bug 1809665: Start graceful shutdown on SIGTERM

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -4,23 +4,27 @@ set -o nounset
 
 config_file=/var/lib/haproxy/conf/haproxy.config
 pid_file=/var/lib/haproxy/run/haproxy.pid
-readonly max_wait_time=30
 readonly timeout_opts="-m 1 --connect-timeout 1"
+
+readonly max_wait_time=30
 readonly numeric_re='^[0-9]+$'
+wait_time=${MAX_RELOAD_WAIT_TIME:-$max_wait_time}
+if ! [[ $wait_time =~ $numeric_re ]]; then
+  echo " - Invalid max reload wait time, using default $max_wait_time ..."
+  wait_time=$max_wait_time
+fi
+shutdown_wait_time=${ROUTER_MAX_SHUTDOWN_TIMEOUT:-${wait_time}}
+if ! [[ $shutdown_wait_time =~ $numeric_re ]]; then
+  echo " - Invalid max shutdown wait time, using $wait_time ..."
+  shutdown_wait_time=$wait_time
+fi
 
 function haproxyHealthCheck() {
-  local wait_time=${MAX_RELOAD_WAIT_TIME:-$max_wait_time}
   local port=${ROUTER_SERVICE_HTTP_PORT:-"80"}
   local url="http://localhost:${port}"
   local retries=0
   local start_ts=$(date +"%s")
   local proxy_proto="${ROUTER_USE_PROXY_PROTOCOL-}"
-
-  if ! [[ $wait_time =~ $numeric_re ]]; then
-    echo " - Invalid max reload wait time, using default $max_wait_time ..."
-    wait_time=$max_wait_time
-  fi
-
   local end_ts=$((start_ts + wait_time))
 
   # test with proxy protocol on
@@ -66,6 +70,25 @@ function haproxyHealthCheck() {
 
 
 old_pids=$(pidof haproxy)
+
+# If signaled, stop accepting new connections and drain the current processes
+if [ -n "${ROUTER_SHUTDOWN-}" ]; then
+  echo " - Shutting down"
+  if [ -z "$old_pids" ]; then
+    exit 0
+  fi
+  kill -USR1 $old_pids
+  for i in $( seq 1 $shutdown_wait_time ); do
+    old_pids=$(pidof haproxy)
+    if [ -z "$old_pids" ]; then
+      exit 0
+    fi
+    sleep 1
+  done
+  kill -TERM $old_pids
+  echo "error: Some processes did not exit within ${shutdown_wait_time}s"
+  exit 1
+fi
 
 reload_status=0
 if [ -n "$old_pids" ]; then

--- a/pkg/router/shutdown/shutdown.go
+++ b/pkg/router/shutdown/shutdown.go
@@ -1,0 +1,29 @@
+package shutdown
+
+import (
+	"os"
+	"os/signal"
+)
+
+var onlyOneSignalHandler = make(chan struct{})
+var shutdownHandler chan os.Signal
+
+// SetupSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
+// which is closed on one of these signals. If a second signal is caught, the program
+// is terminated with exit code 1.
+func SetupSignalHandler() <-chan struct{} {
+	close(onlyOneSignalHandler) // panics when called twice
+
+	shutdownHandler = make(chan os.Signal, 2)
+
+	stop := make(chan struct{})
+	signal.Notify(shutdownHandler, shutdownSignals...)
+	go func() {
+		<-shutdownHandler
+		close(stop)
+		<-shutdownHandler
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return stop
+}

--- a/pkg/router/shutdown/signal_posix.go
+++ b/pkg/router/shutdown/signal_posix.go
@@ -1,0 +1,10 @@
+// +build !windows
+
+package shutdown
+
+import (
+	"os"
+	"syscall"
+)
+
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}

--- a/pkg/router/shutdown/signal_windows.go
+++ b/pkg/router/shutdown/signal_windows.go
@@ -1,0 +1,7 @@
+package shutdown
+
+import (
+	"os"
+)
+
+var shutdownSignals = []os.Signal{os.Interrupt}

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -153,6 +153,14 @@ func NewTemplatePlugin(cfg TemplatePluginConfig, lookupSvc ServiceLookup) (*Temp
 	return newDefaultTemplatePlugin(router, cfg.IncludeUDP, lookupSvc), err
 }
 
+// Stop instructs the router plugin to stop invoking the reload method, and waits until no further
+// reloads will occur. It then invokes the reload script one final time with the ROUTER_SHUTDOWN
+// environment variable set with true.
+func (p *TemplatePlugin) Stop() error {
+	p.Router.(*templateRouter).rateLimitedCommitFunction.Stop()
+	return p.Router.(*templateRouter).reloadRouter(true)
+}
+
 // HandleEndpoints processes watch events on the Endpoints resource.
 func (p *TemplatePlugin) HandleEndpoints(eventType watch.EventType, endpoints *kapi.Endpoints) error {
 	key := endpointsKey(endpoints)

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -440,7 +440,7 @@ func (r *templateRouter) commitAndReload() error {
 
 	log.V(4).Info("reloading the router")
 	reloadStart := time.Now()
-	err := r.reloadRouter()
+	err := r.reloadRouter(false)
 	r.metricReload.Observe(float64(time.Now().Sub(reloadStart)) / float64(time.Second))
 	if err != nil {
 		if r.dynamicConfigManager != nil {
@@ -539,8 +539,11 @@ func (r *templateRouter) writeCertificates(cfg *ServiceAliasConfig) error {
 }
 
 // reloadRouter executes the router's reload script.
-func (r *templateRouter) reloadRouter() error {
+func (r *templateRouter) reloadRouter(shutdown bool) error {
 	cmd := exec.Command(r.reloadScriptPath)
+	if shutdown {
+		cmd.Env = append(os.Environ(), "ROUTER_SHUTDOWN=true")
+	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error reloading router: %v\n%s", err, string(out))


### PR DESCRIPTION
Graceful shutdown in Kubernetes requires:

1. Wait for the frontend to be taken out of rotation by kube-proxy (fast, 5s or so) and external load balancers (slow, 45s is reasonable across all clouds) so that new connections are not allowed
2. Stop accepting new connections
3. Drain existing connections within some timeout
4. Exit with 0 if drain before the timeout, exit with 1 after the timeout (connections still outstanding) 

This PR updates the router to implement the above logic.

When the main process recieves SIGTERM or SIGINT, wait ROUTER_GRACEFUL_SHUTDOWN_DELAY (default: 45) seconds and then signal the reload script with ROUTER_SHUTDOWN=true that a graceful termination is requested. The reload-haproxy script then invokes USR1 on all child haproxy processes and waits ROUTER_MAX_SHUTDOWN_TIMEOUT or MAX_RELOAD_WAIT_TIME (default 30) seconds before invoking TERM on the child processes. If TERM is invoked the script exits with 1, indicating that not all processes completed their work.

Clients with long running requests should set ROUTER_MAX_SHUTDOWN_TIMEOUT as appropriate to ensure all connections exit cleanly.