### PR TITLE
[release-4.4] Bug 1886215: haproxy-config.template: Turn off HTX

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -127,7 +127,7 @@ defaults
   compression type {{env "ROUTER_COMPRESSION_MIME" "text/html text/plain text/css"}}
 {{- end }}
 
-  option http-use-htx
+  no option http-use-htx
 
 {{ if (gt .StatsPort -1) }}
 listen stats


### PR DESCRIPTION
Turn off HTX.  Enabling HTX causes HAProxy to down-case HTTP header names, which breaks non-conformant legacy HTTP clients and servers.  HTTP/2 requires HTX, but OpenShift 4.4 does not support HTTP/2.

* `images/router/haproxy/conf/haproxy-config.template`: Turn off HTX.


----

This PR supersedes https://github.com/openshift/router/pull/201.