### PR TITLE
DO NOT MERGE: Hard code header buffer sizes

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -71,8 +71,8 @@ global
 
   # Increase the default request size to be comparable to modern cloud load balancers (ALB: 64kb), affects
   # total memory use when large numbers of connections are open.
-  tune.maxrewrite 8192
-  tune.bufsize 32768
+  tune.maxrewrite 4096
+  tune.bufsize 16384
 
   {{- range $idx, $adjustment := .HTTPHeaderNameCaseAdjustments }}
   h1-case-adjust {{ $adjustment.From }} {{ $adjustment.To }}


### PR DESCRIPTION
testing out absolute bare minimum header buffer sizes for an ingress controller (namely the default IC).