### PR TITLE
haproxy-config.template: Use power-of-two balancing

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -476,10 +476,10 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
           {{- end }}
         {{- end }}
 
-        {{- with $balanceAlgo := firstMatch $balanceAlgoPattern (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_LOAD_BALANCE_ALGORITHM") }}
+        {{- with $balanceAlgo := firstMatch $balanceAlgoPattern (index $cfg.Annotations "haproxy.router.openshift.io/balance") }}
   balance {{ $balanceAlgo }}
         {{- else }}
-  balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}leastconn{{ end }}
+  balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}{{ firstMatch $balanceAlgoPattern (env "ROUTER_LOAD_BALANCE_ALGORITHM") "leastconn" }}{{ end }}
         {{- end }}
         {{- with $ip_whiteList := firstMatch $cidrListPattern (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist") }}
           {{- if validateHAProxyWhiteList $ip_whiteList }}
@@ -663,10 +663,10 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
 
 # Secure backend, pass through
 backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
-        {{- with $balanceAlgo := firstMatch $balanceAlgoPattern (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME" (env "ROUTER_LOAD_BALANCE_ALGORITHM")) }}
+        {{- with $balanceAlgo := firstMatch $balanceAlgoPattern (index $cfg.Annotations "haproxy.router.openshift.io/balance") }}
   balance {{ $balanceAlgo }}
         {{- else }}
-  balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}source{{ end }}
+  balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}{{ firstMatch $balanceAlgoPattern (env "ROUTER_TCP_BALANCE_SCHEME") (env "ROUTER_LOAD_BALANCE_ALGORITHM") "source" }}{{ end }}
         {{- end }}
         {{- with $ip_whiteList := firstMatch $cidrListPattern (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist") }}
           {{- if validateHAProxyWhiteList $ip_whiteList }}

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -27,6 +27,9 @@
 {{- /* cookie name pattern: */}}
 {{- $cookieNamePattern := `[a-zA-Z0-9_-]+` -}}
 
+{{- /* balanceAlgoPattern matches valid options for the haproxy.router.openshift.io/balance annotation. */}}
+{{- $balanceAlgoPattern := "roundrobin|leastconn|source" -}}
+
 {{- $timeSpecPattern := `[1-9][0-9]*(us|ms|s|m|h|d)?` }}
 
 {{- /* hsts header in response: */}}
@@ -473,7 +476,7 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
           {{- end }}
         {{- end }}
 
-        {{- with $balanceAlgo := firstMatch "roundrobin|leastconn|source" (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_LOAD_BALANCE_ALGORITHM") }}
+        {{- with $balanceAlgo := firstMatch $balanceAlgoPattern (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_LOAD_BALANCE_ALGORITHM") }}
   balance {{ $balanceAlgo }}
         {{- else }}
   balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}leastconn{{ end }}
@@ -660,7 +663,7 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
 
 # Secure backend, pass through
 backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
-        {{- with $balanceAlgo := firstMatch "roundrobin|leastconn|source" (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME" (env "ROUTER_LOAD_BALANCE_ALGORITHM")) }}
+        {{- with $balanceAlgo := firstMatch $balanceAlgoPattern (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME" (env "ROUTER_LOAD_BALANCE_ALGORITHM")) }}
   balance {{ $balanceAlgo }}
         {{- else }}
   balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}source{{ end }}

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -479,7 +479,7 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
         {{- with $balanceAlgo := firstMatch $balanceAlgoPattern (index $cfg.Annotations "haproxy.router.openshift.io/balance") }}
   balance {{ $balanceAlgo }}
         {{- else }}
-  balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}{{ firstMatch $balanceAlgoPattern (env "ROUTER_LOAD_BALANCE_ALGORITHM") "leastconn" }}{{ end }}
+  balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}{{ firstMatch $balanceAlgoPattern (env "ROUTER_LOAD_BALANCE_ALGORITHM") "random" }}{{ end }}
         {{- end }}
         {{- with $ip_whiteList := firstMatch $cidrListPattern (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist") }}
           {{- if validateHAProxyWhiteList $ip_whiteList }}


### PR DESCRIPTION
#### `haproxy-config.template`: Add `$balanceAlgoPattern`

* `images/router/haproxy/conf/haproxy-config.template`: Add a new variable, `balanceAlgoPattern`, with a regular expression that matches the allowed balancing algorithm names, and use it in backend stanzas.


#### `haproxy-config.template`: Use roundrobin if needed

Use the roundrobin balancing algorithm instead of using the algorithm specified by `ROUTER_LOAD_BALANCE_ALGORITHM` or `ROUTER_TCP_BALANCE_SCHEME` if the route has multiple services that specify weights.

Only the roundrobin algorithm properly handles weights, so if the route has multiple services that specify weights, roundrobin should be used unless the route has an explicit annotation that specifies a different algorithm for that specific route.

* `images/router/haproxy/conf/haproxy-config.template`: Use the roundrobin balancing algorithm if the service alias has multiple service units that specify weights and does not have the `haproxy.router.openshift.io/balance` annotation, irrespective of the `ROUTER_LOAD_BALANCE_ALGORITHM` or `ROUTER_TCP_BALANCE_SCHEME` environment variables.


#### `haproxy-config.template`: Use power-of-two balancing

Change the default balancing algorithm for insecure, edge-terminated, and reencrypt routes to "random".

HAProxy 2.0 changes the "random" balancing algorithm to use 2 draws by default, which means the algorithm is effectively the "Power of Two Random Choices" algorithm.  If a route has only 1 or 2 endpoints, power-of-two degenerates to leastconn (the default balancing algorithm before this PR).  If a route has more than 2 endpoints, power-of-two tends to approximate leastconn, and can perform better in scenarios where balancing decision are decentralized (as is the case when multiple routers are balancing to the same set of endpoints) by reducing the likelihood that all HAProxy instances choose the same endpoint.

See https://www.haproxy.com/blog/power-of-two-load-balancing/ for performance comparisons of the random-with-1-draw, roundrobin, power-of-two, and leastconn algorithms.

* `images/router/haproxy/conf/haproxy-config.template`: Modify the `$balanceAlgoPattern` variable to match "random".  Change the default balancing algorithm for insecure, edge-terminated, and reencrypt routes to "random".