### PR TITLE
[release-4.5] Bug 1896914: Back port Clip haproxy.router.openshift.io/timeout annotation values to prevent bricking on upgrade

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -401,7 +401,7 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
       {{- end }}
   tcp-request content reject if !whitelist
     {{- end }}
-    {{- with $value := firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout")}}
+    {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout")) }}
   timeout server  {{$value}}
     {{- end }}
 
@@ -528,7 +528,7 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
       {{- end }}
   tcp-request content reject if !whitelist
     {{- end }}
-    {{- with $value := firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout")}}
+    {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout")) }}
   timeout tunnel  {{$value}}
     {{- end }}
 

--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
 
@@ -21,6 +22,8 @@ import (
 
 const (
 	certConfigMap = "cert_config.map"
+	// max timeout allowable by HAProxy
+	haproxyMaxTimeout = "2147483647ms"
 )
 
 func isTrue(s string) bool {
@@ -275,6 +278,46 @@ func generateHAProxyMap(name string, td templateData) []string {
 	return templateutil.SortMapPaths(lines, `^[^\.]*\.`)
 }
 
+// clipHAProxyTimeoutValue prevents the HAProxy config file
+// from using timeout values specified via the haproxy.router.openshift.io/timeout
+// annotation that exceed the maximum value allowed by HAProxy.
+// Return the parameter string instead of an err in the event that a
+// timeout string value is not parsable as a valid time duration.
+func clipHAProxyTimeoutValue(val string) string {
+	// If the empty string is passed in,
+	// simply return the empty string.
+	if len(val) == 0 {
+		return val
+	}
+	endIndex := len(val) - 1
+	maxTimeout, err := time.ParseDuration(haproxyMaxTimeout)
+	if err != nil {
+		return val
+	}
+	// time.ParseDuration doesn't work with days
+	// despite HAProxy accepting timeouts that specify day units
+	if val[endIndex] == 'd' {
+		days, err := strconv.Atoi(val[:endIndex])
+		if err != nil {
+			return val
+		}
+		if maxTimeout.Hours() < float64(days*24) {
+			log.V(7).Info("Route annotation timeout exceeds maximum allowable by HAProxy, clipping to max")
+			return haproxyMaxTimeout
+		}
+	} else {
+		duration, err := time.ParseDuration(val)
+		if err != nil {
+			return val
+		}
+		if maxTimeout.Milliseconds() < duration.Milliseconds() {
+			log.V(7).Info("Route annotation timeout exceeds maximum allowable by HAProxy, clipping to max")
+			return haproxyMaxTimeout
+		}
+	}
+	return val
+}
+
 var helperFunctions = template.FuncMap{
 	"endpointsForAlias":        endpointsForAlias,        //returns the list of valid endpoints
 	"processEndpointsForAlias": processEndpointsForAlias, //returns the list of valid endpoints after processing them
@@ -297,4 +340,6 @@ var helperFunctions = template.FuncMap{
 	"generateHAProxyMap":           generateHAProxyMap,           //generates a haproxy map content
 	"validateHAProxyWhiteList":     validateHAProxyWhiteList,     //validates a haproxy whitelist (acl) content
 	"generateHAProxyWhiteListFile": generateHAProxyWhiteListFile, //generates a haproxy whitelist file for use in an acl
+
+	"clipHAProxyTimeoutValue": clipHAProxyTimeoutValue, //clips extrodinarily high timeout values to be below the maximum allowed timeout value
 }

--- a/pkg/router/template/template_helper_test.go
+++ b/pkg/router/template/template_helper_test.go
@@ -701,3 +701,41 @@ func TestGetPrimaryAliasKey(t *testing.T) {
 		}
 	}
 }
+
+func TestClipHAProxyTimeoutValue(t *testing.T) {
+	testCases := []struct {
+		value    string
+		expected string
+	}{
+		{
+			value:    "",
+			expected: "",
+		},
+		{
+			value:    "10",
+			expected: "10",
+		},
+		{
+			value:    "10s",
+			expected: "10s",
+		},
+		{
+			value:    "10d",
+			expected: "10d",
+		},
+		{
+			value:    "100d",
+			expected: haproxyMaxTimeout,
+		},
+		{
+			value:    "1000h",
+			expected: haproxyMaxTimeout,
+		},
+	}
+	for _, tc := range testCases {
+		actual := clipHAProxyTimeoutValue(tc.value)
+		if actual != tc.expected {
+			t.Errorf("clipHAProxyTimeoutValue yielded incorrect result: expected %s but got %s", tc.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
This is the 4.5 back port of https://github.com/openshift/router/pull/196

---

This PR adds the function `clipHAProxyTimeoutValue(...)` to `pkg/router/template/template_helper.go` to prevent invalid Route timeout annotations from breaking router reloads. In version 2.x, HAProxy supports a maximum timeout of `2147483647ms`, which is ~24.8 days. `clipHAProxyTimeoutValue` will replace any timeout above the maximum amount with the maximum allowable amount to prevent HAProxy from crashing after upgrades that bump HAProxy 1.8 to 2.x.

This PR also adds unit tests cases for `clipHAProxyTimeoutValue` to verify that it works as intended.