### PR TITLE
Add HAProxy annotation for http2/cleartext (h2c) routes

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -454,7 +454,11 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
     {{- if ge $weight 0 }}{{/* weight=0 is reasonable to keep existing connections to backends with cookies as we can see the HTTP headers */}}
       {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
         {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
+	  {{- if isTrue (index $cfg.Annotations "haproxy.router.openshift.io/enable-h2c") }}
+  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{$weight}} proto h2
+          {{- else }}
   server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{$weight}} alpn h2,http/1.1
+          {{- end }}
           {{- if (eq $cfg.TLSTermination "reencrypt") }} ssl
             {{- if $cfg.VerifyServiceHostname }} verifyhost {{ $serviceUnit.Hostname }}
             {{- end }}

--- a/pkg/router/template/configmanager/haproxy/manager.go
+++ b/pkg/router/template/configmanager/haproxy/manager.go
@@ -1094,6 +1094,7 @@ func modAnnotationsList(termination routev1.TLSTerminationType) []string {
 		"haproxy.router.openshift.io/rate-limit-connections.rate-tcp",
 		"haproxy.router.openshift.io/rate-limit-connections.rate-http",
 		"haproxy.router.openshift.io/pod-concurrent-connections",
+		"haproxy.router.openshift.io/enable-h2c",
 		"router.openshift.io/haproxy.health.check.interval",
 	}
 


### PR DESCRIPTION
If your route type is "termination: edge" then your backend may still
need http2 (e.g., gRPC servers). To support such configurations you
now need to set the following annotation on an edge route:

  "haproxy.router.openshift.io/enable-h2c: true"

Enabling http2 cleartext (h2c) is documented in the haproxy-1.9
releases notes[1]:

  The "proto h2" directive allows HAProxy to communicate using HTTP/2
  without TLS, such as HTTP/2-enabled backends like Varnish and H2O,
  and gRPC servers.

With this annotation enabled the server backend will change from:

    server server1 192.168.1.13:80 alpn h2,http/1.1

to:

    server server1 192.168.1.13:80 proto h2

[1] https://www.haproxy.com/blog/haproxy-1-9-has-arrived/