### PR TITLE
Bug 1853711: haproxy: conditionally add ALPN to reencrypt backend servers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -15,3 +15,4 @@ reviewers:
   - smarterclayton
   - danehans
   - frobware
+component: Routing

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -458,8 +458,10 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
         {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
   server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{$weight}}
           {{- if (eq $cfg.TLSTermination "reencrypt") }} ssl
-	    {{- if not (isTrue $router_disable_http2) }} alpn h2,http/1.1
-	    {{- end }}
+	    {{ if gt (len (index $cfg.Certificates (printf "%s_pod" $cfg.Host)).Contents) 0 }}
+	      {{- if not (isTrue $router_disable_http2) }} alpn h2,http/1.1
+	      {{- end }}
+            {{- end }}
             {{- if $cfg.VerifyServiceHostname }} verifyhost {{ $serviceUnit.Hostname }}
             {{- end }}
             {{- if gt (len (index $cfg.Certificates (printf "%s_pod" $cfg.Host)).Contents) 0 }} verify required ca-file {{ $workingDir }}/router/cacerts/{{$cfgIdx}}.pem

--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -178,7 +178,7 @@ func generateHAProxyCertConfigMap(td templateData) []string {
 			if td.DisableHTTP2 {
 				lines = append(lines, strings.Join([]string{fqCertPath, entry.Value}, " "))
 			} else {
-				lines = append(lines, strings.Join([]string{fqCertPath, entry.SSLBindConfig, entry.Value}, " "))
+				lines = append(lines, strings.Join([]string{fqCertPath, "[alpn h2,http/1.1]", entry.Value}, " "))
 			}
 		}
 	}

--- a/pkg/router/template/util/haproxy/map_entry.go
+++ b/pkg/router/template/util/haproxy/map_entry.go
@@ -95,17 +95,10 @@ func generateSNIPassthroughMapEntry(cfg *BackendConfig) *HAProxyMapEntry {
 // generateCertConfigMapEntry generates a cert config map entry.
 func generateCertConfigMapEntry(cfg *BackendConfig) *HAProxyMapEntry {
 	if len(cfg.Host) > 0 && (cfg.Termination == routev1.TLSTerminationEdge || cfg.Termination == routev1.TLSTerminationReencrypt) && cfg.HasCertificate {
-		e := &HAProxyMapEntry{
+		return &HAProxyMapEntry{
 			Key:   fmt.Sprintf("%s.pem", cfg.Name),
 			Value: templateutil.GenCertificateHostName(cfg.Host, cfg.IsWildcard),
 		}
-		if cfg.HasCertificate {
-			switch cfg.Termination {
-			case routev1.TLSTerminationEdge, routev1.TLSTerminationReencrypt:
-				e.SSLBindConfig = "[alpn h2,http/1.1]"
-			}
-		}
-		return e
 	}
 
 	return nil

--- a/pkg/router/template/util/haproxy/map_entry_test.go
+++ b/pkg/router/template/util/haproxy/map_entry_test.go
@@ -811,11 +811,7 @@ func TestGenerateCertConfigMapEntry(t *testing.T) {
 		}
 
 		certHost := templateutil.GenCertificateHostName(host, wildcard)
-		e := &HAProxyMapEntry{Key: key, Value: certHost}
-		if hascert {
-			e.SSLBindConfig = "[alpn h2,http/1.1]"
-		}
-		return e
+		return &HAProxyMapEntry{Key: key, Value: certHost}
 	}
 
 	for _, tt := range tests {

--- a/pkg/router/template/util/haproxy/types.go
+++ b/pkg/router/template/util/haproxy/types.go
@@ -17,7 +17,6 @@ type BackendConfig struct {
 
 // HAProxyMapEntry is a haproxy map entry.
 type HAProxyMapEntry struct {
-	Key           string
-	Value         string
-	SSLBindConfig string
+	Key   string
+	Value string
 }


### PR DESCRIPTION
Only add "alpn h2,http/1.1" on reencrypt routes when the frontend has
a certificate.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1853711