### PR TITLE
Revert "images/router: Update to haproxy22 package"

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy22 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy20 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy22 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy20 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/4.7:haproxy-router-base
-RUN INSTALL_PKGS="haproxy22 rsyslog procps-ng util-linux" && \
+RUN INSTALL_PKGS="haproxy20 rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
This reverts commit 5f30097fb56585065e5c480272f48222497f1e38.

haproxy-2.2.4 will not allow us to disable HTX anymore which means
client/servers will get down-cased headers. As this may break
customers upgrading from OpenShift 4.6 => 4.7 we plan to add an API in
4.7 that will allow customers to specify case adjustment for various
routes. With that knob in place we will target 2.2.x for OpenShift
4.8.

https://github.com/openshift/enhancements/pull/550