### PR TITLE
Bug 1937972: router/template: Cache compiled regular expressions

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -453,6 +453,7 @@ func (r *templateRouter) commitAndReload() error {
 		reloadStart := time.Now()
 		err := r.writeConfig()
 		r.metricWriteConfig.Observe(float64(time.Now().Sub(reloadStart)) / float64(time.Second))
+		log.V(4).Info("writeConfig", "duration", time.Now().Sub(reloadStart).String())
 		return err
 	}(); err != nil {
 		return err


### PR DESCRIPTION
This is an optimisation that caches compiled regular expressions.

When the template is written calls to `matchString` and `firstMatch`
would recompile the regular expression on every call. When you are
processing ~13,000 routes the time to compile on each invocation becomes
significant. This change brings a reduction of 60% when processing and
writing `haproxy.config`.


```console
router.go:456] template "msg"="writeConfig"  "duration"="10.663160501s"
router.go:456] template "msg"="writeConfig"  "duration"="10.328840858s"
router.go:456] template "msg"="writeConfig"  "duration"="10.762876672s"
```

And if we cache the REs:

```console
template "msg"="writeConfig"  "duration"="3.659229627s"
template "msg"="writeConfig"  "duration"="3.718457818s"
template "msg"="writeConfig"  "duration"="3.672131941s"
```

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1929821