### PR TITLE
Bug 1892338: metrics: Rework template_router_reload_failure metric

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -98,8 +98,8 @@ type templateRouter struct {
 	stateChanged bool
 	// metricReload tracks reloads
 	metricReload prometheus.Summary
-	// metricReloadFails tracks reload failures
-	metricReloadFails prometheus.Counter
+	// metricReloadFailure tracks reload failures
+	metricReloadFailure prometheus.Gauge
 	// metricWriteConfig tracks writing config
 	metricWriteConfig prometheus.Summary
 	// dynamicConfigManager configures route changes dynamically on the
@@ -201,12 +201,12 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 		Help:      "Measures the time spent reloading the router in seconds.",
 	})
 	prometheus.MustRegister(metricsReload)
-	metricReloadFails := prometheus.NewCounter(prometheus.CounterOpts{
+	metricReloadFailure := prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "template_router",
-		Name:      "reload_fails",
-		Help:      "Tracks the number of failed router reloads",
+		Name:      "reload_failure",
+		Help:      "Metric to track the status of the most recent HAProxy reload",
 	})
-	prometheus.MustRegister(metricReloadFails)
+	prometheus.MustRegister(metricReloadFailure)
 	metricWriteConfig := prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: "template_router",
 		Name:      "write_config_seconds",
@@ -238,9 +238,9 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 		captureHTTPResponseHeaders: cfg.captureHTTPResponseHeaders,
 		captureHTTPCookie:          cfg.captureHTTPCookie,
 
-		metricReload:      metricsReload,
-		metricReloadFails: metricReloadFails,
-		metricWriteConfig: metricWriteConfig,
+		metricReload:        metricsReload,
+		metricReloadFailure: metricReloadFailure,
+		metricWriteConfig:   metricWriteConfig,
 
 		rateLimitedCommitFunction: nil,
 	}
@@ -464,10 +464,13 @@ func (r *templateRouter) commitAndReload() error {
 		if r.dynamicConfigManager != nil {
 			r.dynamicConfigManager.Notify(RouterEventReloadError)
 		}
-		// Increment the failed reload counter when a reload fails
-		r.metricReloadFails.Inc()
+		// Set the metricReloadFailure metric to true when a reload fails.
+		r.metricReloadFailure.Set(float64(1))
 		return err
 	}
+
+	// Set the metricReloadFailure metric to false when a reload succeeds.
+	r.metricReloadFailure.Set(float64(0))
 
 	if r.dynamicConfigManager != nil {
 		r.dynamicConfigManager.Notify(RouterEventReloadEnd)


### PR DESCRIPTION
pkg/router/template/router.go: Replace the current template_router_reload_fails counter metric with a new gauge metric, titled template_router_reload_failure, that tracks the result of the most recent HAProxy reload. If a reload fails, the template_router_reload_failure metric will be set to 1 until a successful reload sets the metric to 0.

Previously, the template_router_reload_fails counter metric would monotonically increase when an HAProxy reload failed. This counter metric is difficult to alert on since an increasing counter essentially gives no indication that the reload failures have been resolved.

This new boolean based metric is trivial to properly alert on since the metric will hold "1" if and only if the router is _not_ successfully reloading.