### PR TITLE
Allow configuring HTTP header name case adjustment

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -71,6 +71,10 @@ global
   tune.maxrewrite 8192
   tune.bufsize 32768
 
+  {{- range $idx, $adjustment := .HTTPHeaderNameCaseAdjustments }}
+  h1-case-adjust {{ $adjustment.From }} {{ $adjustment.To }}
+  {{- end }}
+
   # Configure the TLS versions we support
   ssl-default-bind-options ssl-min-ver {{env "SSL_MIN_VERSION" "TLSv1.2"}}
     {{- if ne (env "SSL_MAX_VERSION" "") "" }} ssl-max-ver {{env "SSL_MAX_VERSION"}}{{ end }}
@@ -147,6 +151,9 @@ defaults
 {{- end }}
 {{- if isTrue (env "ROUTER_HTTP_IGNORE_PROBES") }}
   option http-ignore-probes
+{{- end }}
+{{- if .HTTPHeaderNameCaseAdjustments }}
+  option h1-case-adjust-bogus-client
 {{- end }}
 
 {{ if (gt .StatsPort -1) }}
@@ -454,6 +461,12 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
   option forwardfor if-none
     {{- end }}
   {{- end}}
+
+  {{- with $adjustments := $.HTTPHeaderNameCaseAdjustments }}
+    {{- if isTrue (index $cfg.Annotations "haproxy.router.openshift.io/h1-adjust-case") }}
+  option h1-case-adjust-bogus-server
+    {{- end }}
+  {{- end }}
 
     {{- with $balanceAlgo := firstMatch "roundrobin|leastconn|source" (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_LOAD_BALANCE_ALGORITHM") }}
   balance {{ $balanceAlgo }}

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -42,29 +42,30 @@ func newDefaultTemplatePlugin(router RouterInterface, includeUDP bool, lookupSvc
 }
 
 type TemplatePluginConfig struct {
-	WorkingDir                 string
-	TemplatePath               string
-	ReloadScriptPath           string
-	ReloadFn                   func(shutdown bool) error
-	ReloadInterval             time.Duration
-	ReloadCallbacks            []func()
-	DefaultCertificate         string
-	DefaultCertificatePath     string
-	DefaultCertificateDir      string
-	DefaultDestinationCAPath   string
-	StatsPort                  int
-	StatsUsername              string
-	StatsPassword              string
-	IncludeUDP                 bool
-	AllowWildcardRoutes        bool
-	BindPortsAfterSync         bool
-	MaxConnections             string
-	Ciphers                    string
-	StrictSNI                  bool
-	DynamicConfigManager       ConfigManager
-	CaptureHTTPRequestHeaders  []CaptureHTTPHeader
-	CaptureHTTPResponseHeaders []CaptureHTTPHeader
-	CaptureHTTPCookie          *CaptureHTTPCookie
+	WorkingDir                    string
+	TemplatePath                  string
+	ReloadScriptPath              string
+	ReloadFn                      func(shutdown bool) error
+	ReloadInterval                time.Duration
+	ReloadCallbacks               []func()
+	DefaultCertificate            string
+	DefaultCertificatePath        string
+	DefaultCertificateDir         string
+	DefaultDestinationCAPath      string
+	StatsPort                     int
+	StatsUsername                 string
+	StatsPassword                 string
+	IncludeUDP                    bool
+	AllowWildcardRoutes           bool
+	BindPortsAfterSync            bool
+	MaxConnections                string
+	Ciphers                       string
+	StrictSNI                     bool
+	DynamicConfigManager          ConfigManager
+	CaptureHTTPRequestHeaders     []CaptureHTTPHeader
+	CaptureHTTPResponseHeaders    []CaptureHTTPHeader
+	CaptureHTTPCookie             *CaptureHTTPCookie
+	HTTPHeaderNameCaseAdjustments []HTTPHeaderNameCaseAdjustment
 }
 
 // RouterInterface controls the interaction of the plugin with the underlying router implementation
@@ -139,25 +140,26 @@ func NewTemplatePlugin(cfg TemplatePluginConfig, lookupSvc ServiceLookup) (*Temp
 	}
 
 	templateRouterCfg := templateRouterCfg{
-		dir:                        cfg.WorkingDir,
-		templates:                  templates,
-		reloadScriptPath:           cfg.ReloadScriptPath,
-		reloadFn:                   cfg.ReloadFn,
-		reloadInterval:             cfg.ReloadInterval,
-		reloadCallbacks:            cfg.ReloadCallbacks,
-		defaultCertificate:         cfg.DefaultCertificate,
-		defaultCertificatePath:     cfg.DefaultCertificatePath,
-		defaultCertificateDir:      cfg.DefaultCertificateDir,
-		defaultDestinationCAPath:   cfg.DefaultDestinationCAPath,
-		statsUser:                  cfg.StatsUsername,
-		statsPassword:              cfg.StatsPassword,
-		statsPort:                  cfg.StatsPort,
-		allowWildcardRoutes:        cfg.AllowWildcardRoutes,
-		bindPortsAfterSync:         cfg.BindPortsAfterSync,
-		dynamicConfigManager:       cfg.DynamicConfigManager,
-		captureHTTPRequestHeaders:  cfg.CaptureHTTPRequestHeaders,
-		captureHTTPResponseHeaders: cfg.CaptureHTTPResponseHeaders,
-		captureHTTPCookie:          cfg.CaptureHTTPCookie,
+		dir:                           cfg.WorkingDir,
+		templates:                     templates,
+		reloadScriptPath:              cfg.ReloadScriptPath,
+		reloadFn:                      cfg.ReloadFn,
+		reloadInterval:                cfg.ReloadInterval,
+		reloadCallbacks:               cfg.ReloadCallbacks,
+		defaultCertificate:            cfg.DefaultCertificate,
+		defaultCertificatePath:        cfg.DefaultCertificatePath,
+		defaultCertificateDir:         cfg.DefaultCertificateDir,
+		defaultDestinationCAPath:      cfg.DefaultDestinationCAPath,
+		statsUser:                     cfg.StatsUsername,
+		statsPassword:                 cfg.StatsPassword,
+		statsPort:                     cfg.StatsPort,
+		allowWildcardRoutes:           cfg.AllowWildcardRoutes,
+		bindPortsAfterSync:            cfg.BindPortsAfterSync,
+		dynamicConfigManager:          cfg.DynamicConfigManager,
+		captureHTTPRequestHeaders:     cfg.CaptureHTTPRequestHeaders,
+		captureHTTPResponseHeaders:    cfg.CaptureHTTPResponseHeaders,
+		captureHTTPCookie:             cfg.CaptureHTTPCookie,
+		httpHeaderNameCaseAdjustments: cfg.HTTPHeaderNameCaseAdjustments,
 	}
 	router, err := newTemplateRouter(templateRouterCfg)
 	return newDefaultTemplatePlugin(router, cfg.IncludeUDP, lookupSvc), err

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -117,30 +117,33 @@ type templateRouter struct {
 	// captureHTTPCookie specifies an HTTP cookie that should be
 	// captured for logging.
 	captureHTTPCookie *CaptureHTTPCookie
+	// httpHeaderNameCaseAdjustments specifies HTTP header name case adjustments.
+	httpHeaderNameCaseAdjustments []HTTPHeaderNameCaseAdjustment
 }
 
 // templateRouterCfg holds all configuration items required to initialize the template router
 type templateRouterCfg struct {
-	dir                        string
-	templates                  map[string]*template.Template
-	reloadScriptPath           string
-	reloadFn                   func(shutdown bool) error
-	reloadInterval             time.Duration
-	reloadCallbacks            []func()
-	defaultCertificate         string
-	defaultCertificatePath     string
-	defaultCertificateDir      string
-	defaultDestinationCAPath   string
-	statsUser                  string
-	statsPassword              string
-	statsPort                  int
-	allowWildcardRoutes        bool
-	includeUDP                 bool
-	bindPortsAfterSync         bool
-	dynamicConfigManager       ConfigManager
-	captureHTTPRequestHeaders  []CaptureHTTPHeader
-	captureHTTPResponseHeaders []CaptureHTTPHeader
-	captureHTTPCookie          *CaptureHTTPCookie
+	dir                           string
+	templates                     map[string]*template.Template
+	reloadScriptPath              string
+	reloadFn                      func(shutdown bool) error
+	reloadInterval                time.Duration
+	reloadCallbacks               []func()
+	defaultCertificate            string
+	defaultCertificatePath        string
+	defaultCertificateDir         string
+	defaultDestinationCAPath      string
+	statsUser                     string
+	statsPassword                 string
+	statsPort                     int
+	allowWildcardRoutes           bool
+	includeUDP                    bool
+	bindPortsAfterSync            bool
+	dynamicConfigManager          ConfigManager
+	captureHTTPRequestHeaders     []CaptureHTTPHeader
+	captureHTTPResponseHeaders    []CaptureHTTPHeader
+	captureHTTPCookie             *CaptureHTTPCookie
+	httpHeaderNameCaseAdjustments []HTTPHeaderNameCaseAdjustment
 }
 
 // templateConfig is a subset of the templateRouter information that should be passed to the template for generating
@@ -177,6 +180,9 @@ type templateData struct {
 	// CaptureHTTPCookie specifies an HTTP cookie that should be
 	// captured for logging.
 	CaptureHTTPCookie *CaptureHTTPCookie
+	// HTTPHeaderNameCaseAdjustments specifies HTTP header name adjustments
+	// performed on HTTP headers.
+	HTTPHeaderNameCaseAdjustments []HTTPHeaderNameCaseAdjustment
 }
 
 func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
@@ -215,28 +221,29 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 	prometheus.MustRegister(metricWriteConfig)
 
 	router := &templateRouter{
-		dir:                        dir,
-		templates:                  cfg.templates,
-		reloadScriptPath:           cfg.reloadScriptPath,
-		reloadInterval:             cfg.reloadInterval,
-		reloadCallbacks:            cfg.reloadCallbacks,
-		reloadFn:                   cfg.reloadFn,
-		state:                      make(map[ServiceAliasConfigKey]ServiceAliasConfig),
-		serviceUnits:               make(map[ServiceUnitKey]ServiceUnit),
-		certManager:                certManager,
-		defaultCertificate:         cfg.defaultCertificate,
-		defaultCertificatePath:     cfg.defaultCertificatePath,
-		defaultCertificateDir:      cfg.defaultCertificateDir,
-		defaultDestinationCAPath:   cfg.defaultDestinationCAPath,
-		statsUser:                  cfg.statsUser,
-		statsPassword:              cfg.statsPassword,
-		statsPort:                  cfg.statsPort,
-		allowWildcardRoutes:        cfg.allowWildcardRoutes,
-		bindPortsAfterSync:         cfg.bindPortsAfterSync,
-		dynamicConfigManager:       cfg.dynamicConfigManager,
-		captureHTTPRequestHeaders:  cfg.captureHTTPRequestHeaders,
-		captureHTTPResponseHeaders: cfg.captureHTTPResponseHeaders,
-		captureHTTPCookie:          cfg.captureHTTPCookie,
+		dir:                           dir,
+		templates:                     cfg.templates,
+		reloadScriptPath:              cfg.reloadScriptPath,
+		reloadInterval:                cfg.reloadInterval,
+		reloadCallbacks:               cfg.reloadCallbacks,
+		reloadFn:                      cfg.reloadFn,
+		state:                         make(map[ServiceAliasConfigKey]ServiceAliasConfig),
+		serviceUnits:                  make(map[ServiceUnitKey]ServiceUnit),
+		certManager:                   certManager,
+		defaultCertificate:            cfg.defaultCertificate,
+		defaultCertificatePath:        cfg.defaultCertificatePath,
+		defaultCertificateDir:         cfg.defaultCertificateDir,
+		defaultDestinationCAPath:      cfg.defaultDestinationCAPath,
+		statsUser:                     cfg.statsUser,
+		statsPassword:                 cfg.statsPassword,
+		statsPort:                     cfg.statsPort,
+		allowWildcardRoutes:           cfg.allowWildcardRoutes,
+		bindPortsAfterSync:            cfg.bindPortsAfterSync,
+		dynamicConfigManager:          cfg.dynamicConfigManager,
+		captureHTTPRequestHeaders:     cfg.captureHTTPRequestHeaders,
+		captureHTTPResponseHeaders:    cfg.captureHTTPResponseHeaders,
+		captureHTTPCookie:             cfg.captureHTTPCookie,
+		httpHeaderNameCaseAdjustments: cfg.httpHeaderNameCaseAdjustments,
 
 		metricReload:        metricsReload,
 		metricReloadFailure: metricReloadFailure,
@@ -520,20 +527,21 @@ func (r *templateRouter) writeConfig() error {
 		}
 
 		data := templateData{
-			WorkingDir:                 r.dir,
-			State:                      r.state,
-			ServiceUnits:               r.serviceUnits,
-			DefaultCertificate:         r.defaultCertificatePath,
-			DefaultDestinationCA:       r.defaultDestinationCAPath,
-			StatsUser:                  r.statsUser,
-			StatsPassword:              r.statsPassword,
-			StatsPort:                  r.statsPort,
-			BindPorts:                  !r.bindPortsAfterSync || r.synced,
-			DynamicConfigManager:       r.dynamicConfigManager,
-			DisableHTTP2:               disableHTTP2,
-			CaptureHTTPRequestHeaders:  r.captureHTTPRequestHeaders,
-			CaptureHTTPResponseHeaders: r.captureHTTPResponseHeaders,
-			CaptureHTTPCookie:          r.captureHTTPCookie,
+			WorkingDir:                    r.dir,
+			State:                         r.state,
+			ServiceUnits:                  r.serviceUnits,
+			DefaultCertificate:            r.defaultCertificatePath,
+			DefaultDestinationCA:          r.defaultDestinationCAPath,
+			StatsUser:                     r.statsUser,
+			StatsPassword:                 r.statsPassword,
+			StatsPort:                     r.statsPort,
+			BindPorts:                     !r.bindPortsAfterSync || r.synced,
+			DynamicConfigManager:          r.dynamicConfigManager,
+			DisableHTTP2:                  disableHTTP2,
+			CaptureHTTPRequestHeaders:     r.captureHTTPRequestHeaders,
+			CaptureHTTPResponseHeaders:    r.captureHTTPResponseHeaders,
+			CaptureHTTPCookie:             r.captureHTTPCookie,
+			HTTPHeaderNameCaseAdjustments: r.httpHeaderNameCaseAdjustments,
 		}
 		if err := template.Execute(file, data); err != nil {
 			file.Close()

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -261,6 +261,18 @@ const (
 	CookieMatchTypePrefix CookieMatchType = "prefix"
 )
 
+// HTTPHeaderNameCaseAdjustment specifies an HTTP header that should have its
+// capitalization adjusted, and how the header should be adjusted.
+type HTTPHeaderNameCaseAdjustment struct {
+	// From specifies the original header name.  It must be a valid HTTP
+	// header name in lower case.
+	From string
+
+	// To specifies the desired header name.  It should be the same as From
+	// but with the desired capitalization.
+	To string
+}
+
 // RouterEventType indicates the type of event fired by the router.
 type RouterEventType string
 


### PR DESCRIPTION
Implement the `--http-header-name-case-adjustments` flag and `ROUTER_H1_CASE_ADJUST` environment variable to allow specifying case adjustments for HTTP header names.

* `images/router/haproxy/conf/haproxy-config.template`: Add `option h1-case-adjust-bogus-client` and `h1-case-adjust` settings to the global configuration if any adjustments are specified.  Add `option h1-case-adjust-bogus-server` settings to routes that have the `haproxy.router.openshift.io/h1-adjust-case` annotation.
* `pkg/cmd/infra/router/template.go` (`TemplateRouter`): Add `HTTPHeaderNameCaseAdjustmentsString` and `HTTPHeaderNameCaseAdjustment` fields.
(`Bind`): Add `--http-header-name-case-adjustments,` which defaults to the value of the `ROUTER`_H1_CASE_ADJUST environment variable.
(`parseHTTPHeaderNameCaseAdjustments`): New function.  Parse a string value (such as provided with the newly added command-line flag) into a slice of `HTTPHeaderNameCaseAdjustment` values.
(`Complete`): Use `parseHTTPHeaderNameCaseAdjustments` to parse `HTTPHeaderNameCaseAdjustmentsString` into `HTTPHeaderNameCaseAdjustments`.
(`Run`): Specify `HTTPHeaderNameCaseAdjustments` in the plugin config.
* `pkg/router/template/plugin.go` (`TemplatePluginConfig`): Add `HTTPHeaderNameCaseAdjustments` field.
(`NewTemplatePlugin`): Specify `HTTPHeaderNameCaseAdjustments` in the internal template router config.
* `pkg/router/template/router.go` (`templateRouter`, `templateRouterCfg`): Add `httpHeaderNameCaseAdjustments` field.
(`templateData`): Add `HTTPHeaderNameCaseAdjustments` field.
(`newTemplateRouter`): Specify `httpHeaderNameCaseAdjustments` in the template router.
(`writeConfig`): Specify `HTTPHeaderNameCaseAdjustments` in the template parameters.
* `pkg/router/template/types.go` (`HTTPHeaderNameCaseAdjustments`): New type.  Specify an HTTP header name adjustment.