### PR TITLE
Bug 1810181: Wildcard is not needed to copy subdirectory in dockerfile

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -9,7 +9,7 @@ RUN INSTALL_PKGS="haproxy20 rsyslog sysvinit-tools" && \
     setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
     chown -R :0 /var/lib/haproxy && \
     chmod -R g+w /var/lib/haproxy
-COPY images/router/haproxy/* /var/lib/haproxy/
+COPY images/router/haproxy/ /var/lib/haproxy/
 LABEL io.k8s.display-name="OpenShift HAProxy Router" \
       io.k8s.description="This component offers ingress to an OpenShift cluster via Ingress and Route rules." \
       io.openshift.tags="openshift,router,haproxy"

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -9,7 +9,7 @@ RUN INSTALL_PKGS="haproxy20 rsyslog sysvinit-tools" && \
     setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
     chown -R :0 /var/lib/haproxy && \
     chmod -R g+w /var/lib/haproxy
-COPY images/router/haproxy/* /var/lib/haproxy/
+COPY images/router/haproxy/ /var/lib/haproxy/
 LABEL io.k8s.display-name="OpenShift HAProxy Router" \
       io.k8s.description="This component offers ingress to an OpenShift cluster via Ingress and Route rules." \
       io.openshift.tags="openshift,router,haproxy"

--- a/images/router/nginx/Dockerfile
+++ b/images/router/nginx/Dockerfile
@@ -13,7 +13,7 @@ RUN yum install -y nginx-${NGINX_VERSION} && \
     ln -sf /var/lib/nginx/log/error.log /var/log/nginx/error.log && \
     rm /etc/yum.repos.d/nginx.repo
 
-COPY images/router/nginx/* /var/lib/nginx/
+COPY images/router/nginx/ /var/lib/nginx/
 LABEL io.k8s.display-name="OpenShift NGINX Router" \
       io.k8s.description="This is a component of OpenShift and contains an NGINX instance that exposes ingress to services within the cluster through routes, and offers TLS termination, reencryption, or SNI-passthrough on ports 80 and 443."
 USER 1001

--- a/images/router/nginx/Dockerfile.rhel
+++ b/images/router/nginx/Dockerfile.rhel
@@ -13,7 +13,7 @@ RUN yum install -y nginx-${NGINX_VERSION} && \
     ln -sf /var/lib/nginx/log/error.log /var/log/nginx/error.log && \
     rm /etc/yum.repos.d/nginx.repo
 
-COPY images/router/nginx/* /var/lib/nginx/
+COPY images/router/nginx/ /var/lib/nginx/
 LABEL io.k8s.display-name="OpenShift NGINX Router" \
       io.k8s.description="This is a component of OpenShift and contains an NGINX instance that exposes ingress to services within the cluster through routes, and offers TLS termination, reencryption, or SNI-passthrough on ports 80 and 443."
 USER 1001


### PR DESCRIPTION
Docker treats /* as a "collapse subdirectory" option, so we should
avoid potentially incompatible behavior across multiple builders.