### PR TITLE
Bug 1909906: Exit gracefully if metrics listener fails

### DIFF
--- a/pkg/router/shutdown/shutdown.go
+++ b/pkg/router/shutdown/shutdown.go
@@ -27,3 +27,12 @@ func SetupSignalHandler() <-chan struct{} {
 
 	return stop
 }
+
+// RequestShutdown triggers shutdown by sending the shutdown handler a fake
+// signal.
+func RequestShutdown() {
+	select {
+	case shutdownHandler <- shutdownSignals[0]:
+	default:
+	}
+}


### PR DESCRIPTION
Before this PR, the metrics listener code panicked on errors.  This PR changes the listener code to log the error and shut down the router gracefully when an error is encountered.

* `pkg/router/shutdown/shutdown.go` (`RequestShutdown`): New function.  Trigger shutdown by sending a the shutdown handler a fake signal.
* `pkg/router/metrics/metrics.go` (`Listen`): Log errors, and use the new `RequestShutdown` function to initiate graceful shutdown if the metrics listener fails, instead of panicking on errors.