### PR TITLE
[WIP] DO NOT MERGE: Validate haproxy-2.2.4

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy22-2.2.0-1.el7.x86_64.rpm
+RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy22-2.2.4-1.el8.x86_64.rpm
 RUN haproxy -vv
 RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \

--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy20 rsyslog sysvinit-tools" && \
+RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy22-2.2.0-1.el7.x86_64.rpm
+RUN haproxy -vv
+RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy22-2.2.0-1.el7.x86_64.rpm
+RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy22-2.2.4-1.el8.x86_64.rpm
 RUN haproxy -vv
 RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,7 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy20 rsyslog sysvinit-tools" && \
+RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy22-2.2.0-1.el7.x86_64.rpm
+RUN haproxy -vv
+RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -1,5 +1,7 @@
 FROM registry.svc.ci.openshift.org/ocp/4.7:haproxy-router-base
-RUN INSTALL_PKGS="haproxy20 rsyslog procps-ng util-linux" && \
+RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy22-2.2.0-1.el7.x86_64.rpm
+RUN haproxy -vv
+RUN INSTALL_PKGS="rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
Test PR to validate and soak test haproxy-2.2.0 in CI.

https://www.mail-archive.com/haproxy@formilux.org/msg37852.html

[RELEASE] Released version 2.2.0

Released version 2.2.0 with the following main changes :
    - BUILD: mux-h2: fix typo breaking build when using DEBUG_LOCK
    - CLEANUP: makefile: update the outdated list of DEBUG_xxx options
    - BUILD: tools: make resolve_sym_name() return a const
    - CLEANUP: auth: fix useless self-include of auth-t.h
    - BUILD: tree-wide: cast arguments to tolower/toupper to unsigned char
    - CLEANUP: assorted typo fixes in the code and comments
    - WIP/MINOR: ssl: add sample fetches for keylog in frontend
    - DOC: fix tune.ssl.keylog sample fetches array
    - BUG/MINOR: ssl: check conn in keylog sample fetch
    - DOC: configuration: various typo fixes
    - MINOR: log: Remove unused case statement during the log-format string parsing
    - BUG/MINOR: mux-h1: Fix the splicing in TUNNEL mode
    - BUG/MINOR: mux-h1: Don't read data from a pipe if the mux is unable to receive
    - BUG/MINOR: mux-h1: Disable splicing only if input data was processed
    - BUG/MEDIUM: mux-h1: Disable splicing for the conn-stream if read0 is received
    - MINOR: mux-h1: Improve traces about the splicing
    - BUG/MINOR: backend: Remove CO_FL_SESS_IDLE if a client remains on the last server
    - BUG/MEDIUM: connection: Don't consider new private connections as available
    - BUG/MINOR: connection: See new connection as available only on reuse always
    - DOC: configuration: remove obsolete mentions of H2 being converted to HTTP/1.x
    - CLEANUP: ssl: remove unrelevant comment in smp_fetch_ssl_x_keylog()
    - DOC: update INSTALL with new compiler versions
    - DOC: minor update to coding style file
    - MINOR: version: mention that it's an LTS release now