### PR TITLE
Handle errors from commit and reload 

### DIFF
--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -99,6 +99,7 @@ func TestMain(m *testing.M) {
 	plugin, err = templateplugin.NewTemplatePlugin(pluginCfg, svcFetcher)
 	if err != nil {
 		fmt.Println(err)
+		os.RemoveAll(workdir)
 		os.Exit(1)
 	}
 
@@ -112,7 +113,9 @@ func TestMain(m *testing.M) {
 	c := factory.Create(plugin, false)
 	c.Run()
 
-	os.Exit(m.Run())
+	exitCode := m.Run()
+	os.RemoveAll(workdir)
+	os.Exit(exitCode)
 }
 
 func TestAdmissionEdgeCases(t *testing.T) {

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -240,7 +240,9 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 	log.V(4).Info("committing state")
 	// Bypass the rate limiter to ensure the first sync will be
 	// committed without delay.
-	router.commitAndReload()
+	if err := router.commitAndReload(); err != nil {
+		return nil, err
+	}
 	return router, nil
 }
 

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -491,6 +491,9 @@ func (r *templateRouter) writeConfig() error {
 
 	for name, template := range r.templates {
 		filename := filepath.Join(r.dir, name)
+		if err := os.MkdirAll(filepath.Dir(filename), 0777); err != nil {
+			return fmt.Errorf("error creating path %q: %v", filepath.Dir(filename), err)
+		}
 		file, err := os.Create(filename)
 		if err != nil {
 			return fmt.Errorf("error creating config file %s: %v", filename, err)


### PR DESCRIPTION
Whilst looking at the existing unit tests we have for endpoints (because we plan to switch to endpoint slices) I noticed that the unit tests were not creating the config files when calling `writeConfig()`. Working back through the call chain it highlights that we ignore potential errors from `commitAndReload()`.

This correction now means the unit tests correctly write the config files in the temporary directories. But we may now see errors at runtime as they were previously masked.

I split the commits in two. The first just handles the unit tests, which I think we want anyway. The second commit just handles the case where we were ignoring the error.

