### PR TITLE
[WIP] DO NOT MERGE - test/validate haproxy20-2.0.14-1.el7.x86_64.rpm

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,9 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy20 rsyslog sysvinit-tools" && \
+
+RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/rhaos-4.5-rhel-7-build-haproxy20-2.0.14-1.el7.x86_64.rpm
+RUN haproxy -vv
+
+RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,9 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy20 rsyslog sysvinit-tools" && \
+
+RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/rhaos-4.5-rhel-7-build-haproxy20-2.0.14-1.el7.x86_64.rpm
+RUN haproxy -vv
+
+RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
DO NOT MERGE

This PR is to validate a build of haproxy20-2.0.14-1.el7.x86_64.rpm.

ChangeLog :
===========

2020/04/02 : 2.0.14
    - BUG/MINOR: namespace: avoid closing fd when socket failed in my_socketat
    - BUG/MEDIUM: muxes: Use the right argument when calling the destroy method.
    - SCRIPTS: announce-release: use mutt -H instead of -i to include the draft
    - MINOR: http-htx: Add a function to retrieve the headers size of an HTX message
    - MINOR: filters: Forward data only if the last filter forwards something
    - BUG/MINOR: filters: Count HTTP headers as filtered data but don't forward them
    - BUG/MINOR: http-ana: Matching on monitor-uri should be case-sensitive
    - BUG/MAJOR: http-ana: Always abort the request when a tarpit is triggered
    - MINOR: ist: add an iststop() function
    - BUG/MINOR: http: http-request replace-path duplicates the query string
    - BUG/MEDIUM: shctx: make sure to keep all blocks aligned
    - MINOR: compiler: move CPU capabilities definition from config.h and complete them
    - BUG/MEDIUM: ebtree: don't set attribute packed without unaligned access support
    - BUILD: fix recent build failure on unaligned archs
    - CLEANUP: cfgparse: Fix type of second calloc() parameter
    - BUG/MINOR: sample: fix the json converter's endian-sensitivity
    - BUG/MEDIUM: ssl: fix several bad pointer aliases in a few sample fetch functions
    - BUG/MINOR: connection: make sure to correctly tag local PROXY connections
    - MINOR: compiler: add new alignment macros
    - BUILD: ebtree: improve architecture-specific alignment
    - BUG/MINOR: sample: Make sure to return stable IDs in the unique-id fetch
    - BUG/MINOR: dns: ignore trailing dot
    - MINOR: contrib/prometheus-exporter: Add heathcheck status/code in server metrics
    - MINOR: contrib/prometheus-exporter: Add the last heathcheck duration metric
    - BUG/MEDIUM: random: initialize the random pool a bit better
    - MINOR: tools: add 64-bit rotate operators
    - BUG/MEDIUM: random: implement a thread-safe and process-safe PRNG
    - MINOR: backend: use a single call to ha_random32() for the random LB algo
    - BUG/MINOR: checks/threads: use ha_random() and not rand()
    - BUG/MAJOR: list: fix invalid element address calculation
    - MINOR: debug: report the task handler's pointer relative to main
    - BUG/MEDIUM: debug: make the debug_handler check for the thread in threads_to_dump
    - MINOR: haproxy: export main to ease access from debugger
    - BUG/MINOR: wdt: do not return an error when the watchdog couldn't be enabled
    - DOC: fix incorrect indentation of http_auth_*
    - OPTIM: startup: fast unique_id allocation for acl.
    - BUG/MINOR: pattern: Do not pass len = 0 to calloc()
    - DOC: configuration.txt: fix various typos
    - DOC: assorted typo fixes in the documentation and Makefile
    - BUG/MINOR: init: make the automatic maxconn consider the max of soft/hard limits
    - BUG/MAJOR: proxy_protocol: Properly validate TLV lengths
    - REGTEST: make the PROXY TLV validation depend on version 2.2
    - MINOR: htx: Add a function to return a block at a specific offset
    - BUG/MEDIUM: cache/filters: Fix loop on HTX blocks caching the response payload
    - BUG/MEDIUM: compression/filters: Fix loop on HTX blocks compressing the payload
    - BUG/MINOR: http-ana: Reset request analysers on a response side error
    - BUG/MINOR: lua: Ignore the reserve to know if a channel is full or not
    - BUG/MINOR: http-rules: Preserve FLT_END analyzers on reject action
    - BUG/MINOR: http-rules: Fix a typo in the reject action function
    - BUG/MINOR: rules: Preserve FLT_END analyzers on silent-drop action
    - BUG/MINOR: rules: Increment be_counters if backend is assigned for a silent-drop
    - DOC: fix typo about no-tls-tickets
    - DOC: improve description of no-tls-tickets
    - DOC: ssl: clarify security implications of TLS tickets
    - BUILD: wdt: only test for SI_TKILL when compiled with thread support
    - BUG/MEDIUM: random: align the state on 2*64 bits for ARM64
    - BUG/MINOR: haproxy: always initialize sleeping_thread_mask
    - BUG/MINOR: listener/mq: do not dispatch connections to remote threads when stopping
    - BUG/MINOR: haproxy/threads: try to make all threads leave together
    - DOC: proxy_protocol: Reserve TLV type 0x05 as PP2_TYPE_UNIQUE_ID
    - BUILD: on ARM, must be linked to libatomic.
    - BUILD: makefile: fix regex syntax in ARM platform detection
    - BUILD: makefile: fix expression again to detect ARM platform
    - BUG/MEDIUM: peers: resync ended with RESYNC_PARTIAL in wrong cases.
    - DOC: assorted typo fixes in the documentation
    - MINOR: wdt: Move the definitions of WDTSIG and DEBUGSIG into types/signal.h.
    - BUG/MEDIUM: wdt: Don't ignore WDTSIG and DEBUGSIG in __signal_process_queue().
    - MINOR: memory: Change the flush_lock to a spinlock, and don't get it in alloc.
    - BUG/MINOR: connections: Make sure we free the connection on failure.
    - REGTESTS: use "command -v" instead of "which"
    - REGTEST: increase timeouts on the seamless-reload test
    - BUG/MINOR: haproxy/threads: close a possible race in soft-stop detection
    - BUG/MINOR: peers: init bind_proc to 1 if it wasn't initialized
    - BUG/MINOR: peers: avoid an infinite loop with peers_fe is NULL
    - BUG/MINOR: peers: Use after free of "peers" section.
    - MINOR: listener: add so_name sample fetch
    - BUILD: ssl: only pass unsigned chars to isspace()
    - BUG/MINOR: stats: Fix color of draining servers on stats page
    - DOC: internals: Fix spelling errors in filters.txt
    - MINOR: http-rules: Add a flag on redirect rules to know the rule direction
    - BUG/MINOR: http_ana: make sure redirect flags don't have overlapping bits
    - MINOR: http-rules: Handle the rule direction when a redirect is evaluated
    - BUG/MINOR: filters: Use filter offset to decude the amount of forwarded data
    - BUG/MINOR: filters: Forward everything if no data filters are called
    - BUG/MINOR: http-ana: Reset request analysers on error when waiting for response
    - BUG/CRITICAL: hpack: never index a header into the headroom after wrapping