### PR TITLE
Bug 1905100: Add tunnel-timeout and hard-stop-after options to haproxy template

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -46,6 +46,9 @@
 {{- $pathRewriteTargetPattern := `^/.*$` -}}
 
 global
+{{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (env "ROUTER_HARD_STOP_AFTER")) }}
+  hard-stop-after {{$value}}
+{{- end}}
   maxconn {{env "ROUTER_MAX_CONNECTIONS" "20000"}}
 {{- $threads := env "ROUTER_THREADS" }}
 {{- if ne "" (firstMatch "[1-9][0-9]*" $threads) }}

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -486,6 +486,9 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
     {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout")) }}
   timeout server  {{$value}}
     {{- end }}
+    {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout-tunnel")) }}
+  timeout tunnel  {{$value}}
+    {{- end }}
 
     {{- if isTrue (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections") }}
   stick-table type ip size 100k expire 30s store conn_cur,conn_rate(3s),http_req_rate(10s)
@@ -655,7 +658,7 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
       {{- end }}
   tcp-request content reject if !whitelist
     {{- end }}
-    {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout")) }}
+    {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout-tunnel") (index $cfg.Annotations "haproxy.router.openshift.io/timeout")) }}
   timeout tunnel  {{$value}}
     {{- end }}
 


### PR DESCRIPTION
The existing annotation "haproxy.router.openshift.io/timeout" affects
"timeout server" for cleartext/edge/reencrypt routes and "timeout
tunnel" for passthrough routes.

If your cleartext/edge/reencrypt route is upgraded to become a
tunnel (e.g., a websocket) then your backend will get the global
default ROUTER_DEFAULT_TUNNEL_TIMEOUT for "timeout tunnel" which is
unexpected and possibly a vastly different value given that the
default is 1 hour.

From the haproxy-2.0 docs:

```
   If some long-lived sessions are mixed with short-lived sessions (e.g.
   WebSocket and HTTP), it's worth considering "timeout tunnel", which
   overrides "timeout client" and "timeout server" for tunnels.

   This timeout supersedes both the client and server timeouts once the
   connection becomes a tunnel.
```

This commit enables a "timeout tunnel" value to be emitted for
cleartext/edge/reencrypt routes.

If you annotate a cleartext/edge/reencrypt route with
"haproxy.router.openshift.io/timeout-tunnel=123s" then the backend
will now be written as follows:

```
  backend be_tcp:default:foo-edge
    balance source
    timeout server  <haproxy.router.openshift.io/timeout> (if set)
    timeout tunnel  123s
    ...
```
For passthrough routes this new annotation will override any existing
"haproxy.router.openshift.io/timeout" annotation.

With only "haproxy.router.openshift.io/timeout=10s" set:
```
  backend be_tcp:default:foo-passthrough
    balance source
    timeout tunnel  10s
    ...
```

But if both are set, for example:

```
  "haproxy.router.openshift.io/timeout=10s"
  "haproxy.router.openshift.io/timeout-tunnel=42s"
```
```
  backend be_tcp:default:foo-passthrough
    balance source
    timeout tunnel  42s
    ...
```
And removing the "haproxy.router.openshift.io/timeout-tunnel"
annotation takes us back to:
```
  backend be_tcp:default:foo-passthrough
    balance source
    timeout tunnel  10s
    ...
```
The alternative was not to introduce a new annotation but emit the
same value for both "tunnel server" and "tunnel timeout" for
cleartext/edge/reencrypt routes but that's likely to be a breaking
change given how long the current arrangement has been in effect.

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1905100