### PR TITLE
template: Drop http-use-htx option

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -147,8 +147,6 @@ defaults
   compression type {{env "ROUTER_COMPRESSION_MIME" "text/html text/plain text/css"}}
 {{- end }}
 
-  {{ if isTrue $router_disable_http2 }}no {{ end }}option http-use-htx
-
 {{- if isTrue (env "ROUTER_DONT_LOG_NULL") }}
   option dontlognull
 {{- end }}


### PR DESCRIPTION
Commit 8580700 bumped the HAProxy version of the router
to v2.2. In HAProxy 2.2, the `http-use-htx` option is deprecated.

Commit da09224 added configurable HTTP header case names to the router.
With commits da09224 and 8580700 in place, we can safely remove the
`http-use-htx` option (and thus silence any HAProxy warnings about it's
deprecation).