### PR TITLE
build: Add verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,8 @@ images/router/*/Dockerfile.rhel: images/router/base/Dockerfile.rhel
 
 check:
 	$(GO) test -race ./...
+
+.PHONY: verify
+verify:
+	hack/verify-gofmt.sh
+	hack/verify-deps.sh

--- a/hack/verify-deps.sh
+++ b/hack/verify-deps.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+function print_failure {
+  echo "There are unexpected changes to the vendor tree following 'go mod vendor' and 'go mod tidy'. Please"
+  echo "run these commands locally and double-check the Git repository for unexpected changes which may"
+  echo "need to be committed."
+  exit 1
+}
+
+if [ "${OPENSHIFT_CI:-false}" = true ]; then
+  go mod vendor
+  go mod tidy
+
+  test -z "$(git status --porcelain)" || print_failure
+  echo "verified Go modules"
+fi

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+go_files=$( find . -name '*.go' -not -path './vendor/*' -print )
+bad_files=$(gofmt -s -l ${go_files})
+if [[ -n "${bad_files}" ]]; then
+    (>&2 echo "!!! gofmt needs to be run on the listed files")
+	echo "${bad_files}"
+    (>&2 echo "Try running 'gofmt -s -d [path]' or autocorrect with 'hack/verify-gofmt.sh | xargs -n 1 gofmt -s -w'")
+    exit 1
+fi

--- a/pkg/router/template/certmanager_test.go
+++ b/pkg/router/template/certmanager_test.go
@@ -223,7 +223,7 @@ func TestCertManagerConfig(t *testing.T) {
 		config     *certificateManagerConfig
 		shouldPass bool
 	}{
-		"valid": {shouldPass: true, config: validCfg},
+		"valid":                          {shouldPass: true, config: validCfg},
 		"missing certificateKeyFunc":     {shouldPass: false, config: missingCertKeyCfg},
 		"missing caCertificateKeyFunc":   {shouldPass: false, config: missingCACertKeyCfg},
 		"missing destCertificateKeyFunc": {shouldPass: false, config: missingDestCertKeyCfg},


### PR DESCRIPTION
Add verify build target that checks for:
- gofmt
- go module correctness

Ran `make verify` and fixed the one formatting change.