### PR TITLE
Bug 1867971: extend unit tests for endpointslices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e
 	github.com/bcicen/go-haproxy v0.0.0-20180203142132-ff5824fe38be
 	github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292
+	github.com/fortytw2/leaktest v1.3.0
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/getsentry/raven-go v0.2.0 // indirect
 	github.com/gocarina/gocsv v0.0.0-20190927101021-3ecffd272576
+	github.com/google/go-cmp v0.3.1
 	github.com/openshift/api v0.0.0-20200330134433-8e259f67fc55
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
 	github.com/openshift/library-go v0.0.0-20200324092245-db2a8546af81

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
+github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/go-dockerclient v0.0.0-20171004212419-da3951ba2e9e/go.mod h1:KpcjM623fQYE9MZiTGzKhjfxXAV9wbyX2C1cyRHfhl0=

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -633,7 +633,7 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 	plugin = controller.NewUniqueHost(plugin, o.RouterSelection.DisableNamespaceOwnershipCheck, recorder)
 	plugin = controller.NewHostAdmitter(plugin, o.RouteAdmissionFunc(), o.AllowWildcardRoutes, o.RouterSelection.DisableNamespaceOwnershipCheck, recorder)
 
-	controller := factory.Create(plugin, false)
+	controller := factory.Create(plugin, false, wait.NeverStop)
 	controller.Run()
 
 	if blueprintPlugin != nil {
@@ -643,7 +643,7 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 		f.LabelSelector = o.BlueprintRouteLabelSelector
 		f.Namespace = o.BlueprintRouteNamespace
 		f.ResyncInterval = o.ResyncInterval
-		c := f.Create(blueprintPlugin, false)
+		c := f.Create(blueprintPlugin, false, wait.NeverStop)
 		c.Run()
 	}
 

--- a/pkg/router/controller/endpointsubset/sort_address.go
+++ b/pkg/router/controller/endpointsubset/sort_address.go
@@ -89,9 +89,6 @@ func DefaultEndpointAddressOrderByFuncs() []EndpointAddressLessFunc {
 	}
 }
 
-func SortAddresses(addresses []kapi.EndpointAddress, orderByFuncs ...EndpointAddressLessFunc) {
-	if len(orderByFuncs) == 0 {
-		orderByFuncs = DefaultEndpointAddressOrderByFuncs()
-	}
+func SortAddresses(addresses []kapi.EndpointAddress, orderByFuncs []EndpointAddressLessFunc) {
 	newEndpointAddressOrderBy(orderByFuncs...).Sort(addresses)
 }

--- a/pkg/router/controller/endpointsubset/sort_address_test.go
+++ b/pkg/router/controller/endpointsubset/sort_address_test.go
@@ -1,0 +1,73 @@
+package endpointsubset_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/router/pkg/router/controller/endpointsubset"
+	kapi "k8s.io/api/core/v1"
+)
+
+func TestSortAddresses(t *testing.T) {
+	var testcases = []struct {
+		description string
+		input       []kapi.EndpointAddress
+		expected    []kapi.EndpointAddress
+	}{{
+		description: "empty slice",
+	}, {
+		description: "IP address sort lowest -> highest",
+		input: []kapi.EndpointAddress{{
+			IP: "172.16.0.1",
+		}, {
+			IP: "192.168.0.1",
+		}, {
+			IP: "10.0.0.1",
+		}},
+		expected: []kapi.EndpointAddress{{
+			IP: "10.0.0.1",
+		}, {
+			IP: "172.16.0.1",
+		}, {
+			IP: "192.168.0.1",
+		}},
+	}, {
+		description: "equal IP address order by hostname",
+		input: []kapi.EndpointAddress{{
+			IP:       "172.16.0.1",
+			Hostname: "b",
+		}, {
+			IP:       "172.16.0.1",
+			Hostname: "a",
+		}, {
+			IP:       "10.0.0.1",
+			Hostname: "a",
+		}},
+		expected: []kapi.EndpointAddress{{
+			IP:       "10.0.0.1",
+			Hostname: "a",
+		}, {
+			IP:       "172.16.0.1",
+			Hostname: "a",
+		}, {
+			IP:       "172.16.0.1",
+			Hostname: "b",
+		}},
+	}}
+
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			if len(tc.input) > 0 {
+				if diff := cmp.Diff(tc.input, tc.expected); len(diff) == 0 {
+					t.Errorf("expecting input to differ from expected (-want +got):\n%s", diff)
+				}
+			}
+
+			endpointsubset.SortAddresses(tc.input, endpointsubset.DefaultEndpointAddressOrderByFuncs())
+
+			if diff := cmp.Diff(tc.input, tc.expected); len(diff) != 0 {
+				t.Errorf("mismatched sort order (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/router/controller/endpointsubset/sort_port.go
+++ b/pkg/router/controller/endpointsubset/sort_port.go
@@ -96,9 +96,6 @@ func DefaultEndpointPortOrderByFuncs() []EndpointPortLessFunc {
 	}
 }
 
-func SortPorts(ports []kapi.EndpointPort, orderByFuncs ...EndpointPortLessFunc) {
-	if len(orderByFuncs) == 0 {
-		orderByFuncs = DefaultEndpointPortOrderByFuncs()
-	}
+func SortPorts(ports []kapi.EndpointPort, orderByFuncs []EndpointPortLessFunc) {
 	endpointPortOrderBy(orderByFuncs...).Sort(ports)
 }

--- a/pkg/router/controller/endpointsubset/sort_port_test.go
+++ b/pkg/router/controller/endpointsubset/sort_port_test.go
@@ -1,0 +1,97 @@
+package endpointsubset_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/router/pkg/router/controller/endpointsubset"
+	kapi "k8s.io/api/core/v1"
+)
+
+func TestSortPorts(t *testing.T) {
+	var testcases = []struct {
+		description string
+		input       []kapi.EndpointPort
+		expected    []kapi.EndpointPort
+	}{{
+		description: "empty slice",
+	}, {
+		description: "port numbers sort lowest -> highest",
+		input: []kapi.EndpointPort{{
+			Port: 2,
+		}, {
+			Port: 0,
+		}, {
+			Port: 1,
+		}, {
+			Port: 0,
+		}},
+		expected: []kapi.EndpointPort{{
+			Port: 0,
+		}, {
+			Port: 0,
+		}, {
+			Port: 1,
+		}, {
+			Port: 2,
+		}},
+	}, {
+		description: "equal port numbers sort by Name",
+		input: []kapi.EndpointPort{{
+			Port: 3,
+			Name: "b",
+		}, {
+			Port: 3,
+			Name: "a",
+		}, {
+			Port: 2,
+			Name: "a",
+		}},
+		expected: []kapi.EndpointPort{{
+			Port: 2,
+			Name: "a",
+		}, {
+			Port: 3,
+			Name: "a",
+		}, {
+			Port: 3,
+			Name: "b",
+		}},
+	}, {
+		description: "Equal port numbers and equal names sort by protocol",
+		input: []kapi.EndpointPort{{
+			Port:     3,
+			Name:     "a",
+			Protocol: "UDP",
+		}, {
+			Port:     3,
+			Name:     "a",
+			Protocol: "TCP",
+		}},
+		expected: []kapi.EndpointPort{{
+			Port:     3,
+			Name:     "a",
+			Protocol: "TCP",
+		}, {
+			Port:     3,
+			Name:     "a",
+			Protocol: "UDP",
+		}},
+	}}
+
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			if len(tc.input) > 0 {
+				if diff := cmp.Diff(tc.input, tc.expected); len(diff) == 0 {
+					t.Errorf("expecting input to differ from expected (-want +got):\n%s", diff)
+				}
+			}
+
+			endpointsubset.SortPorts(tc.input, endpointsubset.DefaultEndpointPortOrderByFuncs())
+
+			if diff := cmp.Diff(tc.input, tc.expected); len(diff) != 0 {
+				t.Errorf("mismatched sort order (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -171,6 +171,11 @@ func (f *RouterControllerFactory) aggregateEndpointSlice(namespace, name string)
 		fullSet[i] = *eps.DeepCopy()
 	}
 
+	// Make guarantees for all receivers/consumers.
+	sort.SliceStable(fullSet, func(i, j int) bool {
+		return path.Join(fullSet[i].Namespace, fullSet[i].Name) < path.Join(fullSet[j].Namespace, fullSet[j].Name)
+	})
+
 	return fullSet
 }
 

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -34,7 +34,6 @@ import (
 
 const (
 	DefaultResyncInterval = 30 * time.Minute
-	ServiceNameLabel      = "kubernetes.io/service-name"
 	ServiceNameIndex      = "service-name"
 )
 
@@ -144,7 +143,7 @@ func (f *RouterControllerFactory) registerInformerEventHandlers(rc *routercontro
 		f.registerSharedInformerEventHandlers(&discoveryv1beta1.EndpointSlice{}, func(eventType watch.EventType, obj interface{}) {
 			eps := obj.(*discoveryv1beta1.EndpointSlice)
 			if serviceName := endpointSliceServiceName(eps); len(serviceName) == 0 {
-				log.V(4).Info("EndpointSlice has no service name", "namespace", eps.Namespace, "name", eps.Name, "label", ServiceNameLabel)
+				log.V(4).Info("EndpointSlice has no service name", "namespace", eps.Namespace, "name", eps.Name, "label", discoveryv1beta1.LabelServiceName)
 			} else {
 				objMeta := eps.ObjectMeta.DeepCopy()
 				objMeta.Name = serviceName
@@ -393,7 +392,7 @@ func (r routeAge) Less(i, j int) bool {
 }
 
 func endpointSliceServiceName(eps *discoveryv1beta1.EndpointSlice) string {
-	if name, ok := eps.Labels[ServiceNameLabel]; ok && name != "" {
+	if name, ok := eps.Labels[discoveryv1beta1.LabelServiceName]; ok && name != "" {
 		return name
 	}
 	return ""

--- a/pkg/router/controller/factory/factory_endpointslices_test.go
+++ b/pkg/router/controller/factory/factory_endpointslices_test.go
@@ -1,0 +1,408 @@
+package factory_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/google/go-cmp/cmp"
+	routev1 "github.com/openshift/api/route/v1"
+	fakeproject "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1/fake"
+	fakerouterclient "github.com/openshift/client-go/route/clientset/versioned/fake"
+	kapi "k8s.io/api/core/v1"
+	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+	fakekubeclient "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openshift/router/pkg/router"
+	"github.com/openshift/router/pkg/router/controller/factory"
+)
+
+const endpointSliceTestTimeout = 1 * time.Minute
+
+type handleEndpointsEvent struct {
+	eventType watch.EventType
+	endpoints *kapi.Endpoints
+}
+
+type endpointSlicesTestPlugin struct {
+	handleEndpointsCh chan handleEndpointsEvent
+}
+
+// Ensure endpointSlicesTestPlugin is a router.Plugin.
+var _ router.Plugin = (*endpointSlicesTestPlugin)(nil)
+
+func (p *endpointSlicesTestPlugin) HandleRoute(watch.EventType, *routev1.Route) error {
+	return nil
+}
+
+func (p *endpointSlicesTestPlugin) HandleNamespaces(sets.String) error {
+	return nil
+}
+
+func (p endpointSlicesTestPlugin) HandleEndpoints(eventType watch.EventType, endpoints *kapi.Endpoints) error {
+	p.handleEndpointsCh <- handleEndpointsEvent{
+		eventType: eventType,
+		endpoints: endpoints,
+	}
+	return nil
+}
+
+func (p *endpointSlicesTestPlugin) HandleNode(watch.EventType, *kapi.Node) error {
+	return nil
+}
+
+func (p *endpointSlicesTestPlugin) Commit() error {
+	return nil
+}
+
+// int32Ptr returns a pointer to an int32
+func int32Ptr(i int32) *int32 {
+	return &i
+}
+
+// stringPtr returns a pointer to the passed string.
+func stringPtr(s string) *string {
+	return &s
+}
+
+// protocolPtr returns a pointer to the passed protocol.
+func protocolPtr(p kapi.Protocol) *kapi.Protocol {
+	return &p
+}
+
+func newEndpointSliceTestSetup(plugin router.Plugin, initialObjects ...runtime.Object) (*fakekubeclient.Clientset, chan struct{}) {
+	stopCh := make(chan struct{})
+	client := fakekubeclient.NewSimpleClientset(initialObjects...)
+
+	factory.NewDefaultRouterControllerFactory(
+		fakerouterclient.NewSimpleClientset(),
+		&fakeproject.FakeProjects{},
+		client,
+		false, // watch endpoints
+	).Create(plugin, false, stopCh)
+
+	return client, stopCh
+}
+
+func TestEndpointSlicesAdd(t *testing.T) {
+	defer leaktest.CheckTimeout(t, endpointSliceTestTimeout)()
+
+	plugin := &endpointSlicesTestPlugin{
+		handleEndpointsCh: make(chan handleEndpointsEvent),
+	}
+
+	client, stopCh := newEndpointSliceTestSetup(plugin)
+	defer close(stopCh)
+
+	type testCase struct {
+		sliceToAdd              discoveryv1beta1.EndpointSlice
+		expectedServiceName     string
+		expectedEventType       watch.EventType
+		expectedEndpointSubsets []kapi.EndpointSubset
+	}
+
+	testCases := []testCase{{
+		sliceToAdd: discoveryv1beta1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "slice-1",
+				Namespace: "namespace-a",
+				Labels: map[string]string{
+					discoveryv1beta1.LabelServiceName: "service-a",
+				},
+			},
+			AddressType: discoveryv1beta1.AddressTypeIPv4,
+			Endpoints: []discoveryv1beta1.Endpoint{{
+				Addresses: []string{
+					"192.168.0.1",
+					"10.0.0.1",
+					"172.17.10.8",
+				},
+				Hostname: stringPtr("service.com"),
+			}},
+			Ports: []discoveryv1beta1.EndpointPort{{
+				Port: int32Ptr(8080),
+			}, {
+				Name:     stringPtr("https"),
+				Protocol: protocolPtr(kapi.ProtocolTCP),
+				Port:     int32Ptr(443),
+			}, {
+				Name:     stringPtr("http"),
+				Protocol: protocolPtr(kapi.ProtocolTCP),
+				Port:     int32Ptr(80),
+			}},
+		},
+		expectedServiceName: "service-a",
+		expectedEventType:   watch.Modified,
+		expectedEndpointSubsets: []kapi.EndpointSubset{{
+			Addresses: []kapi.EndpointAddress{{
+				IP:       "10.0.0.1",
+				Hostname: "service.com",
+			}, {
+				IP:       "172.17.10.8",
+				Hostname: "service.com",
+			}, {
+				IP:       "192.168.0.1",
+				Hostname: "service.com",
+			}},
+			Ports: []kapi.EndpointPort{{
+				Name:     "http",
+				Port:     80,
+				Protocol: "TCP",
+			}, {
+				Name:     "https",
+				Port:     443,
+				Protocol: "TCP",
+			}, {
+				Port: 8080,
+			}},
+		}},
+	}, {
+		sliceToAdd: discoveryv1beta1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "slice-2",
+				Namespace: "namespace-a",
+				Labels: map[string]string{
+					discoveryv1beta1.LabelServiceName: "service-a",
+				},
+			},
+			AddressType: discoveryv1beta1.AddressTypeIPv4,
+			Endpoints: []discoveryv1beta1.Endpoint{{
+				Addresses: []string{
+					"172.16.10.2",
+					"172.16.10.1",
+				},
+			}},
+			Ports: []discoveryv1beta1.EndpointPort{{
+				Port: int32Ptr(101),
+			}, {
+				Port: int32Ptr(100),
+			}},
+		},
+		expectedServiceName: "service-a",
+		expectedEventType:   watch.Modified,
+		expectedEndpointSubsets: []kapi.EndpointSubset{{
+			Addresses: []kapi.EndpointAddress{{
+				IP:       "10.0.0.1",
+				Hostname: "service.com",
+			}, {
+				IP:       "172.17.10.8",
+				Hostname: "service.com",
+			}, {
+				IP:       "192.168.0.1",
+				Hostname: "service.com",
+			}},
+			Ports: []kapi.EndpointPort{{
+				Name:     "http",
+				Port:     80,
+				Protocol: "TCP",
+			}, {
+				Name:     "https",
+				Port:     443,
+				Protocol: "TCP",
+			}, {
+				Port: 8080,
+			}},
+		}, {
+			Addresses: []kapi.EndpointAddress{{
+				IP: "172.16.10.1",
+			}, {
+				IP: "172.16.10.2",
+			}},
+			Ports: []kapi.EndpointPort{{
+				Port: 100,
+			}, {
+				Port: 101,
+			}},
+		}},
+	}, {
+		sliceToAdd: discoveryv1beta1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "slice-1",
+				Namespace: "namespace-b",
+				Labels: map[string]string{
+					discoveryv1beta1.LabelServiceName: "service-b",
+				},
+			},
+		},
+		expectedServiceName:     "service-b",
+		expectedEventType:       watch.Modified,
+		expectedEndpointSubsets: []kapi.EndpointSubset{{}},
+	}}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			if _, err := client.DiscoveryV1beta1().EndpointSlices(tc.sliceToAdd.Namespace).Create(context.TODO(), &tc.sliceToAdd, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create endpointslice %s: %v", tc.sliceToAdd.Name, err)
+			}
+
+			var event handleEndpointsEvent
+
+			select {
+			case event = <-plugin.handleEndpointsCh:
+			case <-time.After(endpointSliceTestTimeout):
+				t.Fatal("timeout")
+			}
+
+			if event.eventType != tc.expectedEventType {
+				t.Errorf("expected event type %q, got %q", tc.expectedEventType, event.eventType)
+			}
+
+			if event.endpoints.Name != tc.expectedServiceName {
+				t.Errorf("expected service %q, got %q", tc.expectedServiceName, event.endpoints.Name)
+			}
+
+			if diff := cmp.Diff(tc.expectedEndpointSubsets, event.endpoints.Subsets); len(diff) > 0 {
+				t.Errorf("mismatched endpoint subsets (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestEndpointSlicesDelete(t *testing.T) {
+	defer leaktest.CheckTimeout(t, endpointSliceTestTimeout)()
+
+	eps1 := discoveryv1beta1.EndpointSlice{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "endpointslices",
+			APIVersion: "discovery.k8s.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "slice-1",
+			Namespace: "namespace-a",
+			Labels: map[string]string{
+				discoveryv1beta1.LabelServiceName: "service-a",
+			},
+		},
+		AddressType: discoveryv1beta1.AddressTypeIPv4,
+		Endpoints: []discoveryv1beta1.Endpoint{{
+			Addresses: []string{
+				"192.168.0.1",
+				"10.0.0.1",
+				"172.17.10.8",
+			},
+			Hostname: stringPtr("service.com"),
+		}},
+		Ports: []discoveryv1beta1.EndpointPort{{
+			Port: int32Ptr(8080),
+		}, {
+			Name:     stringPtr("https"),
+			Protocol: protocolPtr(kapi.ProtocolTCP),
+			Port:     int32Ptr(443),
+		}, {
+			Name:     stringPtr("http"),
+			Protocol: protocolPtr(kapi.ProtocolTCP),
+			Port:     int32Ptr(80),
+		}},
+	}
+
+	eps2 := discoveryv1beta1.EndpointSlice{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "endpointslices",
+			APIVersion: "discovery.k8s.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "slice-2",
+			Namespace: "namespace-a",
+			Labels: map[string]string{
+				discoveryv1beta1.LabelServiceName: "service-a",
+			},
+		},
+		AddressType: discoveryv1beta1.AddressTypeIPv4,
+		Endpoints: []discoveryv1beta1.Endpoint{{
+			Addresses: []string{
+				"172.16.10.2",
+				"172.16.10.1",
+			},
+		}},
+		Ports: []discoveryv1beta1.EndpointPort{{
+			Port: int32Ptr(101),
+		}, {
+			Port: int32Ptr(100),
+		}},
+	}
+
+	plugin := &endpointSlicesTestPlugin{
+		handleEndpointsCh: make(chan handleEndpointsEvent),
+	}
+
+	client, stopCh := newEndpointSliceTestSetup(plugin)
+	defer close(stopCh)
+
+	for _, eps := range []discoveryv1beta1.EndpointSlice{eps1, eps2} {
+		if _, err := client.DiscoveryV1beta1().EndpointSlices(eps.Namespace).Create(context.TODO(), &eps, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("failed to create endpointslice %s: %v", eps.Name, err)
+		}
+
+		select {
+		case <-plugin.handleEndpointsCh:
+		case <-time.After(endpointSliceTestTimeout):
+			t.Fatal("timeout")
+		}
+	}
+
+	type testCase struct {
+		description             string
+		sliceToDelete           discoveryv1beta1.EndpointSlice
+		expectedEndpointSubsets []kapi.EndpointSubset
+		expectedEventType       watch.EventType
+		expectDeleteError       bool
+	}
+
+	testCases := []testCase{{
+		sliceToDelete: eps1,
+		expectedEndpointSubsets: []kapi.EndpointSubset{{
+			Addresses: []kapi.EndpointAddress{{
+				IP: "172.16.10.1",
+			}, {
+				IP: "172.16.10.2",
+			}},
+			Ports: []kapi.EndpointPort{{
+				Port: 100,
+			}, {
+				Port: 101,
+			}},
+		}},
+		expectedEventType: watch.Modified,
+	}, {
+		sliceToDelete:     eps2,
+		expectedEventType: watch.Deleted,
+	}, {
+		sliceToDelete:     eps1,
+		expectDeleteError: true,
+	}, {
+		sliceToDelete:     eps2,
+		expectDeleteError: true,
+	}}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			if err := client.DiscoveryV1beta1().EndpointSlices(tc.sliceToDelete.Namespace).Delete(context.TODO(), tc.sliceToDelete.Name, metav1.DeleteOptions{}); err != nil {
+				if tc.expectDeleteError {
+					return
+				}
+				t.Fatalf("failed to delete endpointslice %s: %v", eps1.Name, err)
+			}
+
+			var event handleEndpointsEvent
+
+			select {
+			case event = <-plugin.handleEndpointsCh:
+			case <-time.After(endpointSliceTestTimeout):
+				t.Fatal("timeout")
+			}
+
+			if actual := event.eventType; actual != tc.expectedEventType {
+				t.Errorf("expected event type %q, got %q", tc.expectedEventType, actual)
+			}
+
+			if diff := cmp.Diff(tc.expectedEndpointSubsets, event.endpoints.Subsets); len(diff) > 0 {
+				t.Errorf("mismatched endpoint subsets (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -110,7 +110,7 @@ func TestMain(m *testing.M) {
 	plugin = controller.NewHostAdmitter(plugin, routerSelection.RouteAdmissionFunc(), false, false, statusPlugin)
 
 	// Start the controller
-	c := factory.Create(plugin, false)
+	c := factory.Create(plugin, false, wait.NeverStop)
 	c.Run()
 
 	exitCode := m.Run()

--- a/vendor/github.com/fortytw2/leaktest/.travis.yml
+++ b/vendor/github.com/fortytw2/leaktest/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+go:
+ - 1.8
+ - 1.9
+ - "1.10"
+ - "1.11"
+ - tip
+
+script:
+ - go test -v -race -parallel 5 -coverprofile=coverage.txt -covermode=atomic ./
+ - go test github.com/fortytw2/leaktest -run ^TestEmptyLeak$
+
+before_install:
+  - pip install --user codecov
+after_success:
+  - codecov

--- a/vendor/github.com/fortytw2/leaktest/LICENSE
+++ b/vendor/github.com/fortytw2/leaktest/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/fortytw2/leaktest/README.md
+++ b/vendor/github.com/fortytw2/leaktest/README.md
@@ -1,0 +1,64 @@
+## Leaktest [![Build Status](https://travis-ci.org/fortytw2/leaktest.svg?branch=master)](https://travis-ci.org/fortytw2/leaktest) [![codecov](https://codecov.io/gh/fortytw2/leaktest/branch/master/graph/badge.svg)](https://codecov.io/gh/fortytw2/leaktest) [![Sourcegraph](https://sourcegraph.com/github.com/fortytw2/leaktest/-/badge.svg)](https://sourcegraph.com/github.com/fortytw2/leaktest?badge) [![Documentation](https://godoc.org/github.com/fortytw2/gpt?status.svg)](http://godoc.org/github.com/fortytw2/leaktest)
+
+Refactored, tested variant of the goroutine leak detector found in both
+`net/http` tests and the `cockroachdb` source tree.
+
+Takes a snapshot of running goroutines at the start of a test, and at the end -
+compares the two and _voila_. Ignores runtime/sys goroutines. Doesn't play nice
+with `t.Parallel()` right now, but there are plans to do so.
+
+### Installation
+
+Go 1.7+
+
+```
+go get -u github.com/fortytw2/leaktest
+```
+
+Go 1.5/1.6 need to use the tag `v1.0.0`, as newer versions depend on
+`context.Context`.
+
+### Example
+
+These tests fail, because they leak a goroutine
+
+```go
+// Default "Check" will poll for 5 seconds to check that all
+// goroutines are cleaned up
+func TestPool(t *testing.T) {
+    defer leaktest.Check(t)()
+
+    go func() {
+        for {
+            time.Sleep(time.Second)
+        }
+    }()
+}
+
+// Helper function to timeout after X duration
+func TestPoolTimeout(t *testing.T) {
+    defer leaktest.CheckTimeout(t, time.Second)()
+
+    go func() {
+        for {
+            time.Sleep(time.Second)
+        }
+    }()
+}
+
+// Use Go 1.7+ context.Context for cancellation
+func TestPoolContext(t *testing.T) {
+    ctx, _ := context.WithTimeout(context.Background(), time.Second)
+    defer leaktest.CheckContext(ctx, t)()
+
+    go func() {
+        for {
+            time.Sleep(time.Second)
+        }
+    }()
+}
+```
+
+## LICENSE
+
+Same BSD-style as Go, see LICENSE

--- a/vendor/github.com/fortytw2/leaktest/leaktest.go
+++ b/vendor/github.com/fortytw2/leaktest/leaktest.go
@@ -1,0 +1,153 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package leaktest provides tools to detect leaked goroutines in tests.
+// To use it, call "defer leaktest.Check(t)()" at the beginning of each
+// test that may use goroutines.
+// copied out of the cockroachdb source tree with slight modifications to be
+// more re-useable
+package leaktest
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type goroutine struct {
+	id    uint64
+	stack string
+}
+
+type goroutineByID []*goroutine
+
+func (g goroutineByID) Len() int           { return len(g) }
+func (g goroutineByID) Less(i, j int) bool { return g[i].id < g[j].id }
+func (g goroutineByID) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
+
+func interestingGoroutine(g string) (*goroutine, error) {
+	sl := strings.SplitN(g, "\n", 2)
+	if len(sl) != 2 {
+		return nil, fmt.Errorf("error parsing stack: %q", g)
+	}
+	stack := strings.TrimSpace(sl[1])
+	if strings.HasPrefix(stack, "testing.RunTests") {
+		return nil, nil
+	}
+
+	if stack == "" ||
+		// Ignore HTTP keep alives
+		strings.Contains(stack, ").readLoop(") ||
+		strings.Contains(stack, ").writeLoop(") ||
+		// Below are the stacks ignored by the upstream leaktest code.
+		strings.Contains(stack, "testing.Main(") ||
+		strings.Contains(stack, "testing.(*T).Run(") ||
+		strings.Contains(stack, "runtime.goexit") ||
+		strings.Contains(stack, "created by runtime.gc") ||
+		strings.Contains(stack, "interestingGoroutines") ||
+		strings.Contains(stack, "runtime.MHeap_Scavenger") ||
+		strings.Contains(stack, "signal.signal_recv") ||
+		strings.Contains(stack, "sigterm.handler") ||
+		strings.Contains(stack, "runtime_mcall") ||
+		strings.Contains(stack, "goroutine in C code") {
+		return nil, nil
+	}
+
+	// Parse the goroutine's ID from the header line.
+	h := strings.SplitN(sl[0], " ", 3)
+	if len(h) < 3 {
+		return nil, fmt.Errorf("error parsing stack header: %q", sl[0])
+	}
+	id, err := strconv.ParseUint(h[1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing goroutine id: %s", err)
+	}
+
+	return &goroutine{id: id, stack: strings.TrimSpace(g)}, nil
+}
+
+// interestingGoroutines returns all goroutines we care about for the purpose
+// of leak checking. It excludes testing or runtime ones.
+func interestingGoroutines(t ErrorReporter) []*goroutine {
+	buf := make([]byte, 2<<20)
+	buf = buf[:runtime.Stack(buf, true)]
+	var gs []*goroutine
+	for _, g := range strings.Split(string(buf), "\n\n") {
+		gr, err := interestingGoroutine(g)
+		if err != nil {
+			t.Errorf("leaktest: %s", err)
+			continue
+		} else if gr == nil {
+			continue
+		}
+		gs = append(gs, gr)
+	}
+	sort.Sort(goroutineByID(gs))
+	return gs
+}
+
+// ErrorReporter is a tiny subset of a testing.TB to make testing not such a
+// massive pain
+type ErrorReporter interface {
+	Errorf(format string, args ...interface{})
+}
+
+// Check snapshots the currently-running goroutines and returns a
+// function to be run at the end of tests to see whether any
+// goroutines leaked, waiting up to 5 seconds in error conditions
+func Check(t ErrorReporter) func() {
+	return CheckTimeout(t, 5*time.Second)
+}
+
+// CheckTimeout is the same as Check, but with a configurable timeout
+func CheckTimeout(t ErrorReporter, dur time.Duration) func() {
+	ctx, cancel := context.WithCancel(context.Background())
+	fn := CheckContext(ctx, t)
+	return func() {
+		timer := time.AfterFunc(dur, cancel)
+		fn()
+		// Remember to clean up the timer and context
+		timer.Stop()
+		cancel()
+	}
+}
+
+// CheckContext is the same as Check, but uses a context.Context for
+// cancellation and timeout control
+func CheckContext(ctx context.Context, t ErrorReporter) func() {
+	orig := map[uint64]bool{}
+	for _, g := range interestingGoroutines(t) {
+		orig[g.id] = true
+	}
+	return func() {
+		var leaked []string
+		for {
+			select {
+			case <-ctx.Done():
+				t.Errorf("leaktest: timed out checking goroutines")
+			default:
+				leaked = make([]string, 0)
+				for _, g := range interestingGoroutines(t) {
+					if !orig[g.id] {
+						leaked = append(leaked, g.stack)
+					}
+				}
+				if len(leaked) == 0 {
+					return
+				}
+				// don't spin needlessly
+				time.Sleep(time.Millisecond * 50)
+				continue
+			}
+			break
+		}
+		for _, g := range leaked {
+			t.Errorf("leaktest: leaked goroutine: %v", g)
+		}
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -22,6 +22,8 @@ github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
 # github.com/evanphx/json-patch v4.2.0+incompatible
 github.com/evanphx/json-patch
+# github.com/fortytw2/leaktest v1.3.0
+github.com/fortytw2/leaktest
 # github.com/fsnotify/fsnotify v1.4.7
 github.com/fsnotify/fsnotify
 # github.com/getsentry/raven-go v0.2.0


### PR DESCRIPTION
Extends the unit tests to verify the behaviour of adding/deleting endpointslices.

Notable changes:

- Switches the service name label to the upstream definition
- Adds go routines leak checks in the new unit tests
