### PR TITLE
Bug 1752814: Fix decreasing counter metrics when reloading HAProxy

### DIFF
--- a/pkg/router/metrics/haproxy/haproxy.go
+++ b/pkg/router/metrics/haproxy/haproxy.go
@@ -355,9 +355,11 @@ func (e *Exporter) CollectNow() {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
+	now := time.Now()
+
 	e.resetMetrics()
 	e.scrape(true)
-	e.lastScrape = nil
+	e.lastScrape = &now
 }
 
 func fetchHTTP(uri string, timeout time.Duration) func() (io.ReadCloser, error) {

--- a/pkg/router/metrics/haproxy/haproxy_test.go
+++ b/pkg/router/metrics/haproxy/haproxy_test.go
@@ -195,7 +195,6 @@ be_edge_http:openshift-console:downloads,BACKEND,0,0,0,0,1,0,0,0,0,0,,0,0,0,0,UP
 	}
 
 	// expect no scrape due to the interval set by the last gather
-	e.lastScrape = &now
 	f = gatherMetrics(t, r)
 	if e.counterValues[secondConsolePodID][e.counterIndices[connectionsTotalIndex]] != 245 {
 		t.Fatalf("incorrect counter: %#v", e.counterValues[secondConsolePodID])


### PR DESCRIPTION
The HAProxy router [reload process calls](https://github.com/openshift/router/blob/master/pkg/cmd/infra/router/template.go#L539) `CollectNow()` in `pkg/router/metrics/haproxy/haproxy.go`. Currently, `CollectNow()` _does not_ update `e.lastScrape`, which means it is possible for the normal scrape function `Collect(...)` to be called _just after_ `CollectNow()`, but before HAProxy has actually reloaded, since `CollectNow()` essentially "resets" the metrics scrape interval.

The idea in this PR is to have `CollectNow()` set the `e.lastScrape` time, since `CollectNow()` is calling `scrape()` anyways. This will prevent counter metrics from decreasing across reloads since metrics are only saved for reload preservation during `CollectNow()` to minimize memory usage.

