### PR TITLE
Simplify generateCertConfigMapEntry

### DIFF
--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -178,7 +178,7 @@ func generateHAProxyCertConfigMap(td templateData) []string {
 			if td.DisableHTTP2 {
 				lines = append(lines, strings.Join([]string{fqCertPath, entry.Value}, " "))
 			} else {
-				lines = append(lines, strings.Join([]string{fqCertPath, entry.SSLBindConfig, entry.Value}, " "))
+				lines = append(lines, strings.Join([]string{fqCertPath, "[alpn h2,http/1.1]", entry.Value}, " "))
 			}
 		}
 	}

--- a/pkg/router/template/util/haproxy/map_entry.go
+++ b/pkg/router/template/util/haproxy/map_entry.go
@@ -95,17 +95,10 @@ func generateSNIPassthroughMapEntry(cfg *BackendConfig) *HAProxyMapEntry {
 // generateCertConfigMapEntry generates a cert config map entry.
 func generateCertConfigMapEntry(cfg *BackendConfig) *HAProxyMapEntry {
 	if len(cfg.Host) > 0 && (cfg.Termination == routev1.TLSTerminationEdge || cfg.Termination == routev1.TLSTerminationReencrypt) && cfg.HasCertificate {
-		e := &HAProxyMapEntry{
+		return &HAProxyMapEntry{
 			Key:   fmt.Sprintf("%s.pem", cfg.Name),
 			Value: templateutil.GenCertificateHostName(cfg.Host, cfg.IsWildcard),
 		}
-		if cfg.HasCertificate {
-			switch cfg.Termination {
-			case routev1.TLSTerminationEdge, routev1.TLSTerminationReencrypt:
-				e.SSLBindConfig = "[alpn h2,http/1.1]"
-			}
-		}
-		return e
 	}
 
 	return nil

--- a/pkg/router/template/util/haproxy/map_entry_test.go
+++ b/pkg/router/template/util/haproxy/map_entry_test.go
@@ -811,11 +811,7 @@ func TestGenerateCertConfigMapEntry(t *testing.T) {
 		}
 
 		certHost := templateutil.GenCertificateHostName(host, wildcard)
-		e := &HAProxyMapEntry{Key: key, Value: certHost}
-		if hascert {
-			e.SSLBindConfig = "[alpn h2,http/1.1]"
-		}
-		return e
+		return &HAProxyMapEntry{Key: key, Value: certHost}
 	}
 
 	for _, tt := range tests {

--- a/pkg/router/template/util/haproxy/types.go
+++ b/pkg/router/template/util/haproxy/types.go
@@ -17,7 +17,6 @@ type BackendConfig struct {
 
 // HAProxyMapEntry is a haproxy map entry.
 type HAProxyMapEntry struct {
-	Key           string
-	Value         string
-	SSLBindConfig string
+	Key   string
+	Value string
 }


### PR DESCRIPTION
Delete superfluous conditions in the `cert_config.map` generation logic.

https://github.com/openshift/router/pull/125 modified the logic that generates entries in `cert_config.map` in order to add `[alpn h2,http/1.1]` stanzas, with the condition that the stanza was only added if the backend the corresponded to an entry had a certificate and specified edge or reencrypt termination.  However, the generation logic already only adds entries for backends that have certificates and specify either edge or reencrypt termination, so the additional condition is superfluous.

* `pkg/router/template/template_helper.go` (`generateHAProxyCertConfigMap`): Replace use of `SSLBindConfig` with a string literal.
* `pkg/router/template/util/haproxy/map_entry.go` (`generateCertConfigMapEntry`):
* `pkg/router/template/util/haproxy/map_entry_test.go` (`TestGenerateCertConfigMapEntry`): Delete initialization of `SSLBindConfig`.
* `pkg/router/template/util/haproxy/types.go` (`HAProxyMapEntry`): Delete `SSLBindConfig`.


----

@frobware, this PR reverts some of the changes you made in #125.  If you look at `generateCertConfigMapEntry` in its entirety, you can see that the logic is redundant.  Sorry I missed this during review!