### PR TITLE
Allow configuring unique-id HTTP header

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -174,6 +174,11 @@ frontend public
   # before matching, or any requests containing uppercase characters will never match.
   http-request set-header Host %[req.hdr(Host),lower]
 
+  {{- if and (ne (env "ROUTER_UNIQUE_ID_FORMAT") "") (ne (env "ROUTER_UNIQUE_ID_HEADER_NAME") "") }}
+  unique-id-format {{ env "ROUTER_UNIQUE_ID_FORMAT" }}
+  unique-id-header {{ env "ROUTER_UNIQUE_ID_HEADER_NAME" }}
+  {{- end }}
+
   # check if we need to redirect/force using https.
   acl secure_redirect base,map_reg(/var/lib/haproxy/conf/os_route_http_redirect.map) -m found
   redirect scheme https if secure_redirect
@@ -247,6 +252,11 @@ frontend fe_sni
   # before matching, or any requests containing uppercase characters will never match.
   http-request set-header Host %[req.hdr(Host),lower]
 
+  {{- if and (ne (env "ROUTER_UNIQUE_ID_FORMAT") "") (ne (env "ROUTER_UNIQUE_ID_HEADER_NAME") "") }}
+  unique-id-format {{ env "ROUTER_UNIQUE_ID_FORMAT" }}
+  unique-id-header {{ env "ROUTER_UNIQUE_ID_HEADER_NAME" }}
+  {{- end }}
+
   {{ if ne (env "ROUTER_MUTUAL_TLS_AUTH" "none") "none" }}
     {{- with (env "ROUTER_MUTUAL_TLS_AUTH_FILTER") }}
   # If a mutual TLS auth subject filter environment variable is set, we deny
@@ -317,6 +327,11 @@ frontend fe_no_sni
   # DNS labels are case insensitive (RFC 4343), we need to convert the hostname into lowercase
   # before matching, or any requests containing uppercase characters will never match.
   http-request set-header Host %[req.hdr(Host),lower]
+
+  {{- if and (ne (env "ROUTER_UNIQUE_ID_FORMAT") "") (ne (env "ROUTER_UNIQUE_ID_HEADER_NAME") "") }}
+  unique-id-format {{ env "ROUTER_UNIQUE_ID_FORMAT" }}
+  unique-id-header {{ env "ROUTER_UNIQUE_ID_HEADER_NAME" }}
+  {{- end }}
 
   {{ if ne (env "ROUTER_MUTUAL_TLS_AUTH" "none") "none" }}
     {{- with (env "ROUTER_MUTUAL_TLS_AUTH_FILTER") }}


### PR DESCRIPTION
Implement the `ROUTER_UNIQUE_ID_FORMAT` and `ROUTER_UNIQUE_ID_HEADER_NAME` environment variables, which may be used to specify that a header with the given name and format should be injected into every HTTP request.  This header can be used by the application or printed in access logs in order to facilitate tracing requests.

* `images/router/haproxy/conf/haproxy-config.template:` Add `unique-id-format` and `unique-id-header` stanzas using the values from the `ROUTER_UNIQUE_ID_FORMAT` and `ROUTER_UNIQUE_ID_HEADER_NAME` environment variables if the values are nonempty.