### PR TITLE
NE-417: Allow configuring HAProxy header buffer sizes

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -71,8 +71,10 @@ global
 
   # Increase the default request size to be comparable to modern cloud load balancers (ALB: 64kb), affects
   # total memory use when large numbers of connections are open.
-  tune.maxrewrite 8192
-  tune.bufsize 32768
+  # In OCP 4.8, this value is adjustable via the IngressController API.
+  # Cluster administrators are still encouraged to use the default values provided below.
+  tune.maxrewrite {{env "ROUTER_MAX_REWRITE_SIZE" "8192"}}
+  tune.bufsize {{env "ROUTER_BUF_SIZE" "32768"}}
 
   {{- range $idx, $adjustment := .HTTPHeaderNameCaseAdjustments }}
   h1-case-adjust {{ $adjustment.From }} {{ $adjustment.To }}


### PR DESCRIPTION
Allow configuring HAProxy header buffer sizes

Implement the `ROUTER_MAX_REWRITE_SIZE` & `ROUTER_BUF_SIZE` variables to enable control over HAProxy's tune.bufsize and tune.maxrewrite values.

images/router/haproxy/conf/haproxy-config.template: Add `ROUTER_MAX_REWRITE_SIZE` & `ROUTER_BUF_SIZE` env variables to the router template. Use previously fixed values (8192 and 32768 respectively) as defaults.

---

This is in support of https://issues.redhat.com/browse/NE-417.