### PR TITLE
Bug 1835845: Report all backend metrics for when there are no endpoints

### DIFF
--- a/pkg/router/metrics/haproxy/haproxy.go
+++ b/pkg/router/metrics/haproxy/haproxy.go
@@ -495,10 +495,7 @@ func (e *Exporter) collectMetrics(metrics chan<- prometheus.Metric) {
 	for _, m := range e.frontendMetrics {
 		m.Collect(metrics)
 	}
-	for i, m := range e.backendMetrics {
-		if _, ok := e.reducedBackendExports[i]; !e.serverLimited && !ok {
-			continue
-		}
+	for _, m := range e.backendMetrics {
 		m.Collect(metrics)
 	}
 	if !e.serverLimited {


### PR DESCRIPTION
When no servers are exposed, backend metrics are needed to see how many requests are making it to a service. If we don't report them users can't see when no pods are up (a crashlooping service for instance would have no metrics at all because no pods are ready). Always report all backend
metrics. Increases cardinality by O(routes), but prometheus is a lot faster now and this should balance out.