### PR TITLE
Bug 1832539: Only a subset of router metrics should be preserved across restarts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 	github.com/openshift/library-go v0.0.0-20200324092245-db2a8546af81
 
 	github.com/prometheus/client_golang v1.1.0
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.6.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,7 @@ github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
+github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=

--- a/pkg/router/metrics/haproxy/haproxy.go
+++ b/pkg/router/metrics/haproxy/haproxy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -103,7 +104,7 @@ type metricID struct {
 }
 
 // counterValuesByMetric is used to track values across reloads
-type counterValuesByMetric map[metricID]map[int]int64
+type counterValuesByMetric map[metricID][]int64
 
 // defaultSelectedMetrics is the list of metrics included by default. These metrics are a subset
 // of the metrics exposed by haproxy_exporter by default for performance reasons.
@@ -137,12 +138,19 @@ type Exporter struct {
 	serverThresholdCurrent, serverThresholdLimit   prometheus.Gauge
 	frontendMetrics, backendMetrics, serverMetrics map[int]*prometheus.GaugeVec
 
-	// baseCounterValues is added to the value specific haproxy frontend, backend, or server counter
+	// counterValues is added to the value specific haproxy frontend, backend, or server counter
 	// metrics. This allows metrics to be tracked across restarts. This map is updated whenever CollectNow
 	// is invoked.
-	baseCounterValues counterValuesByMetric
-	// the metrics to append to baseCounterValues
-	counterMetrics map[int]struct{}
+	counterValues counterValuesByMetric
+	// counterIndices records the index in the packed array of metrics (under counterValuesByMetric).
+	// A zero indicates the field index is not a counter, a non-zero value is the index in the packed
+	// array. The first position is always zero
+	// Example: Given counter fields 2, 4, and 5, the array should be:
+	//          []byte{0, 0, 0, 1, 0, 2, 3}
+	//          indicating that position 0 in the packed array is where the second field is stored.
+	counterIndices []byte
+	// counterIndexSize the number of counters for each remembered counterValues
+	counterIndexSize int
 }
 
 // NewExporter returns an initialized Exporter. baseScrapeInterval is how often to scrape per 1000 entries
@@ -163,9 +171,16 @@ func NewExporter(opts PrometheusOptions) (*Exporter, error) {
 		return nil, fmt.Errorf("unsupported scheme: %q", u.Scheme)
 	}
 
-	counterMetrics := make(map[int]struct{})
+	// use a compact table representation of previous counter values
+	if len(defaultCounterMetrics) >= math.MaxUint8 {
+		return nil, fmt.Errorf("too many default counter metrics")
+	}
+	sort.Ints(defaultCounterMetrics)
+	var counterIndexSize int
+	counterIndices := make([]byte, defaultCounterMetrics[len(defaultCounterMetrics)-1]+1)
 	for _, m := range defaultCounterMetrics {
-		counterMetrics[m] = struct{}{}
+		counterIndexSize++
+		counterIndices[m] = byte(counterIndexSize)
 	}
 
 	return &Exporter{
@@ -278,7 +293,8 @@ func NewExporter(opts PrometheusOptions) (*Exporter, error) {
 			44: newServerMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "other"}),
 			60: newServerMetric("http_average_response_latency_milliseconds", "Average response latency of the last 1024 requests in milliseconds.", nil),
 		}),
-		counterMetrics: counterMetrics,
+		counterIndices:   counterIndices,
+		counterIndexSize: counterIndexSize + 1,
 	}, nil
 }
 
@@ -384,9 +400,9 @@ func fetchUnix(u *url.URL, timeout time.Duration) func() (io.ReadCloser, error) 
 func (e *Exporter) scrape(record bool) {
 	e.totalScrapes.Inc()
 
-	var targetValues counterValuesByMetric
+	var updatedValues counterValuesByMetric
 	if record {
-		targetValues = make(counterValuesByMetric)
+		updatedValues = make(counterValuesByMetric)
 	}
 
 	body, err := e.fetch()
@@ -428,6 +444,10 @@ loop:
 			return
 		}
 
+		if rows == 0 && len(e.counterIndices) < len(row) {
+			e.counterIndices = append(e.counterIndices, make([]byte, len(row)-len(e.counterIndices))...)
+		}
+
 		// If we exceed the server threshold, ignore the rest of the servers because we will be
 		// displaying only backends and frontends.
 		if row[32] == serverType {
@@ -438,12 +458,12 @@ loop:
 		}
 
 		rows++
-		e.parseRow(row, targetValues)
+		e.parseRow(row, updatedValues)
 	}
 
 	// swap the counter values
 	if record {
-		e.baseCounterValues = targetValues
+		e.counterValues = updatedValues
 	}
 
 	e.serverLimited = servers > e.opts.ServerThreshold
@@ -485,32 +505,32 @@ func (e *Exporter) collectMetrics(metrics chan<- prometheus.Metric) {
 
 // parseRow identifies which metrics to capture for a given row based on type and the value of pxname and svname. If the
 // proxy and server names match our conventions they are labelled to the given route, service, or pod - if they don't match
-// then a generic label set is applied. If targetValues is non-nil then the map will be populated with the updated counter state
+// then a generic label set is applied. If updatedValues is non-nil then the map will be populated with the updated counter state
 // for each metric.
-func (e *Exporter) parseRow(csvRow []string, targetValues counterValuesByMetric) {
+func (e *Exporter) parseRow(csvRow []string, updatedValues counterValuesByMetric) {
 	pxname, svname, typ := csvRow[0], csvRow[1], csvRow[32]
 
 	switch typ {
 	case frontendType:
-		e.exportAndRecordRow(e.frontendMetrics, metricID{proxyType: serverType, proxyName: pxname}, targetValues, csvRow, pxname)
+		e.exportAndRecordRow(e.frontendMetrics, metricID{proxyType: serverType, proxyName: pxname}, updatedValues, csvRow, pxname)
 	case backendType:
 		if mode, value, ok := knownBackendSegment(pxname); ok {
 			if namespace, name, ok := parseNameSegment(value); ok {
-				e.exportAndRecordRow(e.backendMetrics, metricID{proxyType: serverType, proxyName: pxname}, targetValues, csvRow, mode, namespace, name)
+				e.exportAndRecordRow(e.backendMetrics, metricID{proxyType: serverType, proxyName: pxname}, updatedValues, csvRow, mode, namespace, name)
 				return
 			}
 		}
-		e.exportAndRecordRow(e.backendMetrics, metricID{proxyType: serverType, proxyName: pxname}, targetValues, csvRow, "other/"+pxname, "", "")
+		e.exportAndRecordRow(e.backendMetrics, metricID{proxyType: serverType, proxyName: pxname}, updatedValues, csvRow, "other/"+pxname, "", "")
 	case serverType:
 		pod, service, server, _ := knownServerSegment(svname)
 
 		if _, value, ok := knownBackendSegment(pxname); ok {
 			if namespace, name, ok := parseNameSegment(value); ok {
-				e.exportAndRecordRow(e.serverMetrics, metricID{serverType, pxname, svname}, targetValues, csvRow, server, namespace, name, pod, service)
+				e.exportAndRecordRow(e.serverMetrics, metricID{serverType, pxname, svname}, updatedValues, csvRow, server, namespace, name, pod, service)
 				return
 			}
 		}
-		e.exportAndRecordRow(e.serverMetrics, metricID{proxyType: serverType, serverName: svname}, targetValues, csvRow, server, "", "", pod, service)
+		e.exportAndRecordRow(e.serverMetrics, metricID{proxyType: serverType, serverName: svname}, updatedValues, csvRow, server, "", "", pod, service)
 	}
 }
 
@@ -574,31 +594,35 @@ func parseStatusField(value string) int64 {
 	return 0
 }
 
-// exportAndRecordRow parses the provided csvRow labels for the specified metrics and then updates their value given labels. If targetValues is
+// exportAndRecordRow parses the provided csvRow labels for the specified metrics and then updates their value given labels. If updatedValues is
 // non-nil the current value of the metric will be written back to rowID. This allows baseline values to be recorded and used across restarts of
 // HAProxy.
-func (e *Exporter) exportAndRecordRow(metrics metrics, rowID metricID, targetValues counterValuesByMetric, csvRow []string, labels ...string) {
-	updateValues := targetValues != nil
-	baseCounterValues := e.baseCounterValues[rowID]
-	if updateValues && baseCounterValues == nil {
-		baseCounterValues = make(map[int]int64)
+func (e *Exporter) exportAndRecordRow(metrics metrics, rowID metricID, updatedValues counterValuesByMetric, csvRow []string, labels ...string) {
+	var updatedBaseValues []int64
+	baseValues := e.counterValues[rowID]
+	if updatedValues != nil {
+		if baseValues == nil {
+			baseValues = make([]int64, e.counterIndexSize)
+		}
+		updatedValues[rowID] = baseValues
+		updatedBaseValues = baseValues
 	}
 
-	exportCSVFields(e.csvParseFailures, metrics, baseCounterValues, updateValues, csvRow, labels)
-
-	if updateValues {
-		targetValues[rowID] = baseCounterValues
-	}
+	exportCSVFields(e.csvParseFailures, metrics, baseValues, updatedBaseValues, e.counterIndices, csvRow, labels)
 }
 
 // exportCSVFields iterates over the returned CSV values and sets the appropriate metric in the map. Empty values or parse errors result in
-// no metric being scraped.
-func exportCSVFields(csvParseFailures prometheus.Counter, metrics metrics, baselineValues map[int]int64, updateBaseline bool, csvRow []string, labels []string) {
+// no metric being scraped. If updatedBaseValues is not nil then it is updated with the latest value of the metric. If baseValues is nil
+// or the field is not a counter (according to counterIndices) then no value is incremented
+func exportCSVFields(csvParseFailures prometheus.Counter, metrics metrics, baseValues, updatedBaseValues []int64, counterIndices []byte, csvRow []string, labels []string) {
 	for fieldIdx, metric := range metrics {
 		valueStr := csvRow[fieldIdx]
 		if valueStr == "" {
 			continue
 		}
+
+		// the stored position of the previous value
+		storedIdx := counterIndices[byte(fieldIdx)]
 
 		var value int64
 		switch fieldIdx {
@@ -612,10 +636,12 @@ func exportCSVFields(csvParseFailures prometheus.Counter, metrics metrics, basel
 				csvParseFailures.Inc()
 				continue
 			}
-			value += baselineValues[fieldIdx]
+			if baseValues != nil && storedIdx > 0 {
+				value += baseValues[storedIdx]
+			}
 		}
-		if updateBaseline {
-			baselineValues[fieldIdx] = value
+		if updatedBaseValues != nil && storedIdx > 0 {
+			updatedBaseValues[storedIdx] = value
 		}
 
 		metric.WithLabelValues(labels...).Set(float64(value))
@@ -663,25 +689,7 @@ type PrometheusOptions struct {
 // provided HAProxy stats port. It will start goroutines. Use the default
 // prometheus handler to access these metrics.
 func NewPrometheusCollector(opts PrometheusOptions) (*Exporter, error) {
-	if len(opts.ScrapeURI) == 0 {
-		opts.ScrapeURI = "unix:///var/lib/haproxy/run/haproxy.sock"
-	}
-	if len(opts.PidFile) == 0 {
-		opts.PidFile = "/var/lib/haproxy/run/haproxy.pid"
-	}
-	if opts.Timeout == 0 {
-		opts.Timeout = 5 * time.Second
-	}
-	if opts.BaseScrapeInterval == 0 {
-		opts.BaseScrapeInterval = 5 * time.Second
-	}
-	if len(opts.ExportedMetrics) == 0 {
-		opts.ExportedMetrics = defaultSelectedMetrics
-	}
-	if opts.ServerThreshold == 0 {
-		opts.ServerThreshold = 500
-	}
-
+	opts = defaultOptions(opts)
 	exporter, err := NewExporter(opts)
 	if err != nil {
 		return nil, err
@@ -713,4 +721,26 @@ func NewPrometheusCollector(opts PrometheusOptions) (*Exporter, error) {
 	}
 
 	return exporter, nil
+}
+
+func defaultOptions(opts PrometheusOptions) PrometheusOptions {
+	if len(opts.ScrapeURI) == 0 {
+		opts.ScrapeURI = "unix:///var/lib/haproxy/run/haproxy.sock"
+	}
+	if len(opts.PidFile) == 0 {
+		opts.PidFile = "/var/lib/haproxy/run/haproxy.pid"
+	}
+	if opts.Timeout == 0 {
+		opts.Timeout = 5 * time.Second
+	}
+	if opts.BaseScrapeInterval == 0 {
+		opts.BaseScrapeInterval = 5 * time.Second
+	}
+	if len(opts.ExportedMetrics) == 0 {
+		opts.ExportedMetrics = defaultSelectedMetrics
+	}
+	if opts.ServerThreshold == 0 {
+		opts.ServerThreshold = 500
+	}
+	return opts
 }

--- a/pkg/router/metrics/haproxy/haproxy_test.go
+++ b/pkg/router/metrics/haproxy/haproxy_test.go
@@ -1,0 +1,308 @@
+// Package haproxy is inspired by https://github.com/prometheus/haproxy_exporter
+package haproxy
+
+import (
+	"bytes"
+	"flag"
+	"io"
+	"io/ioutil"
+	_ "net/http/pprof"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	client_model "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"k8s.io/klog"
+)
+
+func TestExporter_scrape(t *testing.T) {
+	klog.InitFlags(flag.CommandLine)
+	klog.SetOutput(os.Stderr)
+	scrapes := []string{
+		`public,FRONTEND,,,0,2,20000,162,18770,30715,0,0,0,,,,,OPEN,,,,,,,,,1,2,0,,,,0,0,0,1,,,,0,160,1,0,1,0,,0,1,162,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,1,162,160,0,0,0,,,0,0,,,,,,,
+public_ssl,FRONTEND,,,1,32,20000,200,928408,2060591,0,0,0,,,,,OPEN,,,,,,,,,1,3,0,,,,0,0,0,50,,,,,,,,,,,0,0,0,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,tcp,,0,50,200,,0,0,0,,,,,,,,,,,
+be_sni,fe_sni,0,0,1,32,,184,900961,1776021,,0,,0,0,0,0,no check,1,1,0,,,802,,,1,4,1,,184,,2,0,,51,,,,,,,,,,,,,,3,0,,,,,68,,,2,0,0,734,,,,,,,,,,,,127.0.0.1:10444,,tcp,,,,,,,,0,184,0,,,0,,29,6,0,46392,
+be_sni,BACKEND,0,0,1,32,2000,184,900961,1776021,0,0,,0,0,0,0,UP,1,1,0,,0,802,0,,1,4,0,,184,,1,0,,51,,,,,,,,,,,,,,3,0,0,0,0,0,68,,,2,0,0,734,,,,,,,,,,,,,,tcp,roundrobin,,,,,,,0,184,0,,,,,29,6,0,46392,
+fe_sni,FRONTEND,,,1,32,20000,184,1072234,2875407,0,0,37,,,,,OPEN,,,,,,,,,1,5,0,,,,0,0,0,53,,,,5,426,242,42,0,0,,0,135,715,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,51,184,0,0,0,0,,,0,0,,,,,,,
+be_no_sni,fe_no_sni,0,0,0,0,,0,0,0,,0,,0,0,0,0,no check,1,1,0,,,802,,,1,6,1,,0,,2,0,,0,,,,,,,,,,,,,,0,0,,,,,-1,,,0,0,0,0,,,,,,,,,,,,127.0.0.1:10443,,tcp,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_no_sni,BACKEND,0,0,0,0,2000,0,0,0,0,0,,0,0,0,0,UP,1,1,0,,0,802,0,,1,6,0,,0,,1,0,,0,,,,,,,,,,,,,,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,,tcp,roundrobin,,,,,,,0,0,0,,,,,0,0,0,0,
+fe_no_sni,FRONTEND,,,0,0,20000,0,0,0,0,0,0,,,,,OPEN,,,,,,,,,1,7,0,,,,0,0,0,0,,,,0,0,0,0,0,0,,0,0,0,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,0,0,0,0,0,0,,,0,0,,,,,,,
+openshift_default,BACKEND,0,0,0,1,6000,1,38,3288,0,0,,1,0,0,0,UP,0,0,0,,0,802,,,1,8,0,,0,,1,0,,1,,,,0,0,0,0,1,0,,,,1,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,,http,roundrobin,,,,,,,0,0,0,0,0,,,0,0,0,0,
+be_tcp:openshift-authentication:oauth-openshift,pod:oauth-openshift-5844b98b58-nm72j:oauth-openshift:10.129.0.42:6443,0,0,0,1,,3,20092,221613,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,16,1,,3,,2,0,,1,L4OK,,0,,,,,,,,,,,0,0,,,,,67,,,1,1,0,130,,,,Layer4 check passed,,2,3,4,,,,10.129.0.42:6443,,tcp,,,,,,,,0,3,0,,,0,,2,1,0,63237,
+be_tcp:openshift-authentication:oauth-openshift,pod:oauth-openshift-5844b98b58-z5rhm:oauth-openshift:10.130.64.11:6443,0,0,0,3,,13,7355,62957,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,16,2,,13,,2,0,,1,L4OK,,1,,,,,,,,,,,0,0,,,,,70,,,0,0,0,1493,,,,Layer4 check passed,,2,3,4,,,,10.130.64.11:6443,,tcp,,,,,,,,0,13,0,,,0,,0,1,0,59559,
+be_tcp:openshift-authentication:oauth-openshift,BACKEND,0,0,0,4,1,16,27447,284570,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,16,0,,16,,1,0,,1,,,,,,,,,,,,,,0,0,0,0,0,0,67,,,1,1,0,1615,,,,,,,,,,,,,,tcp,source,,,,,,,0,16,0,,,,,2,1,0,63237,
+be_secure:openshift-console:console,pod:console-6db7cbb464-gr787:console:10.129.0.43:8443,0,0,0,8,,236,505655,2344127,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,17,1,,0,,2,0,,57,L6OK,,1,5,226,1,4,0,0,,,,,0,0,,,,,11,,,0,0,2,1350,,,,Layer6 check passed,,2,3,4,,,,10.129.0.43:8443,7e4a3da6d0368ecb934a4910245f83b4,http,,,,,,,,0,15,221,,,0,,0,4,26,16533,
+be_secure:openshift-console:console,pod:console-6db7cbb464-8s44k:console:10.130.64.12:8443,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,17,2,,0,,2,0,,0,L6OK,,1,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer6 check passed,,2,3,4,,,,10.130.64.12:8443,5b10765dbf34d04f53986cf7ac1bf19c,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_secure:openshift-console:console,BACKEND,0,0,0,8,1,236,505655,2344127,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,17,0,,0,,1,0,,57,,,,5,226,1,4,0,0,,,,236,0,0,0,0,0,0,11,,,0,0,2,1350,,,,,,,,,,,,,1e2670d92730b515ce3a1bb65da45062,http,leastconn,,,,,,,0,15,221,0,0,,,0,4,26,16533,
+be_edge_http:openshift-console:downloads,pod:downloads-564948bf9c-vn6lh:downloads:10.128.0.30:8080,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,18,1,,0,,2,0,,0,L4OK,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer4 check passed,,2,3,4,,,,10.128.0.30:8080,ce739475136fa468d51cfcf5aad91b68,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_edge_http:openshift-console:downloads,pod:downloads-564948bf9c-g7nsm:downloads:10.129.5.61:8080,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,18,2,,0,,2,0,,0,L4OK,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer4 check passed,,2,3,4,,,,10.129.5.61:8080,450630300ddc04605decdd966ea57de6,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_edge_http:openshift-console:downloads,BACKEND,0,0,0,0,1,0,0,0,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,18,0,,0,,1,0,,0,,,,0,0,0,0,0,0,,,,0,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,a663438294fbd72a8e16964e97c8ecde,http,leastconn,,,,,,,0,0,0,0,0,,,0,0,0,0,
+`,
+		// increase the count of connections on the second console pod by 5
+		`public,FRONTEND,,,0,2,20000,162,18770,30715,0,0,0,,,,,OPEN,,,,,,,,,1,2,0,,,,0,0,0,1,,,,0,160,1,0,1,0,,0,1,162,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,1,162,160,0,0,0,,,0,0,,,,,,,
+public_ssl,FRONTEND,,,1,32,20000,200,928408,2060591,0,0,0,,,,,OPEN,,,,,,,,,1,3,0,,,,0,0,0,50,,,,,,,,,,,0,0,0,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,tcp,,0,50,200,,0,0,0,,,,,,,,,,,
+be_sni,fe_sni,0,0,1,32,,184,900961,1776021,,0,,0,0,0,0,no check,1,1,0,,,802,,,1,4,1,,184,,2,0,,51,,,,,,,,,,,,,,3,0,,,,,68,,,2,0,0,734,,,,,,,,,,,,127.0.0.1:10444,,tcp,,,,,,,,0,184,0,,,0,,29,6,0,46392,
+be_sni,BACKEND,0,0,1,32,2000,184,900961,1776021,0,0,,0,0,0,0,UP,1,1,0,,0,802,0,,1,4,0,,184,,1,0,,51,,,,,,,,,,,,,,3,0,0,0,0,0,68,,,2,0,0,734,,,,,,,,,,,,,,tcp,roundrobin,,,,,,,0,184,0,,,,,29,6,0,46392,
+fe_sni,FRONTEND,,,1,32,20000,184,1072234,2875407,0,0,37,,,,,OPEN,,,,,,,,,1,5,0,,,,0,0,0,53,,,,5,426,242,42,0,0,,0,135,715,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,51,184,0,0,0,0,,,0,0,,,,,,,
+be_no_sni,fe_no_sni,0,0,0,0,,0,0,0,,0,,0,0,0,0,no check,1,1,0,,,802,,,1,6,1,,0,,2,0,,0,,,,,,,,,,,,,,0,0,,,,,-1,,,0,0,0,0,,,,,,,,,,,,127.0.0.1:10443,,tcp,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_no_sni,BACKEND,0,0,0,0,2000,0,0,0,0,0,,0,0,0,0,UP,1,1,0,,0,802,0,,1,6,0,,0,,1,0,,0,,,,,,,,,,,,,,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,,tcp,roundrobin,,,,,,,0,0,0,,,,,0,0,0,0,
+fe_no_sni,FRONTEND,,,0,0,20000,0,0,0,0,0,0,,,,,OPEN,,,,,,,,,1,7,0,,,,0,0,0,0,,,,0,0,0,0,0,0,,0,0,0,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,0,0,0,0,0,0,,,0,0,,,,,,,
+openshift_default,BACKEND,0,0,0,1,6000,1,38,3288,0,0,,1,0,0,0,UP,0,0,0,,0,802,,,1,8,0,,0,,1,0,,1,,,,0,0,0,0,1,0,,,,1,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,,http,roundrobin,,,,,,,0,0,0,0,0,,,0,0,0,0,
+be_tcp:openshift-authentication:oauth-openshift,pod:oauth-openshift-5844b98b58-nm72j:oauth-openshift:10.129.0.42:6443,0,0,0,1,,3,20092,221613,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,16,1,,3,,2,0,,1,L4OK,,0,,,,,,,,,,,0,0,,,,,67,,,1,1,0,130,,,,Layer4 check passed,,2,3,4,,,,10.129.0.42:6443,,tcp,,,,,,,,0,3,0,,,0,,2,1,0,63237,
+be_tcp:openshift-authentication:oauth-openshift,pod:oauth-openshift-5844b98b58-z5rhm:oauth-openshift:10.130.64.11:6443,0,0,0,3,,13,7355,62957,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,16,2,,13,,2,0,,1,L4OK,,1,,,,,,,,,,,0,0,,,,,70,,,0,0,0,1493,,,,Layer4 check passed,,2,3,4,,,,10.130.64.11:6443,,tcp,,,,,,,,0,13,0,,,0,,0,1,0,59559,
+be_tcp:openshift-authentication:oauth-openshift,BACKEND,0,0,0,4,1,16,27447,284570,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,16,0,,16,,1,0,,1,,,,,,,,,,,,,,0,0,0,0,0,0,67,,,1,1,0,1615,,,,,,,,,,,,,,tcp,source,,,,,,,0,16,0,,,,,2,1,0,63237,
+be_secure:openshift-console:console,pod:console-6db7cbb464-gr787:console:10.129.0.43:8443,0,0,0,8,,241,505655,2344127,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,17,1,,0,,2,0,,57,L6OK,,1,5,226,1,4,0,0,,,,,0,0,,,,,11,,,0,0,2,1350,,,,Layer6 check passed,,2,3,4,,,,10.129.0.43:8443,7e4a3da6d0368ecb934a4910245f83b4,http,,,,,,,,0,15,221,,,0,,0,4,26,16533,
+be_secure:openshift-console:console,pod:console-6db7cbb464-8s44k:console:10.130.64.12:8443,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,17,2,,0,,2,0,,0,L6OK,,1,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer6 check passed,,2,3,4,,,,10.130.64.12:8443,5b10765dbf34d04f53986cf7ac1bf19c,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_secure:openshift-console:console,BACKEND,0,0,0,8,1,236,505655,2344127,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,17,0,,0,,1,0,,57,,,,5,226,1,4,0,0,,,,236,0,0,0,0,0,0,11,,,0,0,2,1350,,,,,,,,,,,,,1e2670d92730b515ce3a1bb65da45062,http,leastconn,,,,,,,0,15,221,0,0,,,0,4,26,16533,
+be_edge_http:openshift-console:downloads,pod:downloads-564948bf9c-vn6lh:downloads:10.128.0.30:8080,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,18,1,,0,,2,0,,0,L4OK,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer4 check passed,,2,3,4,,,,10.128.0.30:8080,ce739475136fa468d51cfcf5aad91b68,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_edge_http:openshift-console:downloads,pod:downloads-564948bf9c-g7nsm:downloads:10.129.5.61:8080,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,18,2,,0,,2,0,,0,L4OK,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer4 check passed,,2,3,4,,,,10.129.5.61:8080,450630300ddc04605decdd966ea57de6,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_edge_http:openshift-console:downloads,BACKEND,0,0,0,0,1,0,0,0,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,18,0,,0,,1,0,,0,,,,0,0,0,0,0,0,,,,0,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,a663438294fbd72a8e16964e97c8ecde,http,leastconn,,,,,,,0,0,0,0,0,,,0,0,0,0,
+`,
+		// simulate a reset metrics due to the router reloading:
+		// * set first console pod connections to 3
+		// * set fe_sni connections to 0
+		`public,FRONTEND,,,0,2,20000,162,18770,30715,0,0,0,,,,,OPEN,,,,,,,,,1,2,0,,,,0,0,0,1,,,,0,160,1,0,1,0,,0,1,162,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,1,162,160,0,0,0,,,0,0,,,,,,,
+public_ssl,FRONTEND,,,1,32,20000,200,928408,2060591,0,0,0,,,,,OPEN,,,,,,,,,1,3,0,,,,0,0,0,50,,,,,,,,,,,0,0,0,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,tcp,,0,50,200,,0,0,0,,,,,,,,,,,
+be_sni,fe_sni,0,0,1,32,,0,900961,1776021,,0,,0,0,0,0,no check,1,1,0,,,802,,,1,4,1,,184,,2,0,,51,,,,,,,,,,,,,,3,0,,,,,68,,,2,0,0,734,,,,,,,,,,,,127.0.0.1:10444,,tcp,,,,,,,,0,184,0,,,0,,29,6,0,46392,
+be_sni,BACKEND,0,0,1,32,2000,0,900961,1776021,0,0,,0,0,0,0,UP,1,1,0,,0,802,0,,1,4,0,,184,,1,0,,51,,,,,,,,,,,,,,3,0,0,0,0,0,68,,,2,0,0,734,,,,,,,,,,,,,,tcp,roundrobin,,,,,,,0,184,0,,,,,29,6,0,46392,
+fe_sni,FRONTEND,,,1,32,20000,0,1072234,2875407,0,0,37,,,,,OPEN,,,,,,,,,1,5,0,,,,0,0,0,53,,,,5,426,242,42,0,0,,0,135,715,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,51,184,0,0,0,0,,,0,0,,,,,,,
+be_no_sni,fe_no_sni,0,0,0,0,,0,0,0,,0,,0,0,0,0,no check,1,1,0,,,802,,,1,6,1,,0,,2,0,,0,,,,,,,,,,,,,,0,0,,,,,-1,,,0,0,0,0,,,,,,,,,,,,127.0.0.1:10443,,tcp,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_no_sni,BACKEND,0,0,0,0,2000,0,0,0,0,0,,0,0,0,0,UP,1,1,0,,0,802,0,,1,6,0,,0,,1,0,,0,,,,,,,,,,,,,,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,,tcp,roundrobin,,,,,,,0,0,0,,,,,0,0,0,0,
+fe_no_sni,FRONTEND,,,0,0,20000,0,0,0,0,0,0,,,,,OPEN,,,,,,,,,1,7,0,,,,0,0,0,0,,,,0,0,0,0,0,0,,0,0,0,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,0,0,0,0,0,0,,,0,0,,,,,,,
+openshift_default,BACKEND,0,0,0,1,6000,1,38,3288,0,0,,1,0,0,0,UP,0,0,0,,0,802,,,1,8,0,,0,,1,0,,1,,,,0,0,0,0,1,0,,,,1,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,,http,roundrobin,,,,,,,0,0,0,0,0,,,0,0,0,0,
+be_tcp:openshift-authentication:oauth-openshift,pod:oauth-openshift-5844b98b58-nm72j:oauth-openshift:10.129.0.42:6443,0,0,0,1,,3,20092,221613,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,16,1,,3,,2,0,,1,L4OK,,0,,,,,,,,,,,0,0,,,,,67,,,1,1,0,130,,,,Layer4 check passed,,2,3,4,,,,10.129.0.42:6443,,tcp,,,,,,,,0,3,0,,,0,,2,1,0,63237,
+be_tcp:openshift-authentication:oauth-openshift,pod:oauth-openshift-5844b98b58-z5rhm:oauth-openshift:10.130.64.11:6443,0,0,0,3,,13,7355,62957,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,16,2,,13,,2,0,,1,L4OK,,1,,,,,,,,,,,0,0,,,,,70,,,0,0,0,1493,,,,Layer4 check passed,,2,3,4,,,,10.130.64.11:6443,,tcp,,,,,,,,0,13,0,,,0,,0,1,0,59559,
+be_tcp:openshift-authentication:oauth-openshift,BACKEND,0,0,0,4,1,16,27447,284570,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,16,0,,16,,1,0,,1,,,,,,,,,,,,,,0,0,0,0,0,0,67,,,1,1,0,1615,,,,,,,,,,,,,,tcp,source,,,,,,,0,16,0,,,,,2,1,0,63237,
+be_secure:openshift-console:console,pod:console-6db7cbb464-gr787:console:10.129.0.43:8443,0,0,0,8,,3,505655,2344127,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,17,1,,0,,2,0,,57,L6OK,,1,5,226,1,4,0,0,,,,,0,0,,,,,11,,,0,0,2,1350,,,,Layer6 check passed,,2,3,4,,,,10.129.0.43:8443,7e4a3da6d0368ecb934a4910245f83b4,http,,,,,,,,0,15,221,,,0,,0,4,26,16533,
+be_secure:openshift-console:console,pod:console-6db7cbb464-8s44k:console:10.130.64.12:8443,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,17,2,,0,,2,0,,0,L6OK,,1,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer6 check passed,,2,3,4,,,,10.130.64.12:8443,5b10765dbf34d04f53986cf7ac1bf19c,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_secure:openshift-console:console,BACKEND,0,0,0,8,1,236,505655,2344127,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,17,0,,0,,1,0,,57,,,,5,226,1,4,0,0,,,,236,0,0,0,0,0,0,11,,,0,0,2,1350,,,,,,,,,,,,,1e2670d92730b515ce3a1bb65da45062,http,leastconn,,,,,,,0,15,221,0,0,,,0,4,26,16533,
+be_edge_http:openshift-console:downloads,pod:downloads-564948bf9c-vn6lh:downloads:10.128.0.30:8080,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,18,1,,0,,2,0,,0,L4OK,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer4 check passed,,2,3,4,,,,10.128.0.30:8080,ce739475136fa468d51cfcf5aad91b68,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_edge_http:openshift-console:downloads,pod:downloads-564948bf9c-g7nsm:downloads:10.129.5.61:8080,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,18,2,,0,,2,0,,0,L4OK,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer4 check passed,,2,3,4,,,,10.129.5.61:8080,450630300ddc04605decdd966ea57de6,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_edge_http:openshift-console:downloads,BACKEND,0,0,0,0,1,0,0,0,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,18,0,,0,,1,0,,0,,,,0,0,0,0,0,0,,,,0,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,a663438294fbd72a8e16964e97c8ecde,http,leastconn,,,,,,,0,0,0,0,0,,,0,0,0,0,
+`,
+		// increment the first console pod to 4 connections
+		`public,FRONTEND,,,0,2,20000,162,18770,30715,0,0,0,,,,,OPEN,,,,,,,,,1,2,0,,,,0,0,0,1,,,,0,160,1,0,1,0,,0,1,162,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,1,162,160,0,0,0,,,0,0,,,,,,,
+public_ssl,FRONTEND,,,1,32,20000,200,928408,2060591,0,0,0,,,,,OPEN,,,,,,,,,1,3,0,,,,0,0,0,50,,,,,,,,,,,0,0,0,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,tcp,,0,50,200,,0,0,0,,,,,,,,,,,
+be_sni,fe_sni,0,0,1,32,,0,900961,1776021,,0,,0,0,0,0,no check,1,1,0,,,802,,,1,4,1,,184,,2,0,,51,,,,,,,,,,,,,,3,0,,,,,68,,,2,0,0,734,,,,,,,,,,,,127.0.0.1:10444,,tcp,,,,,,,,0,184,0,,,0,,29,6,0,46392,
+be_sni,BACKEND,0,0,1,32,2000,0,900961,1776021,0,0,,0,0,0,0,UP,1,1,0,,0,802,0,,1,4,0,,184,,1,0,,51,,,,,,,,,,,,,,3,0,0,0,0,0,68,,,2,0,0,734,,,,,,,,,,,,,,tcp,roundrobin,,,,,,,0,184,0,,,,,29,6,0,46392,
+fe_sni,FRONTEND,,,1,32,20000,0,1072234,2875407,0,0,37,,,,,OPEN,,,,,,,,,1,5,0,,,,0,0,0,53,,,,5,426,242,42,0,0,,0,135,715,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,51,184,0,0,0,0,,,0,0,,,,,,,
+be_no_sni,fe_no_sni,0,0,0,0,,0,0,0,,0,,0,0,0,0,no check,1,1,0,,,802,,,1,6,1,,0,,2,0,,0,,,,,,,,,,,,,,0,0,,,,,-1,,,0,0,0,0,,,,,,,,,,,,127.0.0.1:10443,,tcp,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_no_sni,BACKEND,0,0,0,0,2000,0,0,0,0,0,,0,0,0,0,UP,1,1,0,,0,802,0,,1,6,0,,0,,1,0,,0,,,,,,,,,,,,,,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,,tcp,roundrobin,,,,,,,0,0,0,,,,,0,0,0,0,
+fe_no_sni,FRONTEND,,,0,0,20000,0,0,0,0,0,0,,,,,OPEN,,,,,,,,,1,7,0,,,,0,0,0,0,,,,0,0,0,0,0,0,,0,0,0,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,0,0,0,0,0,0,,,0,0,,,,,,,
+openshift_default,BACKEND,0,0,0,1,6000,1,38,3288,0,0,,1,0,0,0,UP,0,0,0,,0,802,,,1,8,0,,0,,1,0,,1,,,,0,0,0,0,1,0,,,,1,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,,http,roundrobin,,,,,,,0,0,0,0,0,,,0,0,0,0,
+be_tcp:openshift-authentication:oauth-openshift,pod:oauth-openshift-5844b98b58-nm72j:oauth-openshift:10.129.0.42:6443,0,0,0,1,,3,20092,221613,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,16,1,,3,,2,0,,1,L4OK,,0,,,,,,,,,,,0,0,,,,,67,,,1,1,0,130,,,,Layer4 check passed,,2,3,4,,,,10.129.0.42:6443,,tcp,,,,,,,,0,3,0,,,0,,2,1,0,63237,
+be_tcp:openshift-authentication:oauth-openshift,pod:oauth-openshift-5844b98b58-z5rhm:oauth-openshift:10.130.64.11:6443,0,0,0,3,,13,7355,62957,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,16,2,,13,,2,0,,1,L4OK,,1,,,,,,,,,,,0,0,,,,,70,,,0,0,0,1493,,,,Layer4 check passed,,2,3,4,,,,10.130.64.11:6443,,tcp,,,,,,,,0,13,0,,,0,,0,1,0,59559,
+be_tcp:openshift-authentication:oauth-openshift,BACKEND,0,0,0,4,1,16,27447,284570,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,16,0,,16,,1,0,,1,,,,,,,,,,,,,,0,0,0,0,0,0,67,,,1,1,0,1615,,,,,,,,,,,,,,tcp,source,,,,,,,0,16,0,,,,,2,1,0,63237,
+be_secure:openshift-console:console,pod:console-6db7cbb464-gr787:console:10.129.0.43:8443,0,0,0,8,,4,505655,2344127,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,17,1,,0,,2,0,,57,L6OK,,1,5,226,1,4,0,0,,,,,0,0,,,,,11,,,0,0,2,1350,,,,Layer6 check passed,,2,3,4,,,,10.129.0.43:8443,7e4a3da6d0368ecb934a4910245f83b4,http,,,,,,,,0,15,221,,,0,,0,4,26,16533,
+be_secure:openshift-console:console,pod:console-6db7cbb464-8s44k:console:10.130.64.12:8443,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,17,2,,0,,2,0,,0,L6OK,,1,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer6 check passed,,2,3,4,,,,10.130.64.12:8443,5b10765dbf34d04f53986cf7ac1bf19c,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_secure:openshift-console:console,BACKEND,0,0,0,8,1,236,505655,2344127,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,17,0,,0,,1,0,,57,,,,5,226,1,4,0,0,,,,236,0,0,0,0,0,0,11,,,0,0,2,1350,,,,,,,,,,,,,1e2670d92730b515ce3a1bb65da45062,http,leastconn,,,,,,,0,15,221,0,0,,,0,4,26,16533,
+be_edge_http:openshift-console:downloads,pod:downloads-564948bf9c-vn6lh:downloads:10.128.0.30:8080,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,18,1,,0,,2,0,,0,L4OK,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer4 check passed,,2,3,4,,,,10.128.0.30:8080,ce739475136fa468d51cfcf5aad91b68,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_edge_http:openshift-console:downloads,pod:downloads-564948bf9c-g7nsm:downloads:10.129.5.61:8080,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,18,2,,0,,2,0,,0,L4OK,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer4 check passed,,2,3,4,,,,10.129.5.61:8080,450630300ddc04605decdd966ea57de6,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_edge_http:openshift-console:downloads,BACKEND,0,0,0,0,1,0,0,0,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,18,0,,0,,1,0,,0,,,,0,0,0,0,0,0,,,,0,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,a663438294fbd72a8e16964e97c8ecde,http,leastconn,,,,,,,0,0,0,0,0,,,0,0,0,0,
+`,
+		// simulate a second reset metrics due to the router reloading:
+		// * set first console pod connections to 1
+		// * set fe_sni connections to 0
+		`public,FRONTEND,,,0,2,20000,162,18770,30715,0,0,0,,,,,OPEN,,,,,,,,,1,2,0,,,,0,0,0,1,,,,0,160,1,0,1,0,,0,1,162,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,1,162,160,0,0,0,,,0,0,,,,,,,
+public_ssl,FRONTEND,,,1,32,20000,200,928408,2060591,0,0,0,,,,,OPEN,,,,,,,,,1,3,0,,,,0,0,0,50,,,,,,,,,,,0,0,0,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,tcp,,0,50,200,,0,0,0,,,,,,,,,,,
+be_sni,fe_sni,0,0,1,32,,0,900961,1776021,,0,,0,0,0,0,no check,1,1,0,,,802,,,1,4,1,,184,,2,0,,51,,,,,,,,,,,,,,3,0,,,,,68,,,2,0,0,734,,,,,,,,,,,,127.0.0.1:10444,,tcp,,,,,,,,0,184,0,,,0,,29,6,0,46392,
+be_sni,BACKEND,0,0,1,32,2000,0,900961,1776021,0,0,,0,0,0,0,UP,1,1,0,,0,802,0,,1,4,0,,184,,1,0,,51,,,,,,,,,,,,,,3,0,0,0,0,0,68,,,2,0,0,734,,,,,,,,,,,,,,tcp,roundrobin,,,,,,,0,184,0,,,,,29,6,0,46392,
+fe_sni,FRONTEND,,,1,32,20000,0,1072234,2875407,0,0,37,,,,,OPEN,,,,,,,,,1,5,0,,,,0,0,0,53,,,,5,426,242,42,0,0,,0,135,715,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,51,184,0,0,0,0,,,0,0,,,,,,,
+be_no_sni,fe_no_sni,0,0,0,0,,0,0,0,,0,,0,0,0,0,no check,1,1,0,,,802,,,1,6,1,,0,,2,0,,0,,,,,,,,,,,,,,0,0,,,,,-1,,,0,0,0,0,,,,,,,,,,,,127.0.0.1:10443,,tcp,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_no_sni,BACKEND,0,0,0,0,2000,0,0,0,0,0,,0,0,0,0,UP,1,1,0,,0,802,0,,1,6,0,,0,,1,0,,0,,,,,,,,,,,,,,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,,tcp,roundrobin,,,,,,,0,0,0,,,,,0,0,0,0,
+fe_no_sni,FRONTEND,,,0,0,20000,0,0,0,0,0,0,,,,,OPEN,,,,,,,,,1,7,0,,,,0,0,0,0,,,,0,0,0,0,0,0,,0,0,0,,,0,0,0,0,,,,,,,,,,,,,,,,,,,,,http,,0,0,0,0,0,0,0,,,0,0,,,,,,,
+openshift_default,BACKEND,0,0,0,1,6000,1,38,3288,0,0,,1,0,0,0,UP,0,0,0,,0,802,,,1,8,0,,0,,1,0,,1,,,,0,0,0,0,1,0,,,,1,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,,http,roundrobin,,,,,,,0,0,0,0,0,,,0,0,0,0,
+be_tcp:openshift-authentication:oauth-openshift,pod:oauth-openshift-5844b98b58-nm72j:oauth-openshift:10.129.0.42:6443,0,0,0,1,,3,20092,221613,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,16,1,,3,,2,0,,1,L4OK,,0,,,,,,,,,,,0,0,,,,,67,,,1,1,0,130,,,,Layer4 check passed,,2,3,4,,,,10.129.0.42:6443,,tcp,,,,,,,,0,3,0,,,0,,2,1,0,63237,
+be_tcp:openshift-authentication:oauth-openshift,pod:oauth-openshift-5844b98b58-z5rhm:oauth-openshift:10.130.64.11:6443,0,0,0,3,,13,7355,62957,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,16,2,,13,,2,0,,1,L4OK,,1,,,,,,,,,,,0,0,,,,,70,,,0,0,0,1493,,,,Layer4 check passed,,2,3,4,,,,10.130.64.11:6443,,tcp,,,,,,,,0,13,0,,,0,,0,1,0,59559,
+be_tcp:openshift-authentication:oauth-openshift,BACKEND,0,0,0,4,1,16,27447,284570,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,16,0,,16,,1,0,,1,,,,,,,,,,,,,,0,0,0,0,0,0,67,,,1,1,0,1615,,,,,,,,,,,,,,tcp,source,,,,,,,0,16,0,,,,,2,1,0,63237,
+be_secure:openshift-console:console,pod:console-6db7cbb464-gr787:console:10.129.0.43:8443,0,0,0,8,,1,505655,2344127,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,17,1,,0,,2,0,,57,L6OK,,1,5,226,1,4,0,0,,,,,0,0,,,,,11,,,0,0,2,1350,,,,Layer6 check passed,,2,3,4,,,,10.129.0.43:8443,7e4a3da6d0368ecb934a4910245f83b4,http,,,,,,,,0,15,221,,,0,,0,4,26,16533,
+be_secure:openshift-console:console,pod:console-6db7cbb464-8s44k:console:10.130.64.12:8443,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,17,2,,0,,2,0,,0,L6OK,,1,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer6 check passed,,2,3,4,,,,10.130.64.12:8443,5b10765dbf34d04f53986cf7ac1bf19c,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_secure:openshift-console:console,BACKEND,0,0,0,8,1,236,505655,2344127,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,17,0,,0,,1,0,,57,,,,5,226,1,4,0,0,,,,236,0,0,0,0,0,0,11,,,0,0,2,1350,,,,,,,,,,,,,1e2670d92730b515ce3a1bb65da45062,http,leastconn,,,,,,,0,15,221,0,0,,,0,4,26,16533,
+be_edge_http:openshift-console:downloads,pod:downloads-564948bf9c-vn6lh:downloads:10.128.0.30:8080,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,18,1,,0,,2,0,,0,L4OK,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer4 check passed,,2,3,4,,,,10.128.0.30:8080,ce739475136fa468d51cfcf5aad91b68,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_edge_http:openshift-console:downloads,pod:downloads-564948bf9c-g7nsm:downloads:10.129.5.61:8080,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,256,1,0,0,0,802,0,,1,18,2,,0,,2,0,,0,L4OK,,0,0,0,0,0,0,0,,,,,0,0,,,,,-1,,,0,0,0,0,,,,Layer4 check passed,,2,3,4,,,,10.129.5.61:8080,450630300ddc04605decdd966ea57de6,http,,,,,,,,0,0,0,,,0,,0,0,0,0,
+be_edge_http:openshift-console:downloads,BACKEND,0,0,0,0,1,0,0,0,0,0,,0,0,0,0,UP,512,2,0,,0,802,0,,1,18,0,,0,,1,0,,0,,,,0,0,0,0,0,0,,,,0,0,0,0,0,0,0,-1,,,0,0,0,0,,,,,,,,,,,,,a663438294fbd72a8e16964e97c8ecde,http,leastconn,,,,,,,0,0,0,0,0,,,0,0,0,0,
+`,
+	}
+	var index int
+
+	e, err := NewExporter(defaultOptions(PrometheusOptions{ScrapeURI: "http://localhost"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.fetch = func() (io.ReadCloser, error) {
+		r := strings.NewReader(scrapes[index])
+		if index < (len(scrapes) - 1) {
+			index++
+		}
+		return ioutil.NopCloser(r), nil
+	}
+	r := prometheus.NewRegistry()
+	if err := r.Register(e); err != nil {
+		t.Fatal(err)
+	}
+
+	connectionsTotalIndex := 7
+	secondConsolePodID := metricID{proxyType: "2", proxyName: "be_secure:openshift-console:console", serverName: "pod:console-6db7cbb464-gr787:console:10.129.0.43:8443"}
+
+	// perform the first scrape
+	f := gatherMetrics(t, r)
+	if e.counterValues != nil {
+		t.Fatal(e.counterValues)
+	}
+	mustHaveMetric(t, f, "haproxy_exporter_total_scrapes", 1)
+	// this metric should stay the same across all runs because it is not a counter
+	mustHaveMetric(t, f, "haproxy_server_max_sessions", 32, map[string]string{"namespace": "", "pod": "", "route": "", "server": "fe_sni", "service": ""})
+	mustHaveMetric(t, f, "haproxy_server_connections_total", 184, map[string]string{"namespace": "", "pod": "", "route": "", "server": "fe_sni", "service": ""})
+	mustHaveMetric(t, f, "haproxy_server_connections_total", 236, map[string]string{"namespace": "openshift-console", "pod": "console-6db7cbb464-gr787", "route": "console", "server": "10.129.0.43:8443", "service": "console"})
+
+	// simulate reload
+	e.CollectNow()
+	if e.counterValues[secondConsolePodID][e.counterIndices[connectionsTotalIndex]] != 241 {
+		t.Fatalf("incorrect counter: %#v", e.counterValues[secondConsolePodID])
+	}
+
+	e.lastScrape = nil
+	f = gatherMetrics(t, r)
+	if e.counterValues[secondConsolePodID][e.counterIndices[connectionsTotalIndex]] != 241 {
+		t.Fatalf("incorrect counter: %#v", e.counterValues[secondConsolePodID])
+	}
+
+	mustHaveMetric(t, f, "haproxy_exporter_total_scrapes", 3)
+	mustHaveMetric(t, f, "haproxy_server_max_sessions", 32, map[string]string{"namespace": "", "pod": "", "route": "", "server": "fe_sni", "service": ""})
+	mustHaveMetric(t, f, "haproxy_server_connections_total", 184, map[string]string{"namespace": "", "pod": "", "route": "", "server": "fe_sni", "service": ""})
+	mustHaveMetric(t, f, "haproxy_server_connections_total", 244, map[string]string{"namespace": "openshift-console", "pod": "console-6db7cbb464-gr787", "route": "console", "server": "10.129.0.43:8443", "service": "console"})
+
+	now := time.Now()
+	e.lastScrape = &now
+	e.scrapeInterval = time.Hour
+	f = gatherMetrics(t, r)
+	if e.counterValues[secondConsolePodID][e.counterIndices[connectionsTotalIndex]] != 241 {
+		t.Fatalf("incorrect counter: %#v", e.counterValues[secondConsolePodID])
+	}
+
+	mustHaveMetric(t, f, "haproxy_exporter_total_scrapes", 3)
+	mustHaveMetric(t, f, "haproxy_server_max_sessions", 32, map[string]string{"namespace": "", "pod": "", "route": "", "server": "fe_sni", "service": ""})
+	mustHaveMetric(t, f, "haproxy_server_connections_total", 184, map[string]string{"namespace": "", "pod": "", "route": "", "server": "fe_sni", "service": ""})
+	mustHaveMetric(t, f, "haproxy_server_connections_total", 244, map[string]string{"namespace": "openshift-console", "pod": "console-6db7cbb464-gr787", "route": "console", "server": "10.129.0.43:8443", "service": "console"})
+
+	// simulate second reload
+	e.CollectNow()
+	if e.counterValues[secondConsolePodID][e.counterIndices[connectionsTotalIndex]] != 245 {
+		t.Fatalf("incorrect counter: %#v", e.counterValues[secondConsolePodID])
+	}
+
+	// expect no scrape due to the interval set by the last gather
+	e.lastScrape = &now
+	f = gatherMetrics(t, r)
+	if e.counterValues[secondConsolePodID][e.counterIndices[connectionsTotalIndex]] != 245 {
+		t.Fatalf("incorrect counter: %#v", e.counterValues[secondConsolePodID])
+	}
+
+	mustHaveMetric(t, f, "haproxy_exporter_total_scrapes", 4)
+	mustHaveMetric(t, f, "haproxy_server_max_sessions", 32, map[string]string{"namespace": "", "pod": "", "route": "", "server": "fe_sni", "service": ""})
+	mustHaveMetric(t, f, "haproxy_server_connections_total", 184, map[string]string{"namespace": "", "pod": "", "route": "", "server": "fe_sni", "service": ""})
+	mustHaveMetric(t, f, "haproxy_server_connections_total", 245, map[string]string{"namespace": "openshift-console", "pod": "console-6db7cbb464-gr787", "route": "console", "server": "10.129.0.43:8443", "service": "console"})
+}
+
+func mustHaveMetric(t *testing.T, families []*client_model.MetricFamily, name string, value float64, labels ...map[string]string) {
+	t.Helper()
+	if !hasMetric(families, name, value, labels...) {
+		t.Fatalf("does not have metric %s%v=%f:\n\n%s", name, labels, value, mustMetricsToString(families, name))
+	}
+}
+
+func gatherMetrics(t *testing.T, r *prometheus.Registry) []*client_model.MetricFamily {
+	t.Helper()
+	f, err := r.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func hasMetric(families []*client_model.MetricFamily, metric string, value float64, labels ...map[string]string) bool {
+	for _, family := range families {
+		if *family.Name != metric {
+			continue
+		}
+		for _, m := range family.Metric {
+			if !hasAllLabels(m.Label, labels) {
+				continue
+			}
+			var v float64
+			switch {
+			case m.Counter != nil:
+				v = *m.Counter.Value
+			case m.Gauge != nil:
+				v = *m.Gauge.Value
+			case m.Untyped != nil:
+				v = *m.Untyped.Value
+			default:
+				continue
+			}
+			if value == v {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func mustMetricsToString(families []*client_model.MetricFamily, names ...string) string {
+	s, err := metricsToString(families, names...)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func metricsToString(families []*client_model.MetricFamily, names ...string) (string, error) {
+	buf := &bytes.Buffer{}
+	e := expfmt.NewEncoder(buf, expfmt.FmtText)
+	for _, family := range families {
+		if !hasName(family, names) {
+			continue
+		}
+		if err := e.Encode(family); err != nil {
+			return "", err
+		}
+	}
+	return buf.String(), nil
+}
+
+func hasAllLabels(pairs []*client_model.LabelPair, labels []map[string]string) bool {
+	for _, labelSet := range labels {
+		for k, v := range labelSet {
+			var match bool
+			for _, pair := range pairs {
+				if *pair.Name == k && *pair.Value == v {
+					match = true
+					break
+				}
+			}
+			if !match {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func hasName(family *client_model.MetricFamily, names []string) bool {
+	if len(names) == 0 {
+		return true
+	}
+	var named string
+	if family.Name != nil {
+		named = *family.Name
+	}
+	for _, name := range names {
+		if name == named {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Only a subset of metrics are supposed to have incremented values.
The current logic increments ALL values after restart.