### PR TITLE
Set log-send-hostname in haproxy-config.template

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -44,6 +44,7 @@ global
   daemon
 {{- with (env "ROUTER_SYSLOG_ADDRESS") }}
   log {{.}} {{env "ROUTER_LOG_FACILITY" "local1"}} {{env "ROUTER_LOG_LEVEL" "warning"}}
+  log-send-hostname
 {{- end}}
   ca-base /etc/ssl
   crt-base /etc/ssl


### PR DESCRIPTION
Set the hostname field in the syslog header if syslog is configured.

* `images/router/haproxy/conf/haproxy-config.template` (`global`): Set `log-send-hostname`.