### PR TITLE
Bug 1925697: Route admission should not use the override

### DIFF
--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -235,8 +235,7 @@ func ValidateHostName(route *routev1.Route) field.ErrorList {
 	}
 	hostPath := field.NewPath("spec.host")
 
-	lenient, _ := route.Annotations[routev1.AllowNonDNSCompliantHostAnnotation]
-	result = routeapi.ValidateHost(route.Spec.Host, lenient, hostPath)
+	result = routeapi.ValidateHost(route.Spec.Host, "false", hostPath)
 
 	return result
 }

--- a/pkg/router/controller/unique_host_test.go
+++ b/pkg/router/controller/unique_host_test.go
@@ -60,7 +60,7 @@ func TestValidateHostName(t *testing.T) {
 			expectedErrors: true,
 		},
 		{
-			name: "invalid-host-64-chars-label-can-be-overridden",
+			name: "invalid-host-64-chars-label-cannot-be-overridden",
 			route: &routev1.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -71,7 +71,7 @@ func TestValidateHostName(t *testing.T) {
 					Host: "name-namespace-1234567890-1234567890-1234567890-1234567890-12345.example.test",
 				},
 			},
-			expectedErrors: false,
+			expectedErrors: true,
 		},
 		{
 			name: "valid-name-253-chars",
@@ -115,7 +115,7 @@ func TestValidateHostName(t *testing.T) {
 			expectedErrors: true,
 		},
 		{
-			name: "invalid-name-one-label-can-be-overridden",
+			name: "invalid-name-one-label-cannot-be-overridden",
 			route: &routev1.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -126,7 +126,7 @@ func TestValidateHostName(t *testing.T) {
 					Host: "org",
 				},
 			},
-			expectedErrors: false,
+			expectedErrors: true,
 		},
 		{
 			name: "invalid-name-asterisk",


### PR DESCRIPTION
The override annotation was supposed to allow a route to be created, but not admitted, if it had an invalid host name.  However, use of the override now allows the route to be admitted with an invalid host name.  The route should not be admitted.
