### PR TITLE
Updating openshift-enterprise-haproxy-router builder & base images to be consistent with ART

### DIFF
--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/4.6:haproxy-router-base
+FROM registry.svc.ci.openshift.org/ocp/4.7:haproxy-router-base
 RUN INSTALL_PKGS="haproxy20 rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
Updating openshift-enterprise-haproxy-router builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/openshift-enterprise-haproxy-router.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/router/pull/197 . Allow it to merge and then run `/test all` on this PR.