### PR TITLE
Allow configuring dontlognull/http-ignore-probes

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -142,6 +142,13 @@ defaults
 
   option http-use-htx
 
+{{- if isTrue (env "ROUTER_DONT_LOG_NULL") }}
+  option dontlognull
+{{- end }}
+{{- if isTrue (env "ROUTER_HTTP_IGNORE_PROBES") }}
+  option http-ignore-probes
+{{- end }}
+
 {{ if (gt .StatsPort -1) }}
 listen stats
   bind :{{if (gt .StatsPort 0)}}{{.StatsPort}}{{else}}1936{{end}}


### PR DESCRIPTION
Implement the `ROUTER_DONT_LOG_NULL` and `ROUTER_HTTP_IGNORE_PROBES` environment variables, which control HAProxy's `dontlognull` and `http-ignore-probes` options.

* `images/router/haproxy/conf/haproxy-config.template`: Add `ROUTER_DONT_LOG_NULL` and `ROUTER_HTTP_IGNORE_PROBES`.


----

Related to https://github.com/openshift/enhancements/pull/460.