### PR TITLE
Use ServiceAliasConfigKeys for dynamic config

### DIFF
--- a/pkg/router/template/configmanager/haproxy/blueprint_plugin_test.go
+++ b/pkg/router/template/configmanager/haproxy/blueprint_plugin_test.go
@@ -63,15 +63,15 @@ func (cm *fakeConfigManager) RemoveRouteEndpoints(id templaterouter.ServiceAlias
 func (cm *fakeConfigManager) Notify(event templaterouter.RouterEventType) {
 }
 
-func (cm *fakeConfigManager) ServerTemplateName(id string) string {
+func (cm *fakeConfigManager) ServerTemplateName(id templaterouter.ServiceAliasConfigKey) string {
 	return "fakeConfigManager"
 }
 
-func (cm *fakeConfigManager) ServerTemplateSize(id string) string {
+func (cm *fakeConfigManager) ServerTemplateSize(id templaterouter.ServiceAliasConfigKey) string {
 	return "1"
 }
 
-func (cm *fakeConfigManager) GenerateDynamicServerNames(id string) []string {
+func (cm *fakeConfigManager) GenerateDynamicServerNames(id templaterouter.ServiceAliasConfigKey) []string {
 	return []string{}
 }
 

--- a/pkg/router/template/configmanager/haproxy/manager.go
+++ b/pkg/router/template/configmanager/haproxy/manager.go
@@ -635,7 +635,7 @@ func (cm *haproxyConfigManager) Commit() {
 }
 
 // ServerTemplateName returns the dynamic server template name.
-func (cm *haproxyConfigManager) ServerTemplateName(id string) string {
+func (cm *haproxyConfigManager) ServerTemplateName(id templaterouter.ServiceAliasConfigKey) string {
 	if cm.maxDynamicServers > 0 {
 		// Adding the id makes the name unwieldy - use pod.
 		return fmt.Sprintf("%s-pod", dynamicServerPrefix)
@@ -646,7 +646,7 @@ func (cm *haproxyConfigManager) ServerTemplateName(id string) string {
 
 // ServerTemplateSize returns the dynamic server template size.
 // Note this is returned as a string for easier use in the haproxy template.
-func (cm *haproxyConfigManager) ServerTemplateSize(id string) string {
+func (cm *haproxyConfigManager) ServerTemplateSize(id templaterouter.ServiceAliasConfigKey) string {
 	if cm.maxDynamicServers < 1 {
 		return ""
 	}
@@ -655,7 +655,7 @@ func (cm *haproxyConfigManager) ServerTemplateSize(id string) string {
 }
 
 // GenerateDynamicServerNames generates the dynamic server names.
-func (cm *haproxyConfigManager) GenerateDynamicServerNames(id string) []string {
+func (cm *haproxyConfigManager) GenerateDynamicServerNames(id templaterouter.ServiceAliasConfigKey) []string {
 	if cm.maxDynamicServers > 0 {
 		if prefix := cm.ServerTemplateName(id); len(prefix) > 0 {
 			names := make([]string, cm.maxDynamicServers)

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -216,13 +216,13 @@ type ConfigManager interface {
 	Notify(event RouterEventType)
 
 	// ServerTemplateName returns the dynamic server template name.
-	ServerTemplateName(id string) string
+	ServerTemplateName(id ServiceAliasConfigKey) string
 
 	// ServerTemplateSize returns the dynamic server template size.
-	ServerTemplateSize(id string) string
+	ServerTemplateSize(id ServiceAliasConfigKey) string
 
 	// GenerateDynamicServerNames generates the dynamic server names.
-	GenerateDynamicServerNames(id string) []string
+	GenerateDynamicServerNames(id ServiceAliasConfigKey) []string
 }
 
 // RouterEventType indicates the type of event fired by the router.


### PR DESCRIPTION
Following https://github.com/openshift/router/pull/51 doing it for other template methods.

Verified that the router is functional with these changes and `ROUTER_HAPROXY_CONFIG_MANAGER='true'`

Fixes #107