### PR TITLE
Add HTTP header capture

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -167,6 +167,13 @@ frontend public
   monitor-uri /_______internal_router_healthz
   {{- end }}
 
+  {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
+  capture request header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
+  {{- end }}
+  {{- range $idx, $captureHeader := .CaptureHTTPResponseHeaders }}
+  capture response header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
+  {{- end }}
+
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
 
@@ -240,6 +247,13 @@ frontend fe_sni
     {{- end }}
   mode http
 
+  {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
+  capture request header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
+  {{- end }}
+  {{- range $idx, $captureHeader := .CaptureHTTPResponseHeaders }}
+  capture response header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
+  {{- end }}
+
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
 
@@ -310,6 +324,13 @@ frontend fe_no_sni
       {{- with (env "ROUTER_MUTUAL_TLS_AUTH_CRL") }} crl-file {{.}} {{ end }}
     {{- end }}
   mode http
+
+  {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
+  capture request header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
+  {{- end }}
+  {{- range $idx, $captureHeader := .CaptureHTTPResponseHeaders }}
+  capture response header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
+  {{- end }}
 
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -41,26 +41,28 @@ func newDefaultTemplatePlugin(router RouterInterface, includeUDP bool, lookupSvc
 }
 
 type TemplatePluginConfig struct {
-	WorkingDir               string
-	TemplatePath             string
-	ReloadScriptPath         string
-	ReloadFn                 func(shutdown bool) error
-	ReloadInterval           time.Duration
-	ReloadCallbacks          []func()
-	DefaultCertificate       string
-	DefaultCertificatePath   string
-	DefaultCertificateDir    string
-	DefaultDestinationCAPath string
-	StatsPort                int
-	StatsUsername            string
-	StatsPassword            string
-	IncludeUDP               bool
-	AllowWildcardRoutes      bool
-	BindPortsAfterSync       bool
-	MaxConnections           string
-	Ciphers                  string
-	StrictSNI                bool
-	DynamicConfigManager     ConfigManager
+	WorkingDir                 string
+	TemplatePath               string
+	ReloadScriptPath           string
+	ReloadFn                   func(shutdown bool) error
+	ReloadInterval             time.Duration
+	ReloadCallbacks            []func()
+	DefaultCertificate         string
+	DefaultCertificatePath     string
+	DefaultCertificateDir      string
+	DefaultDestinationCAPath   string
+	StatsPort                  int
+	StatsUsername              string
+	StatsPassword              string
+	IncludeUDP                 bool
+	AllowWildcardRoutes        bool
+	BindPortsAfterSync         bool
+	MaxConnections             string
+	Ciphers                    string
+	StrictSNI                  bool
+	DynamicConfigManager       ConfigManager
+	CaptureHTTPRequestHeaders  []CaptureHTTPHeader
+	CaptureHTTPResponseHeaders []CaptureHTTPHeader
 }
 
 // RouterInterface controls the interaction of the plugin with the underlying router implementation
@@ -135,22 +137,24 @@ func NewTemplatePlugin(cfg TemplatePluginConfig, lookupSvc ServiceLookup) (*Temp
 	}
 
 	templateRouterCfg := templateRouterCfg{
-		dir:                      cfg.WorkingDir,
-		templates:                templates,
-		reloadScriptPath:         cfg.ReloadScriptPath,
-		reloadFn:                 cfg.ReloadFn,
-		reloadInterval:           cfg.ReloadInterval,
-		reloadCallbacks:          cfg.ReloadCallbacks,
-		defaultCertificate:       cfg.DefaultCertificate,
-		defaultCertificatePath:   cfg.DefaultCertificatePath,
-		defaultCertificateDir:    cfg.DefaultCertificateDir,
-		defaultDestinationCAPath: cfg.DefaultDestinationCAPath,
-		statsUser:                cfg.StatsUsername,
-		statsPassword:            cfg.StatsPassword,
-		statsPort:                cfg.StatsPort,
-		allowWildcardRoutes:      cfg.AllowWildcardRoutes,
-		bindPortsAfterSync:       cfg.BindPortsAfterSync,
-		dynamicConfigManager:     cfg.DynamicConfigManager,
+		dir:                        cfg.WorkingDir,
+		templates:                  templates,
+		reloadScriptPath:           cfg.ReloadScriptPath,
+		reloadFn:                   cfg.ReloadFn,
+		reloadInterval:             cfg.ReloadInterval,
+		reloadCallbacks:            cfg.ReloadCallbacks,
+		defaultCertificate:         cfg.DefaultCertificate,
+		defaultCertificatePath:     cfg.DefaultCertificatePath,
+		defaultCertificateDir:      cfg.DefaultCertificateDir,
+		defaultDestinationCAPath:   cfg.DefaultDestinationCAPath,
+		statsUser:                  cfg.StatsUsername,
+		statsPassword:              cfg.StatsPassword,
+		statsPort:                  cfg.StatsPort,
+		allowWildcardRoutes:        cfg.AllowWildcardRoutes,
+		bindPortsAfterSync:         cfg.BindPortsAfterSync,
+		dynamicConfigManager:       cfg.DynamicConfigManager,
+		captureHTTPRequestHeaders:  cfg.CaptureHTTPRequestHeaders,
+		captureHTTPResponseHeaders: cfg.CaptureHTTPResponseHeaders,
 	}
 	router, err := newTemplateRouter(templateRouterCfg)
 	return newDefaultTemplatePlugin(router, cfg.IncludeUDP, lookupSvc), err

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -225,6 +225,16 @@ type ConfigManager interface {
 	GenerateDynamicServerNames(id string) []string
 }
 
+// CaptureHTTPHeader specifies an HTTP header that should be captured for access
+// logs.
+type CaptureHTTPHeader struct {
+	// Name specifies an HTTP header name.
+	Name string
+
+	// MaxLength specifies a maximum length for the header value.
+	MaxLength int
+}
+
 // RouterEventType indicates the type of event fired by the router.
 type RouterEventType string
 


### PR DESCRIPTION
Add `--capture-http-request-headers` and `--capture-http-response-headers` command-line flags, as well as `ROUTER_CAPTURE_HTTP_REQUEST_HEADERS` and `ROUTER_CAPTURE_HTTP_RESPONSE_HEADERS` environment variables, to allow specifying HTTP request or response headers that should be captured for logging.

Each flag or environment variable accepts a comma-delimited list of `name:maxLength` values, where `name` is an HTTP header name and `maxLength` is a maximum length.  The router captures the named headers, which may be referenced in a custom `ROUTER_SYSLOG_FORMAT` string or are included in the default log message format if no custom format string is provided.  A header value that exceeds its maximum length is truncated to that length.

This change is related to [NE-320](https://issues.redhat.com/browse/NE-320).

* `images/router/haproxy/conf/haproxy-config.template`: Add `capture request header` and `capture response header` stanzas to the `public`, `fe_sni`, and `fe_no_sni` frontends.
* `pkg/cmd/infra/router/template.go` (`TemplateRouter`): Add `CaptureHTTPRequestHeadersString`, `CaptureHTTPResponseHeadersString`, `CaptureHTTPResponseHeaders`, and `CaptureHTTPRequestHeaders` fields.
(`Bind`): Add `--capture-http-request-headers` and `--capture-http-response-headers` flags, which default to the values of the `ROUTER_CAPTURE_HTTP_REQUEST_HEADERS` and `ROUTER_CAPTURE_HTTP_RESPONSE_HEADERS` environment variables, respectively.
(`httpHeaderNameRE`): New variable with a regular expression that matches valid HTTP header names.
(`parseCaptureHeaders`): New function.  Parse a string value (such as provided with the newly added command-line flags) into a slice of `CaptureHTTPHeader` values.
(`Complete`): Use `parseCaptureHeaders` to parse `CaptureHTTPRequestHeadersString` and `CaptureHTTPResponseHeadersString` into `CaptureHTTPResponseHeaders` and `CaptureHTTPRequestHeaders`.
(`Run`): Specify `CaptureHTTPRequestHeaders` and `CaptureHTTPResponseHeaders` in the plugin config.
* `pkg/router/template/plugin.go` (`TemplatePluginConfig`): Add `CaptureHTTPRequestHeaders` and `CaptureHTTPResponseHeaders` fields.
(`NewTemplatePlugin`): Specify `CaptureHTTPRequestHeaders` and `CaptureHTTPResponseHeaders` in the internal template router config.
* `pkg/router/template/router.go` (`templateRouter`):
(`templateRouterCfg`): Add `captureHTTPRequestHeaders` and `captureHTTPResponseHeaders` fields.
(`templateData`): Add `CaptureHTTPRequestHeaders` and `CaptureHTTPResponseHeaders` fields.
(`newTemplateRouter`): Specify `captureHTTPRequestHeaders` and `captureHTTPResponseHeaders` in the template router.
(`writeConfig`): Specify `CaptureHTTPRequestHeaders` and `CaptureHTTPResponseHeaders` in the template parameters.
* `pkg/router/template/types.go` (`CaptureHTTPHeader`): New type.  Specify an HTTP header name and maximum value length.