### PR TITLE
Bug 1903206: Add unit tests to verify NotReadyAddresses in EndpointSlices

### DIFF
--- a/pkg/router/controller/endpointsubset/converter.go
+++ b/pkg/router/controller/endpointsubset/converter.go
@@ -1,0 +1,63 @@
+package endpointsubset
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/discovery/v1beta1"
+)
+
+// ConvertEndpointSlice converts items to a slice of EndpointSubset's.
+func ConvertEndpointSlice(items []v1beta1.EndpointSlice, addressOrderByFuncs []EndpointAddressLessFunc, portOrderByFuncs []EndpointPortLessFunc) []v1.EndpointSubset {
+	var subsets []v1.EndpointSubset
+
+	for i := range items {
+		var ports []v1.EndpointPort
+		var addresses []v1.EndpointAddress
+		var notReadyAddresses []v1.EndpointAddress
+
+		for j := range items[i].Endpoints {
+			for k := range items[i].Endpoints[j].Addresses {
+				epa := v1.EndpointAddress{
+					IP:        items[i].Endpoints[j].Addresses[k],
+					TargetRef: items[i].Endpoints[j].TargetRef,
+				}
+				if items[i].Endpoints[j].Hostname != nil {
+					epa.Hostname = *items[i].Endpoints[j].Hostname
+				}
+				// A nil Ready condition indicates an unknown state and should be interpreted as ready.
+				if items[i].Endpoints[j].Conditions.Ready != nil && !*items[i].Endpoints[j].Conditions.Ready {
+					notReadyAddresses = append(notReadyAddresses, epa)
+				} else {
+					addresses = append(addresses, epa)
+				}
+			}
+		}
+
+		for j := range items[i].Ports {
+			endpointPort := v1.EndpointPort{
+				AppProtocol: items[i].Ports[j].AppProtocol,
+			}
+			if items[i].Ports[j].Name != nil {
+				endpointPort.Name = *items[i].Ports[j].Name
+			}
+			if items[i].Ports[j].Port != nil {
+				endpointPort.Port = *items[i].Ports[j].Port
+			}
+			if items[i].Ports[j].Protocol != nil {
+				endpointPort.Protocol = *items[i].Ports[j].Protocol
+			}
+			ports = append(ports, endpointPort)
+		}
+
+		SortAddresses(addresses, addressOrderByFuncs)
+		SortAddresses(notReadyAddresses, addressOrderByFuncs)
+		SortPorts(ports, portOrderByFuncs)
+
+		subsets = append(subsets, v1.EndpointSubset{
+			Addresses:         addresses,
+			NotReadyAddresses: notReadyAddresses,
+			Ports:             ports,
+		})
+	}
+
+	return subsets
+}

--- a/pkg/router/controller/endpointsubset/converter_test.go
+++ b/pkg/router/controller/endpointsubset/converter_test.go
@@ -1,0 +1,106 @@
+package endpointsubset_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/openshift/router/pkg/router/controller/endpointsubset"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// int32Ptr returns a pointer to an int32
+func int32Ptr(i int32) *int32 {
+	return &i
+}
+
+// boolPtr returns a pointer to a bool
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+func TestConvertEndpointSlice(t *testing.T) {
+	tests := []struct {
+		name       string
+		want       []v1.EndpointSubset
+		conditions v1beta1.EndpointConditions
+	}{{
+		name: "no Ready condition set, expect zero NotReadyAddresses",
+		conditions: v1beta1.EndpointConditions{
+			Ready: nil,
+		},
+		want: []v1.EndpointSubset{{
+			Addresses: []v1.EndpointAddress{{
+				IP: "192.168.0.1",
+			}},
+			NotReadyAddresses: nil,
+			Ports: []v1.EndpointPort{{
+				Port: 8080,
+			}},
+		}},
+	}, {
+		name: "Ready condition set to true, expect zero NotReadyAddresses",
+		conditions: v1beta1.EndpointConditions{
+			Ready: boolPtr(true),
+		},
+		want: []v1.EndpointSubset{{
+			Addresses: []v1.EndpointAddress{{
+				IP: "192.168.0.1",
+			}},
+			NotReadyAddresses: nil,
+			Ports: []v1.EndpointPort{{
+				Port: 8080,
+			}},
+		}},
+	}, {
+		name: "Ready condition set to false, expect zero ReadyAddresses and non-zero NotReadyAddresses",
+		conditions: v1beta1.EndpointConditions{
+			Ready: boolPtr(false),
+		},
+		want: []v1.EndpointSubset{{
+			Addresses: nil,
+			NotReadyAddresses: []v1.EndpointAddress{{
+				IP: "192.168.0.1",
+			}},
+			Ports: []v1.EndpointPort{{
+				Port: 8080,
+			}},
+		}},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			items := []v1beta1.EndpointSlice{{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "endpointslices",
+					APIVersion: "discovery.k8s.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "slice-1",
+					Namespace: "namespace-a",
+					Labels: map[string]string{
+						v1beta1.LabelServiceName: "service-a",
+					},
+				},
+				AddressType: v1beta1.AddressTypeIPv4,
+				Endpoints: []v1beta1.Endpoint{{
+					Addresses: []string{
+						"192.168.0.1",
+					},
+					Conditions: tc.conditions,
+				}},
+				Ports: []v1beta1.EndpointPort{{
+					Port: int32Ptr(8080),
+				}},
+			}}
+
+			got := endpointsubset.ConvertEndpointSlice(items, endpointsubset.DefaultEndpointAddressOrderByFuncs(), endpointsubset.DefaultEndpointPortOrderByFuncs())
+			if diff := cmp.Diff(got, tc.want); len(diff) != 0 {
+				t.Errorf("ConvertEndpointSlice() failed (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Moved the existing utility function into endpointsubset package. Added
unit tests to assert on EndpointSlices having Ready/NotReady
conditions.

Follow on from https://github.com/openshift/router/pull/229