### PR TITLE
Bug 1874278: Drop openssl to SECLEVEL=1 in Dockerfile

### DIFF
--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -8,7 +8,8 @@ RUN INSTALL_PKGS="haproxy20 rsyslog procps-ng util-linux" && \
     touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
     setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
     chown -R :0 /var/lib/haproxy && \
-    chmod -R g+w /var/lib/haproxy
+    chmod -R g+w /var/lib/haproxy && \
+    sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
 COPY images/router/haproxy/ /var/lib/haproxy/
 LABEL io.k8s.display-name="OpenShift HAProxy Router" \
       io.k8s.description="This component offers ingress to an OpenShift cluster via Ingress and Route rules." \


### PR DESCRIPTION
Force openssl to use `SECLEVEL=1` to allow for 1024 bit RSA keys to be used in HAProxy for TLS. 

Relevant documentation:
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_security_level.html
https://access.redhat.com/articles/3666211