### PR TITLE
Address gosec G601 issues

### DIFF
--- a/pkg/router/controller/contention.go
+++ b/pkg/router/controller/contention.go
@@ -260,14 +260,12 @@ func ingressConditionTouched(ingress *routev1.RouteIngress) *metav1.Time {
 }
 
 func ingressChanged(oldRoute, route *routev1.Route, routerName string) *routev1.RouteIngress {
-	var ingress *routev1.RouteIngress
 	for i := range route.Status.Ingress {
 		if route.Status.Ingress[i].RouterName == routerName {
-			ingress = &route.Status.Ingress[i]
-			for _, old := range oldRoute.Status.Ingress {
-				if old.RouterName == routerName {
-					if !ingressEqual(ingress, &old) {
-						return ingress
+			for j := range oldRoute.Status.Ingress {
+				if oldRoute.Status.Ingress[j].RouterName == routerName {
+					if !ingressEqual(&route.Status.Ingress[i], &oldRoute.Status.Ingress[j]) {
+						return &route.Status.Ingress[i]
 					}
 					return nil
 				}

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -235,11 +235,11 @@ func recordIngressCondition(route *routev1.Route, name, hostName string, conditi
 func findMostRecentIngress(route *routev1.Route) string {
 	var newest string
 	var recent time.Time
-	for _, ingress := range route.Status.Ingress {
-		if condition := findCondition(&ingress, routev1.RouteAdmitted); condition != nil && condition.LastTransitionTime != nil {
+	for i := range route.Status.Ingress {
+		if condition := findCondition(&route.Status.Ingress[i], routev1.RouteAdmitted); condition != nil && condition.LastTransitionTime != nil {
 			if condition.LastTransitionTime.Time.After(recent) {
 				recent = condition.LastTransitionTime.Time
-				newest = ingress.RouterName
+				newest = route.Status.Ingress[i].RouterName
 			}
 		}
 	}

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -481,6 +481,7 @@ func (r *templateRouter) commitAndReload() error {
 func (r *templateRouter) writeConfig() error {
 	//write out any certificate files that don't exist
 	for k, cfg := range r.state {
+		cfg := cfg // avoid implicit memory aliasing (gosec G601)
 		if err := r.writeCertificates(&cfg); err != nil {
 			return fmt.Errorf("error writing certificates for %s: %v", k, err)
 		}

--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -166,6 +166,7 @@ func backendConfig(name string, cfg ServiceAliasConfig, hascert bool) *haproxyut
 func generateHAProxyCertConfigMap(td templateData) []string {
 	lines := make([]string, 0)
 	for k, cfg := range td.State {
+		cfg := cfg // avoid implicit memory aliasing (gosec G601)
 		hascert := false
 		if len(cfg.Host) > 0 {
 			certKey := generateCertKey(&cfg)


### PR DESCRIPTION
$ gosec -version
Version: 2.5.0
Git tag: v2.5.0
Build date: 2020-10-26T11:52:22Z

On simple inspection the G601 issues from gosec looked innocuous
enough but I decided to clean these up anyway.

For the changes to router.go and template_helper.go I took the
simplest approach of creating a new variable (and copy). I could have
changed everything to be index based but I chose to go with the
smallest change.

PR inspired by https://github.com/openshift/router/issues/208

It still leaves open the question asked in #208 on whether we will run
this tool as during build and/or prior to a release.