### PR TITLE
Bug 1889863: Fix logging of namespace label selector

### DIFF
--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -251,10 +251,10 @@ func (o *RouterSelection) NewFactory(routeclient routeclientset.Interface, proje
 	factory.ResyncInterval = o.ResyncInterval
 	switch {
 	case o.NamespaceLabels != nil:
-		log.V(0).Info("router is only using routes in namespaces matching labels", "labels", o.NamespaceLabels)
+		log.V(0).Info("router is only using routes in namespaces matching labels", "labels", o.NamespaceLabels.String())
 		factory.NamespaceLabels = o.NamespaceLabels
 	case o.ProjectLabels != nil:
-		log.V(0).Info("router is only using routes in projects matching labels", "labels", o.ProjectLabels)
+		log.V(0).Info("router is only using routes in projects matching labels", "labels", o.ProjectLabels.String())
 		factory.ProjectLabels = o.ProjectLabels
 	case len(factory.Namespace) > 0:
 		log.V(0).Info("router is only using resources in namespace", "namespace", factory.Namespace)


### PR DESCRIPTION
Fix the log output of any configured namespace label selectors on startup.

With `NAMESPACE_LABELS` set to `foo=bar`, before this change, the output looked like this:

    "msg"="router is only using routes in namespaces matching labels"  "labels"=[{}]

After this change, the output looks like this:

    "msg"="router is only using routes in namespaces matching labels"  "labels"="foo=bar"

Most likely the output was broken by the change from glog to logr/zap in https://github.com/openshift/router/pull/47/commits/dc68ebfcbd9fdc600391ebe050228534dd2b07c3.

* `pkg/cmd/infra/router/router.go` (`NewFactory`): Stringify label selectors before logging them.