### PR TITLE
Bug 1861455: Remove initial haproxy template commitAndReload

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -254,12 +254,7 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 		log.V(0).Info("initializing dynamic config manager ... ")
 		router.dynamicConfigManager.Initialize(router, router.defaultCertificatePath)
 	}
-	log.V(4).Info("committing state")
-	// Bypass the rate limiter to ensure the first sync will be
-	// committed without delay.
-	if err := router.commitAndReload(); err != nil {
-		return nil, err
-	}
+
 	return router, nil
 }
 

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -98,6 +98,8 @@ type templateRouter struct {
 	stateChanged bool
 	// metricReload tracks reloads
 	metricReload prometheus.Summary
+	// metricReloadFails tracks reload failures
+	metricReloadFails prometheus.Counter
 	// metricWriteConfig tracks writing config
 	metricWriteConfig prometheus.Summary
 	// dynamicConfigManager configures route changes dynamically on the
@@ -199,6 +201,12 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 		Help:      "Measures the time spent reloading the router in seconds.",
 	})
 	prometheus.MustRegister(metricsReload)
+	metricReloadFails := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "template_router",
+		Name:      "reload_fails",
+		Help:      "Tracks the number of failed router reloads",
+	})
+	prometheus.MustRegister(metricReloadFails)
 	metricWriteConfig := prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: "template_router",
 		Name:      "write_config_seconds",
@@ -231,6 +239,7 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 		captureHTTPCookie:          cfg.captureHTTPCookie,
 
 		metricReload:      metricsReload,
+		metricReloadFails: metricReloadFails,
 		metricWriteConfig: metricWriteConfig,
 
 		rateLimitedCommitFunction: nil,
@@ -460,6 +469,8 @@ func (r *templateRouter) commitAndReload() error {
 		if r.dynamicConfigManager != nil {
 			r.dynamicConfigManager.Notify(RouterEventReloadError)
 		}
+		// Increment the failed reload counter when a reload fails
+		r.metricReloadFails.Inc()
 		return err
 	}
 


### PR DESCRIPTION
Waiting for the router factory/controller to call the router plugin's `Commit` function guarantees that route/endpoint resources are available to the template code, and thus removes the possibility of a "routeless" router. A "routeless" router can be detrimental during upgrades if the routes carrying over during the upgrade break a newer version HAProxy, since the "routeless" configuration will continue to run if future successive reloads fail, and the upgrade will succeed when it should not.
The initial (premature) call to the router's `commitAndReload()` function outside of the rate limited loop is older code (3.11 era) and should be removed.  

This PR also adds a failed reload count metric for tracking failed reloads that happen well after a new router pod is created. This will be used for cluster alerting. 

See the linked BZ for more context. 

/assign @Miciah 
/cc @frobware @danehans