### PR TITLE
Bug 1832352: Enable ALPN http/2 on reencrypt and passthrough routes only

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -455,8 +455,8 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
     {{- if ge $weight 0 }}{{/* weight=0 is reasonable to keep existing connections to backends with cookies as we can see the HTTP headers */}}
       {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
         {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
-  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{$weight}} alpn h2,http/1.1
-          {{- if (eq $cfg.TLSTermination "reencrypt") }} ssl
+  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{$weight}}
+          {{- if (eq $cfg.TLSTermination "reencrypt") }} alpn h2,http/1.1 ssl
             {{- if $cfg.VerifyServiceHostname }} verifyhost {{ $serviceUnit.Hostname }}
             {{- end }}
             {{- if gt (len (index $cfg.Certificates (printf "%s_pod" $cfg.Host)).Contents) 0 }} verify required ca-file {{ $workingDir }}/cacerts/{{$cfgIdx}}.pem
@@ -465,7 +465,6 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
               {{- else }} verify none
               {{- end }}
             {{- end }}
-
           {{- else if or (eq $cfg.TLSTermination "") (eq $cfg.TLSTermination "edge") }}
           {{- end }}{{/* end type specific options*/}}
 
@@ -552,7 +551,7 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
       {{- if ne $weight 0 }}{{/* drop connections where weight=0 as we can't use cookies, leaving only r-r and src-ip as dispatch methods and weight make no sense there */}}
         {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
           {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
-  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} weight {{$weight}} alpn h2,http/1.1
+  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} weight {{$weight}}
             {{- if and (not $endpoint.NoHealthCheck) (gt $cfg.ActiveEndpoints 1) }} check inter {{firstMatch $timeSpecPattern (index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval") (env "ROUTER_BACKEND_CHECK_INTERVAL") "5000ms"}}
             {{- end }}{{/* end else no health check */}}
             {{- with $podMaxConn := index $cfg.Annotations "haproxy.router.openshift.io/pod-concurrent-connections" }}

--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -175,7 +175,7 @@ func generateHAProxyCertConfigMap(td templateData) []string {
 		backendConfig := backendConfig(string(k), cfg, hascert)
 		if entry := haproxyutil.GenerateMapEntry(certConfigMap, backendConfig); entry != nil {
 			fqCertPath := path.Join(td.WorkingDir, "certs", entry.Key)
-			lines = append(lines, fmt.Sprintf("%s %s", fqCertPath, entry.Value))
+			lines = append(lines, strings.Join([]string{fqCertPath, entry.SSLBindConfig, entry.Value}, " "))
 		}
 	}
 

--- a/pkg/router/template/util/haproxy/map_entry.go
+++ b/pkg/router/template/util/haproxy/map_entry.go
@@ -101,9 +101,7 @@ func generateCertConfigMapEntry(cfg *BackendConfig) *HAProxyMapEntry {
 		}
 		if cfg.HasCertificate {
 			switch cfg.Termination {
-			case routev1.TLSTerminationEdge:
-				fallthrough
-			case routev1.TLSTerminationReencrypt:
+			case routev1.TLSTerminationEdge, routev1.TLSTerminationReencrypt:
 				e.SSLBindConfig = "[alpn h2,http/1.1]"
 			}
 		}

--- a/pkg/router/template/util/haproxy/map_entry.go
+++ b/pkg/router/template/util/haproxy/map_entry.go
@@ -95,10 +95,19 @@ func generateSNIPassthroughMapEntry(cfg *BackendConfig) *HAProxyMapEntry {
 // generateCertConfigMapEntry generates a cert config map entry.
 func generateCertConfigMapEntry(cfg *BackendConfig) *HAProxyMapEntry {
 	if len(cfg.Host) > 0 && (cfg.Termination == routev1.TLSTerminationEdge || cfg.Termination == routev1.TLSTerminationReencrypt) && cfg.HasCertificate {
-		return &HAProxyMapEntry{
+		e := &HAProxyMapEntry{
 			Key:   fmt.Sprintf("%s.pem", cfg.Name),
 			Value: templateutil.GenCertificateHostName(cfg.Host, cfg.IsWildcard),
 		}
+		if cfg.HasCertificate {
+			switch cfg.Termination {
+			case routev1.TLSTerminationEdge:
+				fallthrough
+			case routev1.TLSTerminationReencrypt:
+				e.SSLBindConfig = "[alpn h2,http/1.1]"
+			}
+		}
+		return e
 	}
 
 	return nil

--- a/pkg/router/template/util/haproxy/map_entry_test.go
+++ b/pkg/router/template/util/haproxy/map_entry_test.go
@@ -811,7 +811,11 @@ func TestGenerateCertConfigMapEntry(t *testing.T) {
 		}
 
 		certHost := templateutil.GenCertificateHostName(host, wildcard)
-		return &HAProxyMapEntry{Key: key, Value: certHost}
+		e := &HAProxyMapEntry{Key: key, Value: certHost}
+		if hascert {
+			e.SSLBindConfig = "[alpn h2,http/1.1]"
+		}
+		return e
 	}
 
 	for _, tt := range tests {

--- a/pkg/router/template/util/haproxy/types.go
+++ b/pkg/router/template/util/haproxy/types.go
@@ -17,6 +17,7 @@ type BackendConfig struct {
 
 // HAProxyMapEntry is a haproxy map entry.
 type HAProxyMapEntry struct {
-	Key   string
-	Value string
+	Key           string
+	Value         string
+	SSLBindConfig string
 }


### PR DESCRIPTION
This change supports http/2 negotiation for re-encrypt and pass-through routes only. For a re-encrypt route, a custom certificate must be specified to enable http/2 negotiation through the router to the server backend. 

The original diagnosis was made in BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1826990:

> In OpenShift 4.4, we enabled HTTP/2 on the frontend for the ingress controller; that is, we allow clients to ask the ingress controller to use HTTP/2, using ALPN.  Because the console and oauth-server are both behind the ingress controller's balancer and are using the same serving certificate (namely the ingress controller's default certificate), a browser might perform connection coalescing[1], meaning the browser re-uses the connection that it used to connect to the console route to connect to the oauth route.  Because we enabled HTTP/2 on the frontend, this means the browser may connect to the console route using HTTP/2 and then re-use the HTTP/2 connection to try to connect to the oauth route, which fails.

> In general, we cannot support HTTP/2 ALPN on routes that use the default certificate without risk of connection re-use/coalescing causing problems of this nature.  To unblock this issue, we can disable HTTP/2 on the frontend.  Later on, in order to support HTTP/2, we will need a solution that enables HTTP/2 only for routes that have custom certificates (which should prevent browsers from coalescing connections).

Asynchronous to this change we will also look at supporting edge terminated routes.
