### PR TITLE
Add some TLS/SSL header for Tomcat SSL Valve

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -334,6 +334,11 @@ frontend fe_sni
   http-request set-header X-SSL-Client-NotBefore %{+Q}[ssl_c_notbefore]
   http-request set-header X-SSL-Client-NotAfter  %{+Q}[ssl_c_notafter]
   http-request set-header X-SSL-Client-DER       %{+Q}[ssl_c_der,base64]
+  # For Tomcat SSL Valve
+  http-request set-header X-SSL-Cipher           %{+Q}[ssl_fc_cipher] 
+  http-request set-header X-SSL-Session-ID       %{+Q}[ssl_fc_session_id,hex]
+  http-request set-header X-SSL-Algo-KeySize     %{+Q}[ssl_fc_alg_keysize]
+  http-request add-header X-SSL-Client-Cert -----BEGIN\ CERTIFICATE-----\ %[ssl_c_der,base64]\ -----END\ CERTIFICATE-----\ # don't forget last space
   {{- end }}
 
   # map to backend


### PR DESCRIPTION
To be able to send the TLS client information to tomcat via [SSL Valve](http://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#SSL_Valve) are some more TLS Header necessary.

This PR adds that header.
```
  # For Tomcat SSL Valve
  http-request set-header X-SSL-Cipher           %{+Q}[ssl_fc_cipher] 
  http-request set-header X-SSL-Session-ID       %{+Q}[ssl_fc_session_id,hex]
  http-request set-header X-SSL-Algo-KeySize     %{+Q}[ssl_fc_alg_keysize]
  http-request add-header X-SSL-Client-Cert -----BEGIN\ CERTIFICATE-----\ %[ssl_c_der,base64]\ -----END\ CERTIFICATE-----\ # don't forget last space
```