### PR TITLE
Bug 1867186: Add SameSite route annotation

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -546,7 +546,10 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
   
   {{- if not (isTrue (index $cfg.Annotations "haproxy.router.openshift.io/disable_cookies")) }}
   cookie {{firstMatch $cookieNamePattern (index $cfg.Annotations "router.openshift.io/cookie_name") (env "ROUTER_COOKIE_NAME" "") $cfg.RoutingKeyName}} insert indirect nocache httponly
-    {{- if and (matchValues (print $cfg.TLSTermination) "edge" "reencrypt") (ne $cfg.InsecureEdgeTerminationPolicy "Allow") }} secure
+    {{- if and (matchValues (print $cfg.TLSTermination) "edge" "reencrypt") (ne $cfg.InsecureEdgeTerminationPolicy "Allow") }}
+      {{- with $samesite := firstMatch "Lax|Strict|None" (index $cfg.Annotations "router.openshift.io/cookie-same-site") "None" }}
+        {{- ""}} secure attr SameSite={{ $samesite }}
+      {{- end }}
     {{- end }}
   {{- end }}{{/* end disable cookies check */}}
 

--- a/pkg/router/template/configmanager/haproxy/manager.go
+++ b/pkg/router/template/configmanager/haproxy/manager.go
@@ -1105,5 +1105,6 @@ func modAnnotationsList(termination routev1.TLSTerminationType) []string {
 	annotations = append(annotations, "router.openshift.io/cookie_name")
 	annotations = append(annotations, "haproxy.router.openshift.io/hsts_header")
 	annotations = append(annotations, "haproxy.router.openshift.io/rewrite-target")
+	annotations = append(annotations, "router.openshift.io/cookie-same-site")
 	return annotations
 }


### PR DESCRIPTION
Fix to add annotation for same site via route
Usage -> oc annotate route myapp router.openshift.io/cookie-same-site="Lax"|"Strict"|"None"
1. Setting Lax
[miheer@miheer ocp-4-6-samesite]$ oc annotate route myapp router.openshift.io/cookie-same-site="Lax" -n showcase --overwrite
route.route.openshift.io/myapp annotated
[miheer@miheer ocp-4-6-samesite]$ curl -vk https://www.examplesite1.apps.misalunk-rfe600.apacshift.support

< date: Tue, 22 Sep 2020 17:07:06 GMT
* Added cookie 87ab708e9d309ffdd16273918fdaf28c="cdd92fe93ea53dbca50353a813393b52" for domain www.examplesite1.apps.misalunk-rfe600.apacshift.support, path /, expire 0
< set-cookie: 87ab708e9d309ffdd16273918fdaf28c=cdd92fe93ea53dbca50353a813393b52; path=/; HttpOnly; Secure; SameSite=Lax
< cache-control: private
* HTTP/1.0 connection set to keep alive!
< connection: keep-alive
< 
* Connection #0 to host www.examplesite1.apps.misalunk-rfe600.apacshift.support left intact
Hey, we have Flask in a Docker container on 'myapp-74d456c9c4-27vsx'[miheer@miheer ocp-4-6-samesite]$ 

2. Setting Strict
miheer@miheer ocp-4-6-samesite]$ oc annotate route myapp router.openshift.io/cookie-same-site="Strict" -n showcase --overwrite
route.route.openshift.io/myapp annotated
[miheer@miheer ocp-4-6-samesite]$ curl -vk https://www.examplesite1.apps.misalunk-rfe600.apacshift.support

< date: Tue, 22 Sep 2020 17:10:49 GMT
* Added cookie 87ab708e9d309ffdd16273918fdaf28c="cdd92fe93ea53dbca50353a813393b52" for domain www.examplesite1.apps.misalunk-rfe600.apacshift.support, path /, expire 0
< set-cookie: 87ab708e9d309ffdd16273918fdaf28c=cdd92fe93ea53dbca50353a813393b52; path=/; HttpOnly; Secure; SameSite=Strict
< cache-control: private
* HTTP/1.0 connection set to keep alive!
< connection: keep-alive


3. Setting None
curl -vk https://www.examplesite1.apps.misalunk-rfe600.apacshift.support

oc annotate route myapp router.openshift.io/cookie-same-site="None" -n showcase --overwriteplesite1.apps.misalunk-rfe600.apacshift.support
route.route.openshift.io/myapp annotated

< date: Tue, 22 Sep 2020 17:12:25 GMT

Added cookie 87ab708e9d309ffdd16273918fdaf28c="cdd92fe93ea53dbca50353a813393b52" for domain www.examplesite1.apps.misalunk-rfe600.apacshift.support, path /, expire 0
< set-cookie: 87ab708e9d309ffdd16273918fdaf28c=cdd92fe93ea53dbca50353a813393b52; path=/; HttpOnly; Secure; SameSite=None