### PR TITLE
Use generateCertKey consistently

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -1094,7 +1094,8 @@ func (r *templateRouter) SyncedAtLeastOnce() bool {
 // hasRequiredEdgeCerts ensures that at least a host certificate and key are provided.
 // a ca cert is not required because it may be something that is in the root cert chain
 func hasRequiredEdgeCerts(cfg *ServiceAliasConfig) bool {
-	hostCert, ok := cfg.Certificates[cfg.Host]
+	certKey := generateCertKey(cfg)
+	hostCert, ok := cfg.Certificates[certKey]
 	return ok && len(hostCert.Contents) > 0 && len(hostCert.PrivateKey) > 0
 }
 

--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -168,7 +168,8 @@ func generateHAProxyCertConfigMap(td templateData) []string {
 	for k, cfg := range td.State {
 		hascert := false
 		if len(cfg.Host) > 0 {
-			cert, ok := cfg.Certificates[cfg.Host]
+			certKey := generateCertKey(&cfg)
+			cert, ok := cfg.Certificates[certKey]
 			hascert = ok && len(cert.Contents) > 0
 		}
 


### PR DESCRIPTION
Fix some lookups in the service alias configuration's certificates map to use `generateCertKey` instead of using the host as the map key.

* `pkg/router/template/router.go` (`hasRequiredEdgeCerts`):
* `pkg/router/template/template_helper.go` (`generateHAProxyCertConfigMap`): Use `generateCertKey` to get the map key for the certificate in the service alias configuration.