### PR TITLE
Bug 1885414: haproxy-config.template: Only enable HTX for HTTP/2

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -140,7 +140,7 @@ defaults
   compression type {{env "ROUTER_COMPRESSION_MIME" "text/html text/plain text/css"}}
 {{- end }}
 
-  option http-use-htx
+  {{ if isTrue $router_disable_http2 }}no {{ end }}option http-use-htx
 
 {{ if (gt .StatsPort -1) }}
 listen stats


### PR DESCRIPTION
Enable HTX if HTTP/2 is enabled, and turn off HTX otherwise.  Enabling HTX causes HAProxy to down-case HTTP header names, which breaks non-conformant legacy HTTP clients and servers.

* `images/router/haproxy/conf/haproxy-config.template`: Turn off HTX if HTTP/2 is not enabled.