### PR TITLE
Reload client CA and CRL when updated

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -348,7 +348,7 @@ func (r *templateRouter) watchSecretDir(secPath, outName string) error {
 				}
 				currentRealPath = newRealPath
 
-				log.V(0).Info("got watch event for update", "event", event, "name", outName)
+				log.V(0).Info("got watch event from fsnotify", "operation", event.Op.String(), "path", event.Name)
 				os.Remove(outName)
 				if err := secretToPem(secPath, outName); err != nil {
 					log.Error(err, "failed to update default certificate", "path", outName)

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -354,12 +354,7 @@ func (r *templateRouter) watchSecretDir(secPath, outName string) error {
 					log.Error(err, "failed to update default certificate", "path", outName)
 				}
 
-				r.lock.Lock()
-				r.stateChanged = true
-				r.dynamicallyConfigured = false
-				r.defaultCertificatePath = outName
-				r.lock.Unlock()
-				r.Commit()
+				r.rateLimitedCommitFunction.RegisterChange()
 			case err, ok := <-watcher.Errors:
 				if !ok {
 					log.V(0).Info("fsnotify channel closed")

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -340,7 +340,7 @@ func (r *templateRouter) watchSecretDir(secPath, outName string) error {
 
 				newRealPath, err := filepath.EvalSymlinks(path)
 				if err != nil {
-					log.V(0).Info("watchSecretDir error", "error", err)
+					log.Error(err, "failed to resolve symlink", "path", path)
 					continue
 				}
 				if newRealPath == currentRealPath {
@@ -351,7 +351,7 @@ func (r *templateRouter) watchSecretDir(secPath, outName string) error {
 				log.V(0).Info("got watch event for update", "event", event, "name", outName)
 				os.Remove(outName)
 				if err := secretToPem(secPath, outName); err != nil {
-					log.V(0).Info("failed to update", "name", outName, "error", err)
+					log.Error(err, "failed to update default certificate", "path", outName)
 				}
 
 				r.lock.Lock()
@@ -365,7 +365,7 @@ func (r *templateRouter) watchSecretDir(secPath, outName string) error {
 					log.V(0).Info("fsnotify channel closed")
 					return
 				}
-				log.V(0).Info("got error from fsnotify", "error", err)
+				log.Error(err, "received error from fsnotify")
 			}
 		}
 	}()


### PR DESCRIPTION
#### `watchSecretDir`: Use `log.Error`

* `pkg/router/template/router.go` (`watchSecretDir`): Use `log.Error` instead of `log.Info` when logging errors.


#### `watchSecretDir`: Register change directly

* `pkg/router/template/router.go` (`watchSecretDir`): Simplify by directly registering the change to trigger a router reload.


#### `watchSecretDir`: Improve event logging

* `pkg/router/template/router.go` (`watchSecretDir`): Improve log messages for fsnotify events to indicate that they are coming from fsnotify and to show the operation and file path more clearly.


#### Replace `watchSecretDir` with `watchVolumeMountDir`

* `pkg/router/template/router.go` (`watchSecretDir`): Rename...
(`watchVolumeMountDir`): ...to this.  Factor out the logic specific to the default certificate.  Instead, take a path to a volume mount and a callback function, configure fsnotify to watch the `..data` symlink in the volume mount, and call the function when fsnotify sends an event if the symlink has changed.
(`writeDefaultCert`): Update to use `watchVolumeMountDir`.


#### Reload client CA and CRL when updated

* `pkg/router/template/router.go` (`newTemplateRouter`): Call the new `watchMutualTLSCert` method.
(`watchMutualTLSCert`): New method.  If `ROUTER_MUTUAL_TLS_AUTH_CA` or `ROUTER_MUTUAL_TLS_AUTH_CRL` are set, configure fsnotify watches on the associated volume mount or mounts using `watchVolumeMountDir,` and register the change to trigger a router reload.


----

Related  to https://github.com/openshift/enhancements/pull/462.