### PR TITLE
Add HTTP cookie capture

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -173,6 +173,9 @@ frontend public
   {{- range $idx, $captureHeader := .CaptureHTTPResponseHeaders }}
   capture response header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
   {{- end }}
+  {{- with $captureCookie := .CaptureHTTPCookie }}
+  capture cookie {{ $captureCookie.Name }}{{ if eq $captureCookie.MatchType "exact" }}={{ end }} len {{ $captureCookie.MaxLength }}
+  {{- end }}
 
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
@@ -253,6 +256,9 @@ frontend fe_sni
   {{- range $idx, $captureHeader := .CaptureHTTPResponseHeaders }}
   capture response header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
   {{- end }}
+  {{- with $captureCookie := .CaptureHTTPCookie }}
+  capture cookie {{ $captureCookie.Name }}{{ if eq $captureCookie.MatchType "exact" }}={{ end }} len {{ $captureCookie.MaxLength }}
+  {{- end }}
 
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
@@ -330,6 +336,9 @@ frontend fe_no_sni
   {{- end }}
   {{- range $idx, $captureHeader := .CaptureHTTPResponseHeaders }}
   capture response header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
+  {{- end }}
+  {{- with $captureCookie := .CaptureHTTPCookie }}
+  capture cookie {{ $captureCookie.Name }}{{ if eq $captureCookie.MatchType "exact" }}={{ end }} len {{ $captureCookie.MaxLength }}
   {{- end }}
 
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -63,6 +63,7 @@ type TemplatePluginConfig struct {
 	DynamicConfigManager       ConfigManager
 	CaptureHTTPRequestHeaders  []CaptureHTTPHeader
 	CaptureHTTPResponseHeaders []CaptureHTTPHeader
+	CaptureHTTPCookie          *CaptureHTTPCookie
 }
 
 // RouterInterface controls the interaction of the plugin with the underlying router implementation
@@ -155,6 +156,7 @@ func NewTemplatePlugin(cfg TemplatePluginConfig, lookupSvc ServiceLookup) (*Temp
 		dynamicConfigManager:       cfg.DynamicConfigManager,
 		captureHTTPRequestHeaders:  cfg.CaptureHTTPRequestHeaders,
 		captureHTTPResponseHeaders: cfg.CaptureHTTPResponseHeaders,
+		captureHTTPCookie:          cfg.CaptureHTTPCookie,
 	}
 	router, err := newTemplateRouter(templateRouterCfg)
 	return newDefaultTemplatePlugin(router, cfg.IncludeUDP, lookupSvc), err

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -112,6 +112,9 @@ type templateRouter struct {
 	// captureHTTPResponseHeaders specifies HTTP response headers
 	// that should be captured for logging.
 	captureHTTPResponseHeaders []CaptureHTTPHeader
+	// captureHTTPCookie specifies an HTTP cookie that should be
+	// captured for logging.
+	captureHTTPCookie *CaptureHTTPCookie
 }
 
 // templateRouterCfg holds all configuration items required to initialize the template router
@@ -135,6 +138,7 @@ type templateRouterCfg struct {
 	dynamicConfigManager       ConfigManager
 	captureHTTPRequestHeaders  []CaptureHTTPHeader
 	captureHTTPResponseHeaders []CaptureHTTPHeader
+	captureHTTPCookie          *CaptureHTTPCookie
 }
 
 // templateConfig is a subset of the templateRouter information that should be passed to the template for generating
@@ -168,6 +172,9 @@ type templateData struct {
 	// CaptureHTTPResponseHeaders specifies HTTP response headers
 	// that should be captured for logging.
 	CaptureHTTPResponseHeaders []CaptureHTTPHeader
+	// CaptureHTTPCookie specifies an HTTP cookie that should be
+	// captured for logging.
+	CaptureHTTPCookie *CaptureHTTPCookie
 }
 
 func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
@@ -221,6 +228,7 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 		dynamicConfigManager:       cfg.dynamicConfigManager,
 		captureHTTPRequestHeaders:  cfg.captureHTTPRequestHeaders,
 		captureHTTPResponseHeaders: cfg.captureHTTPResponseHeaders,
+		captureHTTPCookie:          cfg.captureHTTPCookie,
 
 		metricReload:      metricsReload,
 		metricWriteConfig: metricWriteConfig,
@@ -510,6 +518,7 @@ func (r *templateRouter) writeConfig() error {
 			DisableHTTP2:               disableHTTP2,
 			CaptureHTTPRequestHeaders:  r.captureHTTPRequestHeaders,
 			CaptureHTTPResponseHeaders: r.captureHTTPResponseHeaders,
+			CaptureHTTPCookie:          r.captureHTTPCookie,
 		}
 		if err := template.Execute(file, data); err != nil {
 			file.Close()

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -235,6 +235,32 @@ type CaptureHTTPHeader struct {
 	MaxLength int
 }
 
+// CaptureHTTPCookie specifies an HTTP cookie that should be captured
+// for access logs.
+type CaptureHTTPCookie struct {
+	// Name specifies an HTTP cookie name.
+	Name string
+
+	// MaxLength specifies a maximum length for the cookie value.
+	MaxLength int
+
+	// MatchType specifies the type of match to be performed on the cookie
+	// name.
+	MatchType CookieMatchType
+}
+
+// CookieMatchType indicates the type of matching used against cookie names to
+// select a cookie for capture.
+type CookieMatchType string
+
+const (
+	// CookieMatchTypeExact indicates that an exact match should be performed.
+	CookieMatchTypeExact CookieMatchType = "exact"
+
+	// CookieMatchTypePrefix indicates that a prefix match should be performed.
+	CookieMatchTypePrefix CookieMatchType = "prefix"
+)
+
 // RouterEventType indicates the type of event fired by the router.
 type RouterEventType string
 


### PR DESCRIPTION
Add a `--capture-http-cookie` command-line flag, as well as `ROUTER_CAPTURE_HTTP_COOKIE` environment variable, to allow specifying an HTTP cookie that should be captured for logging.

The flag and environment variable each accept a `name:maxLength` value, where `name` is an HTTP cookie and `maxLength` is a maximum length.  The router captures the named cookie, which may be referenced in a custom `ROUTER_SYSLOG_FORMAT` string or is included in the default log message format if no custom format string is provided.  A cookie value that exceeds its maximum length is truncated to that length.  The value of the first cookie that matches the provided name captured.  By default, names are compared using a prefix match.  An equals sign ("=") may be appended to the name to indicate that the comparison should use an exact match.

* `images/router/haproxy/conf/haproxy-config.template`: Add `capture cookie` stanzas to the `public`, `fe_sni`, and `fe_no_sni` frontends.
* `pkg/cmd/infra/router/template.go` (`TemplateRouter`): Add `CaptureHTTPCookieString` and `CaptureHTTPCookie` fields.
(`Bind`): Add the `--capture-http-cookie` flag, which defaults to the value of the `ROUTER_CAPTURE_HTTP_COOKIE` environment variable.
(`parseCaptureCookie`): New function.  Parse a string value (such as provided with the newly added command-line flag) into a `CaptureHTTPCookie` value.
(`Complete`): Use `parseCaptureCookie` to parse `CaptureHTTPCookieString` into `CaptureHTTPCookie`.
(`Run`): Specify `CaptureHTTPCookie` in the plugin config.
* `pkg/router/template/plugin.go` (`TemplatePluginConfig`): Add `CaptureHTTPCookie` field.
(`NewTemplatePlugin`): Specify `CaptureHTTPCookie` in the internal template router config.
* `pkg/router/template/router.go` (`templateRouter`):
(`templateRouterCfg`): Add `captureHTTPCookie` field.
(`templateData`): Add `CaptureHTTPCookie` field.
(`newTemplateRouter`): Specify `captureHTTPCookie` in the template router.
(`writeConfig`): Specify `CaptureHTTPCookie` in the template parameters.
* `pkg/router/template/types.go` (`CaptureHTTPCookie`): New type.  Specify an HTTP cookie name, maximum value length, and match type.
(`CookieMatchType`): New type.
(`CookieMatchTypeExact`, `CookieMatchTypePrefix`): New constants.

----

Depends on #139.