### PR TITLE
haproxy-config.template: Re-indent.

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -47,21 +47,21 @@
 
 global
 {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (env "ROUTER_HARD_STOP_AFTER")) }}
-  hard-stop-after {{$value}}
-{{- end}}
-  maxconn {{env "ROUTER_MAX_CONNECTIONS" "20000"}}
+  hard-stop-after {{ $value }}
+{{- end }}
+  maxconn {{ env "ROUTER_MAX_CONNECTIONS" "20000" }}
 {{- $threads := env "ROUTER_THREADS" }}
 {{- if ne "" (firstMatch "[1-9][0-9]*" $threads) }}
   nbthread {{ $threads }}
-{{-  end }}
+{{- end }}
 
 
 
   daemon
 {{- with (env "ROUTER_SYSLOG_ADDRESS") }}
-  log {{.}} {{env "ROUTER_LOG_FACILITY" "local1"}} {{env "ROUTER_LOG_LEVEL" "warning"}}
+  log {{ . }} {{ env "ROUTER_LOG_FACILITY" "local1" }} {{ env "ROUTER_LOG_LEVEL" "warning" }}
   log-send-hostname
-{{- end}}
+{{- end }}
   ca-base /etc/ssl
   crt-base /etc/ssl
   # TODO: Check if we can get reload to be faster by saving server state.
@@ -73,58 +73,58 @@ global
   # total memory use when large numbers of connections are open.
   # In OCP 4.8, this value is adjustable via the IngressController API.
   # Cluster administrators are still encouraged to use the default values provided below.
-  tune.maxrewrite {{env "ROUTER_MAX_REWRITE_SIZE" "8192"}}
-  tune.bufsize {{env "ROUTER_BUF_SIZE" "32768"}}
+  tune.maxrewrite {{ env "ROUTER_MAX_REWRITE_SIZE" "8192" }}
+  tune.bufsize {{ env "ROUTER_BUF_SIZE" "32768" }}
 
-  {{- range $idx, $adjustment := .HTTPHeaderNameCaseAdjustments }}
+{{- range $idx, $adjustment := .HTTPHeaderNameCaseAdjustments }}
   h1-case-adjust {{ $adjustment.From }} {{ $adjustment.To }}
-  {{- end }}
+{{- end }}
 
   # Configure the TLS versions we support
-  ssl-default-bind-options ssl-min-ver {{env "SSL_MIN_VERSION" "TLSv1.2"}}
-    {{- if ne (env "SSL_MAX_VERSION" "") "" }} ssl-max-ver {{env "SSL_MAX_VERSION"}}{{ end }}
+  ssl-default-bind-options ssl-min-ver {{ env "SSL_MIN_VERSION" "TLSv1.2" }}
+{{- if ne (env "SSL_MAX_VERSION" "") "" }} ssl-max-ver {{env "SSL_MAX_VERSION" }}{{ end }}
 
 # The default cipher suite can be selected from the three sets recommended by https://wiki.mozilla.org/Security/Server_Side_TLS,
 # or the user can provide one using the ROUTER_CIPHERS environment variable.
 # By default when a cipher set is not provided, intermediate is used.
-{{- if eq (env "ROUTER_CIPHERS" "intermediate") "modern" }}
+  {{- if eq (env "ROUTER_CIPHERS" "intermediate") "modern" }}
   # Modern cipher suite (no legacy browser support) from https://wiki.mozilla.org/Security/Server_Side_TLS
   tune.ssl.default-dh-param 2048
   ssl-default-bind-ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
-{{ else }}
+  {{ else }}
 
-  {{- if eq (env "ROUTER_CIPHERS" "intermediate") "intermediate" }}
+    {{- if eq (env "ROUTER_CIPHERS" "intermediate") "intermediate" }}
   # Intermediate cipher suite (default) from https://wiki.mozilla.org/Security/Server_Side_TLS
   tune.ssl.default-dh-param 2048
   ssl-default-bind-ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
-  {{ else }}
+    {{ else }}
 
-    {{- if eq (env "ROUTER_CIPHERS" "intermediate") "old" }}
+      {{- if eq (env "ROUTER_CIPHERS" "intermediate") "old" }}
 
   # Old cipher suite (maximum compatibility but insecure) from https://wiki.mozilla.org/Security/Server_Side_TLS
   tune.ssl.default-dh-param 1024
   ssl-default-bind-ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:DES-CBC3-SHA:HIGH:SEED:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!RSAPSK:!aDH:!aECDH:!EDH-DSS-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA:!SRP
 
-    {{- else }}
+      {{- else }}
   # user provided list of ciphers (Colon separated list as seen above)
   # the env default is not used here since we can't get here with empty ROUTER_CIPHERS
   tune.ssl.default-dh-param 2048
-  ssl-default-bind-ciphers {{env "ROUTER_CIPHERS" "ECDHE-ECDSA-CHACHA20-POLY1305"}}
+  ssl-default-bind-ciphers {{ env "ROUTER_CIPHERS" "ECDHE-ECDSA-CHACHA20-POLY1305" }}
+      {{- end }}
     {{- end }}
   {{- end }}
-{{- end }}
 
 defaults
-  maxconn {{env "ROUTER_MAX_CONNECTIONS" "20000"}}
+  maxconn {{ env "ROUTER_MAX_CONNECTIONS" "20000" }}
 
-{{- if ne (env "ROUTER_SYSLOG_ADDRESS") "" }}
-  {{- if ne (env "ROUTER_SYSLOG_FORMAT") "" }}
-  log-format {{env "ROUTER_SYSLOG_FORMAT"}}
-  {{- else }}
+  {{- if ne (env "ROUTER_SYSLOG_ADDRESS") "" }}
+    {{- if ne (env "ROUTER_SYSLOG_FORMAT") "" }}
+  log-format {{ env "ROUTER_SYSLOG_FORMAT" }}
+    {{- else }}
   option httplog
-  {{- end }}
+    {{- end }}
   log global
-{{- end }}
+  {{- end }}
 
   # To configure custom default errors, you can either uncomment the
   # line below (server ... 127.0.0.1:8080) and point it to your custom
@@ -133,78 +133,78 @@ defaults
   # server openshift_backend 127.0.0.1:8080
   errorfile 503 /var/lib/haproxy/conf/error-page-503.http
 
-  timeout connect {{firstMatch $timeSpecPattern (env "ROUTER_DEFAULT_CONNECT_TIMEOUT") "5s"}}
-  timeout client {{firstMatch $timeSpecPattern (env "ROUTER_DEFAULT_CLIENT_TIMEOUT") "30s"}}
-  timeout client-fin {{firstMatch $timeSpecPattern (env "ROUTER_CLIENT_FIN_TIMEOUT") "1s"}}
-  timeout server {{firstMatch $timeSpecPattern (env "ROUTER_DEFAULT_SERVER_TIMEOUT") "30s"}}
-  timeout server-fin {{firstMatch $timeSpecPattern (env "ROUTER_DEFAULT_SERVER_FIN_TIMEOUT") "1s"}}
-  timeout http-request {{firstMatch $timeSpecPattern (env "ROUTER_SLOWLORIS_TIMEOUT") "10s" }}
-  timeout http-keep-alive {{firstMatch $timeSpecPattern (env "ROUTER_SLOWLORIS_HTTP_KEEPALIVE") "300s" }}
+  timeout connect {{ firstMatch $timeSpecPattern (env "ROUTER_DEFAULT_CONNECT_TIMEOUT") "5s" }}
+  timeout client {{ firstMatch $timeSpecPattern (env "ROUTER_DEFAULT_CLIENT_TIMEOUT") "30s" }}
+  timeout client-fin {{ firstMatch $timeSpecPattern (env "ROUTER_CLIENT_FIN_TIMEOUT") "1s" }}
+  timeout server {{ firstMatch $timeSpecPattern (env "ROUTER_DEFAULT_SERVER_TIMEOUT") "30s" }}
+  timeout server-fin {{ firstMatch $timeSpecPattern (env "ROUTER_DEFAULT_SERVER_FIN_TIMEOUT") "1s" }}
+  timeout http-request {{ firstMatch $timeSpecPattern (env "ROUTER_SLOWLORIS_TIMEOUT") "10s" }}
+  timeout http-keep-alive {{ firstMatch $timeSpecPattern (env "ROUTER_SLOWLORIS_HTTP_KEEPALIVE") "300s" }}
 
   # Long timeout for WebSocket connections.
-  timeout tunnel {{firstMatch $timeSpecPattern (env "ROUTER_DEFAULT_TUNNEL_TIMEOUT") "1h" }}
+  timeout tunnel {{ firstMatch $timeSpecPattern (env "ROUTER_DEFAULT_TUNNEL_TIMEOUT") "1h" }}
 
-{{- if isTrue (env "ROUTER_ENABLE_COMPRESSION") }}
+  {{- if isTrue (env "ROUTER_ENABLE_COMPRESSION") }}
   compression algo gzip
-  compression type {{env "ROUTER_COMPRESSION_MIME" "text/html text/plain text/css"}}
-{{- end }}
+  compression type {{ env "ROUTER_COMPRESSION_MIME" "text/html text/plain text/css" }}
+  {{- end }}
 
-{{- if isTrue (env "ROUTER_DONT_LOG_NULL") }}
+  {{- if isTrue (env "ROUTER_DONT_LOG_NULL") }}
   option dontlognull
-{{- end }}
-{{- if isTrue (env "ROUTER_HTTP_IGNORE_PROBES") }}
+  {{- end }}
+  {{- if isTrue (env "ROUTER_HTTP_IGNORE_PROBES") }}
   option http-ignore-probes
-{{- end }}
-{{- if .HTTPHeaderNameCaseAdjustments }}
+  {{- end }}
+  {{- if .HTTPHeaderNameCaseAdjustments }}
   option h1-case-adjust-bogus-client
-{{- end }}
+  {{- end }}
 
-{{ if (gt .StatsPort -1) }}
+  {{ if (gt .StatsPort -1) }}
 listen stats
-  bind :{{if (gt .StatsPort 0)}}{{.StatsPort}}{{else}}1936{{end}}
+  bind :{{ if (gt .StatsPort 0) }}{{ .StatsPort }}{{ else }}1936{{ end }}
   mode http
   # Health check monitoring uri.
   monitor-uri /healthz
 
-{{- if and (and (ne .StatsUser "") (ne .StatsPassword "")) (gt .StatsPort 0) }}
+    {{- if and (and (ne .StatsUser "") (ne .StatsPassword "")) (gt .StatsPort 0) }}
   # Add your custom health check monitoring failure condition here.
   # monitor fail if <condition>
   stats enable
   stats hide-version
   stats realm Haproxy\ Statistics
   stats uri /
-  stats auth {{.StatsUser}}:{{.StatsPassword}}
-{{- end }}
-{{- end }}
+  stats auth {{ .StatsUser }}:{{ .StatsPassword }}
+    {{- end }}
+  {{- end }}
 
-{{ if .BindPorts -}}
+  {{ if .BindPorts -}}
 frontend public
     {{ if eq "v4v6" $router_ip_v4_v6_mode }}
-  bind :{{env "ROUTER_SERVICE_HTTP_PORT" "80"}}
-  bind :::{{env "ROUTER_SERVICE_HTTP_PORT" "80"}} v6only
+  bind :{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }}
+  bind :::{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }} v6only
     {{- else if eq "v6" $router_ip_v4_v6_mode }}
-  bind :::{{env "ROUTER_SERVICE_HTTP_PORT" "80"}} v6only
+  bind :::{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }} v6only
     {{- else }}
-  bind :{{env "ROUTER_SERVICE_HTTP_PORT" "80"}}
+  bind :{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }}
     {{- end }}
-    {{- if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
+  {{- if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
   mode http
   tcp-request inspect-delay 5s
   tcp-request content accept if HTTP
 
-  {{- if (eq .StatsPort -1) }}
+    {{- if (eq .StatsPort -1) }}
   monitor-uri /_______internal_router_healthz
-  {{- end }}
+    {{- end }}
 
-  {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
+    {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
   capture request header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
-  {{- end }}
-  {{- range $idx, $captureHeader := .CaptureHTTPResponseHeaders }}
+    {{- end }}
+    {{- range $idx, $captureHeader := .CaptureHTTPResponseHeaders }}
   capture response header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
-  {{- end }}
-  {{- with $captureCookie := .CaptureHTTPCookie }}
+    {{- end }}
+    {{- with $captureCookie := .CaptureHTTPCookie }}
   capture cookie {{ $captureCookie.Name }}{{ if eq $captureCookie.MatchType "exact" }}={{ end }} len {{ $captureCookie.MaxLength }}
-  {{- end }}
+    {{- end }}
 
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
@@ -213,10 +213,10 @@ frontend public
   # before matching, or any requests containing uppercase characters will never match.
   http-request set-header Host %[req.hdr(Host),lower]
 
-  {{- if and (ne (env "ROUTER_UNIQUE_ID_FORMAT") "") (ne (env "ROUTER_UNIQUE_ID_HEADER_NAME") "") }}
+    {{- if and (ne (env "ROUTER_UNIQUE_ID_FORMAT") "") (ne (env "ROUTER_UNIQUE_ID_HEADER_NAME") "") }}
   unique-id-format {{ env "ROUTER_UNIQUE_ID_FORMAT" }}
   unique-id-header {{ env "ROUTER_UNIQUE_ID_HEADER_NAME" }}
-  {{- end }}
+    {{- end }}
 
   # check if we need to redirect/force using https.
   acl secure_redirect base,map_reg(/var/lib/haproxy/conf/os_route_http_redirect.map) -m found
@@ -230,18 +230,18 @@ frontend public
 # determined by the next backend in the chain which may be an app backend (passthrough termination) or a backend
 # that terminates encryption in this router (edge)
 frontend public_ssl
-    {{- if ne (env "ROUTER_SYSLOG_ADDRESS") ""}}
+    {{- if ne (env "ROUTER_SYSLOG_ADDRESS") "" }}
   option tcplog
     {{- end }}
     {{ if eq "v4v6" $router_ip_v4_v6_mode }}
-  bind :{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}}
-  bind :::{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}} v6only
+  bind :{{ env "ROUTER_SERVICE_HTTPS_PORT" "443" }}
+  bind :::{{ env "ROUTER_SERVICE_HTTPS_PORT" "443" }} v6only
     {{- else if eq "v6" $router_ip_v4_v6_mode }}
-  bind :::{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}} v6only
+  bind :::{{ env "ROUTER_SERVICE_HTTPS_PORT" "443" }} v6only
     {{- else }}
-  bind :{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}}
+  bind :{{ env "ROUTER_SERVICE_HTTPS_PORT" "443" }}
     {{- end }}
-    {{- if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
+  {{- if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
   tcp-request  inspect-delay 5s
   tcp-request content accept if { req_ssl_hello_type 1 }
 
@@ -270,30 +270,30 @@ frontend public_ssl
 # traffic
 ##########################################################################
 backend be_sni
-  server fe_sni 127.0.0.1:{{env "ROUTER_SERVICE_SNI_PORT" "10444"}} weight 1 send-proxy
+  server fe_sni 127.0.0.1:{{ env "ROUTER_SERVICE_SNI_PORT" "10444" }} weight 1 send-proxy
 
 frontend fe_sni
   # terminate ssl on edge
-  bind 127.0.0.1:{{env "ROUTER_SERVICE_SNI_PORT" "10444"}} ssl
-    {{- if isTrue (env "ROUTER_STRICT_SNI") }} strict-sni {{ end }}
-    {{- ""}} crt {{firstMatch ".+" .DefaultCertificate "/var/lib/haproxy/conf/default_pub_keys.pem"}}
-    {{- ""}} crt-list /var/lib/haproxy/conf/cert_config.map accept-proxy
+  bind 127.0.0.1:{{ env "ROUTER_SERVICE_SNI_PORT" "10444" }} ssl
+  {{- if isTrue (env "ROUTER_STRICT_SNI") }} strict-sni {{ end }}
+    {{- "" }} crt {{firstMatch ".+" .DefaultCertificate "/var/lib/haproxy/conf/default_pub_keys.pem" }}
+    {{- "" }} crt-list /var/lib/haproxy/conf/cert_config.map accept-proxy
     {{- with (env "ROUTER_MUTUAL_TLS_AUTH") }}
-      {{- ""}} verify {{.}}
-      {{- with (env "ROUTER_MUTUAL_TLS_AUTH_CA") }} ca-file {{.}} {{ else }} ca-file /etc/ssl/certs/ca-bundle.trust.crt {{ end }}
-      {{- with (env "ROUTER_MUTUAL_TLS_AUTH_CRL") }} crl-file {{.}} {{ end }}
+      {{- "" }} verify {{. }}
+    {{- with (env "ROUTER_MUTUAL_TLS_AUTH_CA") }} ca-file {{. }} {{ else }} ca-file /etc/ssl/certs/ca-bundle.trust.crt {{ end }}
+    {{- with (env "ROUTER_MUTUAL_TLS_AUTH_CRL") }} crl-file {{. }} {{ end }}
     {{- end }}
   mode http
 
-  {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
+    {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
   capture request header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
-  {{- end }}
-  {{- range $idx, $captureHeader := .CaptureHTTPResponseHeaders }}
+    {{- end }}
+    {{- range $idx, $captureHeader := .CaptureHTTPResponseHeaders }}
   capture response header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
-  {{- end }}
-  {{- with $captureCookie := .CaptureHTTPCookie }}
+    {{- end }}
+    {{- with $captureCookie := .CaptureHTTPCookie }}
   capture cookie {{ $captureCookie.Name }}{{ if eq $captureCookie.MatchType "exact" }}={{ end }} len {{ $captureCookie.MaxLength }}
-  {{- end }}
+    {{- end }}
 
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
@@ -302,13 +302,13 @@ frontend fe_sni
   # before matching, or any requests containing uppercase characters will never match.
   http-request set-header Host %[req.hdr(Host),lower]
 
-  {{- if and (ne (env "ROUTER_UNIQUE_ID_FORMAT") "") (ne (env "ROUTER_UNIQUE_ID_HEADER_NAME") "") }}
+    {{- if and (ne (env "ROUTER_UNIQUE_ID_FORMAT") "") (ne (env "ROUTER_UNIQUE_ID_HEADER_NAME") "") }}
   unique-id-format {{ env "ROUTER_UNIQUE_ID_FORMAT" }}
   unique-id-header {{ env "ROUTER_UNIQUE_ID_HEADER_NAME" }}
-  {{- end }}
+    {{- end }}
 
-  {{ if ne (env "ROUTER_MUTUAL_TLS_AUTH" "none") "none" }}
-    {{- with (env "ROUTER_MUTUAL_TLS_AUTH_FILTER") }}
+    {{ if ne (env "ROUTER_MUTUAL_TLS_AUTH" "none") "none" }}
+      {{- with (env "ROUTER_MUTUAL_TLS_AUTH_FILTER") }}
   # If a mutual TLS auth subject filter environment variable is set, we deny
   # requests if the DN field in the client certificate doesn't match that value.
   # Please note that this match is a regular expression match.
@@ -320,9 +320,9 @@ frontend fe_sni
   #             and the request will be passed on to the backend.
   #          B. ROUTER_MUTUAL_TLS_AUTH_FILTER="legacy-web-client", the request
   #             will be rejected.
-  acl cert_cn_matches ssl_c_s_dn -m reg {{.}}
+  acl cert_cn_matches ssl_c_s_dn -m reg {{ . }}
   http-request deny unless cert_cn_matches
-    {{- end }}
+      {{- end }}
 
   # Add X-SSL* headers to pass client certificate information to the backend.
   http-request set-header X-SSL                  %[ssl_fc]
@@ -336,7 +336,7 @@ frontend fe_sni
   http-request set-header X-SSL-Client-NotBefore %{+Q}[ssl_c_notbefore]
   http-request set-header X-SSL-Client-NotAfter  %{+Q}[ssl_c_notafter]
   http-request set-header X-SSL-Client-DER       %{+Q}[ssl_c_der,base64]
-  {{- end }}
+    {{- end }}
 
   # map to backend
   # Search from most specific to general path (host case).
@@ -359,27 +359,27 @@ frontend fe_sni
 ##########################################################################
 # backend for when sni does not exist, or ssl term needs to happen on the edge
 backend be_no_sni
-  server fe_no_sni 127.0.0.1:{{env "ROUTER_SERVICE_NO_SNI_PORT" "10443"}} weight 1 send-proxy
+  server fe_no_sni 127.0.0.1:{{ env "ROUTER_SERVICE_NO_SNI_PORT" "10443" }} weight 1 send-proxy
 
 frontend fe_no_sni
   # terminate ssl on edge
-  bind 127.0.0.1:{{env "ROUTER_SERVICE_NO_SNI_PORT" "10443"}} ssl crt {{firstMatch ".+" .DefaultCertificate "/var/lib/haproxy/conf/default_pub_keys.pem"}} accept-proxy
+  bind 127.0.0.1:{{ env "ROUTER_SERVICE_NO_SNI_PORT" "10443" }} ssl crt {{ firstMatch ".+" .DefaultCertificate "/var/lib/haproxy/conf/default_pub_keys.pem" }} accept-proxy
     {{- with (env "ROUTER_MUTUAL_TLS_AUTH") }}
-      {{- ""}} verify {{.}}
-      {{- with (env "ROUTER_MUTUAL_TLS_AUTH_CA") }} ca-file {{.}} {{ else }} ca-file /etc/ssl/certs/ca-bundle.trust.crt {{ end }}
-      {{- with (env "ROUTER_MUTUAL_TLS_AUTH_CRL") }} crl-file {{.}} {{ end }}
+      {{- "" }} verify {{. }}
+    {{- with (env "ROUTER_MUTUAL_TLS_AUTH_CA") }} ca-file {{. }} {{ else }} ca-file /etc/ssl/certs/ca-bundle.trust.crt {{ end }}
+    {{- with (env "ROUTER_MUTUAL_TLS_AUTH_CRL") }} crl-file {{. }} {{ end }}
     {{- end }}
   mode http
 
-  {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
+    {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
   capture request header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
-  {{- end }}
-  {{- range $idx, $captureHeader := .CaptureHTTPResponseHeaders }}
+    {{- end }}
+    {{- range $idx, $captureHeader := .CaptureHTTPResponseHeaders }}
   capture response header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
-  {{- end }}
-  {{- with $captureCookie := .CaptureHTTPCookie }}
+    {{- end }}
+    {{- with $captureCookie := .CaptureHTTPCookie }}
   capture cookie {{ $captureCookie.Name }}{{ if eq $captureCookie.MatchType "exact" }}={{ end }} len {{ $captureCookie.MaxLength }}
-  {{- end }}
+    {{- end }}
 
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
@@ -388,20 +388,20 @@ frontend fe_no_sni
   # before matching, or any requests containing uppercase characters will never match.
   http-request set-header Host %[req.hdr(Host),lower]
 
-  {{- if and (ne (env "ROUTER_UNIQUE_ID_FORMAT") "") (ne (env "ROUTER_UNIQUE_ID_HEADER_NAME") "") }}
+    {{- if and (ne (env "ROUTER_UNIQUE_ID_FORMAT") "") (ne (env "ROUTER_UNIQUE_ID_HEADER_NAME") "") }}
   unique-id-format {{ env "ROUTER_UNIQUE_ID_FORMAT" }}
   unique-id-header {{ env "ROUTER_UNIQUE_ID_HEADER_NAME" }}
-  {{- end }}
+    {{- end }}
 
-  {{ if ne (env "ROUTER_MUTUAL_TLS_AUTH" "none") "none" }}
-    {{- with (env "ROUTER_MUTUAL_TLS_AUTH_FILTER") }}
+    {{ if ne (env "ROUTER_MUTUAL_TLS_AUTH" "none") "none" }}
+      {{- with (env "ROUTER_MUTUAL_TLS_AUTH_FILTER") }}
   # If a mutual TLS auth subject filter environment variable is set, we deny
   # requests if the DN field in the client certificate doesn't match that value.
   # Please note that this match is a regular expression match.
   # See the config section 'frontend fe_sni' for examples.
-  acl cert_cn_matches ssl_c_s_dn -m reg {{.}}
+  acl cert_cn_matches ssl_c_s_dn -m reg {{ . }}
   http-request deny unless cert_cn_matches
-    {{- end }}
+      {{- end }}
 
   # Add X-SSL* headers to pass client certificate information to the backend.
   http-request set-header X-SSL                  %[ssl_fc]
@@ -415,7 +415,7 @@ frontend fe_no_sni
   http-request set-header X-SSL-Client-NotBefore %{+Q}[ssl_c_notbefore]
   http-request set-header X-SSL-Client-NotAfter  %{+Q}[ssl_c_notafter]
   http-request set-header X-SSL-Client-DER       %{+Q}[ssl_c_der,base64]
-  {{- end }}
+    {{- end }}
 
   # map to backend
   # Search from most specific to general path (host case).
@@ -436,7 +436,7 @@ backend openshift_default
   option http-pretend-keepalive
 
 ##-------------- app level backends ----------------
-{{/*
+    {{/*
        1. If termination is not set: This is plain http -> http.  Create a be_http:<service> backend.
           Incoming http traffic is terminated and sent as http to the pods.
 
@@ -451,283 +451,283 @@ backend openshift_default
           Incoming traffic is inspected to get the hostname from the SNI header, but then all traffic is
           passed through to the backend pod by just looking at the TCP headers.
 */}}
-{{- range $cfgIdx, $cfg := .State }}
-  {{- if matchValues (print $cfg.TLSTermination) "" "edge" "reencrypt" }}
+    {{- range $cfgIdx, $cfg := .State }}
+      {{- if matchValues (print $cfg.TLSTermination) "" "edge" "reencrypt" }}
 
 # Plain http backend or backend with TLS terminated at the edge or a
 # secure backend with re-encryption.
-backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
+backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
   mode http
   option redispatch
-  {{- with $setHeaders := firstMatch $setForwardedHeadersPattern (index $cfg.Annotations $setForwardedHeadersAnnotation) $setForwardedHeadersDefaultValue }}
-    {{- if eq $setHeaders "append" }}
+        {{- with $setHeaders := firstMatch $setForwardedHeadersPattern (index $cfg.Annotations $setForwardedHeadersAnnotation) $setForwardedHeadersDefaultValue }}
+          {{- if eq $setHeaders "append" }}
   option forwardfor
-    {{- else if eq $setHeaders "if-none" }}
+          {{- else if eq $setHeaders "if-none" }}
   option forwardfor if-none
-    {{- end }}
-  {{- end}}
-
-  {{- with $adjustments := $.HTTPHeaderNameCaseAdjustments }}
-    {{- if isTrue (index $cfg.Annotations "haproxy.router.openshift.io/h1-adjust-case") }}
-  option h1-case-adjust-bogus-server
-    {{- end }}
-  {{- end }}
-
-    {{- with $balanceAlgo := firstMatch "roundrobin|leastconn|source" (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_LOAD_BALANCE_ALGORITHM") }}
-  balance {{ $balanceAlgo }}
-    {{- else }}
-  balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}leastconn{{ end }}
-    {{- end }}
-    {{- with $ip_whiteList := firstMatch $cidrListPattern (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist") }}
-      {{- if validateHAProxyWhiteList $ip_whiteList }}
-  acl whitelist src {{$ip_whiteList}}
-      {{- else }}
-	{{- with $whiteListFileName := generateHAProxyWhiteListFile $workingDir $cfgIdx $ip_whiteList}}
-  acl whitelist src -f {{$whiteListFileName}}
+          {{- end }}
         {{- end }}
-      {{- end }}
-  tcp-request content reject if !whitelist
-    {{- end }}
-    {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout")) }}
-  timeout server  {{$value}}
-    {{- end }}
-    {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout-tunnel")) }}
-  timeout tunnel  {{$value}}
-    {{- end }}
 
-    {{- if isTrue (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections") }}
+        {{- with $adjustments := $.HTTPHeaderNameCaseAdjustments }}
+          {{- if isTrue (index $cfg.Annotations "haproxy.router.openshift.io/h1-adjust-case") }}
+  option h1-case-adjust-bogus-server
+          {{- end }}
+        {{- end }}
+
+        {{- with $balanceAlgo := firstMatch "roundrobin|leastconn|source" (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_LOAD_BALANCE_ALGORITHM") }}
+  balance {{ $balanceAlgo }}
+        {{- else }}
+  balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}leastconn{{ end }}
+        {{- end }}
+        {{- with $ip_whiteList := firstMatch $cidrListPattern (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist") }}
+          {{- if validateHAProxyWhiteList $ip_whiteList }}
+  acl whitelist src {{ $ip_whiteList }}
+          {{- else }}
+            {{- with $whiteListFileName := generateHAProxyWhiteListFile $workingDir $cfgIdx $ip_whiteList }}
+  acl whitelist src -f {{ $whiteListFileName }}
+            {{- end }}
+          {{- end }}
+  tcp-request content reject if !whitelist
+        {{- end }}
+        {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout")) }}
+  timeout server  {{ $value }}
+        {{- end }}
+        {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout-tunnel")) }}
+  timeout tunnel  {{ $value }}
+        {{- end }}
+
+        {{- if isTrue (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections") }}
   stick-table type ip size 100k expire 30s store conn_cur,conn_rate(3s),http_req_rate(10s)
   tcp-request content track-sc2 src
-      {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp")) }}
+          {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp")) }}
   tcp-request content reject if { src_conn_cur ge  {{ index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp" }} }
-      {{- else }}
+          {{- else }}
   # concurrent TCP connections not restricted
-      {{- end }}
+          {{- end }}
 
-      {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-tcp")) }}
+          {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-tcp")) }}
   tcp-request content reject if { src_conn_rate ge {{ index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-tcp" }} }
-      {{- else }}
+          {{- else }}
   #TCP connection rate not restricted
-      {{- end }}
+          {{- end }}
 
-      {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-http")) }}
+          {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-http")) }}
   tcp-request content reject if { src_http_req_rate ge {{ index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-http" }} }
-      {{- else }}
+          {{- else }}
   #HTTP request rate not restricted
-      {{- end }}
-    {{- end }}
+          {{- end }}
+        {{- end }}
 
   timeout check 5000ms
-  {{- with $setHeaders := firstMatch $setForwardedHeadersPattern (index $cfg.Annotations $setForwardedHeadersAnnotation) $setForwardedHeadersDefaultValue }}
-    {{- if eq $setHeaders "append" }}
-    {{- /* X-Forwarded-For: is handled by "option forwardfor" above.  */}}
+        {{- with $setHeaders := firstMatch $setForwardedHeadersPattern (index $cfg.Annotations $setForwardedHeadersAnnotation) $setForwardedHeadersDefaultValue }}
+          {{- if eq $setHeaders "append" }}
+            {{- /* X-Forwarded-For: is handled by "option forwardfor" above.  */}}
   http-request add-header X-Forwarded-Host %[req.hdr(host)]
   http-request add-header X-Forwarded-Port %[dst_port]
   http-request add-header X-Forwarded-Proto http if !{ ssl_fc }
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   http-request add-header X-Forwarded-Proto-Version h2 if { ssl_fc_alpn -i h2 }
-      {{- if eq "v4v6" $router_ip_v4_v6_mode }}
+            {{- if eq "v4v6" $router_ip_v4_v6_mode }}
   # See the quoting rules in https://tools.ietf.org/html/rfc7239 for IPv6 addresses (v4 addresses get translated to v6 when in hybrid mode)
   acl ipv6_addr src -m sub :
   http-request add-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if ipv6_addr
   http-request add-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !ipv6_addr
-      {{- else if eq "v6" $router_ip_v4_v6_mode }}
+            {{- else if eq "v6" $router_ip_v4_v6_mode }}
   http-request add-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
-      {{- else }}
+            {{- else }}
   http-request add-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
-      {{- end }}
-    {{- else if eq $setHeaders "replace" }}
+            {{- end }}
+          {{- else if eq $setHeaders "replace" }}
   http-request set-header X-Forwarded-For %[src]
   http-request set-header X-Forwarded-Host %[req.hdr(host)]
   http-request set-header X-Forwarded-Port %[dst_port]
   http-request set-header X-Forwarded-Proto http if !{ ssl_fc }
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
   http-request set-header X-Forwarded-Proto-Version h2 if { ssl_fc_alpn -i h2 }
-      {{- if eq "v4v6" $router_ip_v4_v6_mode }}
+            {{- if eq "v4v6" $router_ip_v4_v6_mode }}
   # See the quoting rules in https://tools.ietf.org/html/rfc7239 for IPv6 addresses (v4 addresses get translated to v6 when in hybrid mode)
   acl ipv6_addr src -m sub :
   http-request set-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if ipv6_addr
   http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !ipv6_addr
-      {{- else if eq "v6" $router_ip_v4_v6_mode }}
+            {{- else if eq "v6" $router_ip_v4_v6_mode }}
   http-request set-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
-      {{- else }}
+            {{- else }}
   http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
-      {{- end }}
-    {{- else if eq $setHeaders "if-none" }}
-      {{- /* X-Forwarded-For: is handled by "option forwardfor if-none" above.  */}}
+            {{- end }}
+          {{- else if eq $setHeaders "if-none" }}
+            {{- /* X-Forwarded-For: is handled by "option forwardfor if-none" above.  */}}
   http-request set-header X-Forwarded-Host %[req.hdr(host)] if !{ req.hdr(X-Forwarded-Host) -m found }
   http-request set-header X-Forwarded-Port %[dst_port] if !{ req.hdr(X-Forwarded-Port) -m found }
   http-request set-header X-Forwarded-Proto http if !{ ssl_fc } !{ req.hdr(X-Forwarded-Proto) -m found }
   http-request set-header X-Forwarded-Proto https if { ssl_fc } !{ req.hdr(X-Forwarded-Proto) -m found }
   http-request set-header X-Forwarded-Proto-Version h2 if { ssl_fc_alpn -i h2 } !{ req.hdr(X-Forwarded-Proto-Version) -m found }
-      {{- if eq "v4v6" $router_ip_v4_v6_mode }}
+            {{- if eq "v4v6" $router_ip_v4_v6_mode }}
   # See the quoting rules in https://tools.ietf.org/html/rfc7239 for IPv6 addresses (v4 addresses get translated to v6 when in hybrid mode)
   acl ipv6_addr src -m sub :
   http-request set-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if ipv6_addr !{ req.hdr(Forwarded) -m found }
   http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !ipv6_addr !{ req.hdr(Forwarded) -m found }
-      {{- else if eq "v6" $router_ip_v4_v6_mode }}
+            {{- else if eq "v6" $router_ip_v4_v6_mode }}
   http-request set-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !{ req.hdr(Forwarded) -m found }
-      {{- else }}
-  http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !{ req.hdr(Forwarded) -m found }
-      {{- end }}
-    {{- else if eq $setHeaders "never" }}
-      {{- /* No Forward headers set.  */}}
-    {{- end }}
-  {{- end}}
-
-  {{- with $pathRewriteTarget := firstMatch $pathRewriteTargetPattern (index $cfg.Annotations "haproxy.router.openshift.io/rewrite-target") }}
-  # Path rewrite target
-    {{- if eq $pathRewriteTarget "/" }}
-  http-request replace-path ^{{ $cfg.Path }}/?(.*)$ {{ $pathRewriteTarget }}\1
-    {{- else }}
-  http-request replace-path ^{{ $cfg.Path }}(.*)$ {{ $pathRewriteTarget }}\1
-    {{- end }}
-  {{- end }}{{/* rewrite target */}}
-  
-  {{- if not (isTrue (index $cfg.Annotations "haproxy.router.openshift.io/disable_cookies")) }}
-  cookie {{firstMatch $cookieNamePattern (index $cfg.Annotations "router.openshift.io/cookie_name") (env "ROUTER_COOKIE_NAME" "") $cfg.RoutingKeyName}} insert indirect nocache httponly
-    {{- if and (matchValues (print $cfg.TLSTermination) "edge" "reencrypt") (ne $cfg.InsecureEdgeTerminationPolicy "Allow") }}
-      {{- with $samesite := firstMatch "Lax|Strict|None" (index $cfg.Annotations "router.openshift.io/cookie-same-site") "None" }}
-        {{- ""}} secure attr SameSite={{ $samesite }}
-      {{- end }}
-    {{- end }}
-  {{- end }}{{/* end disable cookies check */}}
-
-  {{- if matchValues (print $cfg.TLSTermination) "edge" "reencrypt" }}
-    {{- with $hsts := firstMatch $hstsPattern (index $cfg.Annotations "haproxy.router.openshift.io/hsts_header") }}
-  http-response set-header Strict-Transport-Security {{$hsts}}
-    {{- end }}{{/* hsts header */}}
-  {{- end }}{{/* is "edge" or "reencrypt" */}}
-
-  {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
-    {{- if ge $weight 0 }}{{/* weight=0 is reasonable to keep existing connections to backends with cookies as we can see the HTTP headers */}}
-      {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
-        {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
-  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{$weight}}
-          {{- if (eq $cfg.TLSTermination "reencrypt") }} ssl
-	    {{- if not (isTrue $router_disable_http2) }} alpn h2,http/1.1
-	    {{- end }}
-            {{- if $cfg.VerifyServiceHostname }} verifyhost {{ $serviceUnit.Hostname }}
-            {{- end }}
-            {{- if gt (len (index $cfg.Certificates (printf "%s_pod" $cfg.Host)).Contents) 0 }} verify required ca-file {{ $workingDir }}/router/cacerts/{{$cfgIdx}}.pem
             {{- else }}
-              {{- if gt (len $defaultDestinationCA) 0 }} verify required ca-file {{ $defaultDestinationCA }}
-              {{- else }} verify none
-              {{- end }}
+  http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !{ req.hdr(Forwarded) -m found }
             {{- end }}
-          {{- else if or (eq $cfg.TLSTermination "") (eq $cfg.TLSTermination "edge") }}
-          {{- end }}{{/* end type specific options*/}}
-
-            {{- if and (not $endpoint.NoHealthCheck) (gt $cfg.ActiveEndpoints 1) }} check inter {{firstMatch $timeSpecPattern (index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval") (env "ROUTER_BACKEND_CHECK_INTERVAL") "5000ms"}}
-            {{- end }}{{/* end else no health check */}}
-            {{- with $podMaxConn := index $cfg.Annotations "haproxy.router.openshift.io/pod-concurrent-connections" }}
-              {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/pod-concurrent-connections")) }} maxconn {{$podMaxConn}} {{- end }}
-            {{- end}}{{/* end pod-concurrent-connections annotation */}}
-
-          {{- end }}{{/* end if cg.TLSTermination */}}
-        {{- end }}{{/* end range processEndpointsForAlias */}}
-      {{- end }}{{/* end get serviceUnit from its name */}}
-  {{- end }}{{/* end range over serviceUnitNames */}}
-
-  {{- with $dynamicConfigManager }}
-    {{- if (eq $cfg.TLSTermination "reencrypt") }}
-      {{- range $idx, $serverName := $dynamicConfigManager.GenerateDynamicServerNames $cfgIdx }}
-  server {{$serverName}} 172.4.0.4:8765 weight 0 ssl disabled check inter {{firstMatch $timeSpecPattern (index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval") (env "ROUTER_BACKEND_CHECK_INTERVAL") "5000ms"}}
-        {{- if gt (len (index $cfg.Certificates (printf "%s_pod" $cfg.Host)).Contents) 0 }} verify required ca-file {{ $workingDir }}/router/cacerts/{{$cfgIdx}}.pem
-        {{- else }}
-          {{- if gt (len $defaultDestinationCA) 0 }} verify required ca-file {{ $defaultDestinationCA }}
-          {{- else }} verify none
+          {{- else if eq $setHeaders "never" }}
+            {{- /* No Forward headers set.  */}}
           {{- end }}
         {{- end }}
-        {{- with $podMaxConn := index $cfg.Annotations "haproxy.router.openshift.io/pod-concurrent-connections" }}
-          {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/pod-concurrent-connections")) }} maxconn {{$podMaxConn}} {{- end }}
-        {{- end}}{{/* end pod-concurrent-connections annotation */}}
-      {{- end }}{{/* end range over dynamic server names */}}
 
-    {{- else }}
-      {{- with $name := $dynamicConfigManager.ServerTemplateName $cfgIdx }}
-        {{- with $size := $dynamicConfigManager.ServerTemplateSize $cfgIdx }}
-  dynamic-cookie-key {{$cfg.RoutingKeyName}}
-  server-template {{$name}}- 1-{{$size}} 172.4.0.4:8765 check disabled
+        {{- with $pathRewriteTarget := firstMatch $pathRewriteTargetPattern (index $cfg.Annotations "haproxy.router.openshift.io/rewrite-target") }}
+  # Path rewrite target
+          {{- if eq $pathRewriteTarget "/" }}
+  http-request replace-path ^{{ $cfg.Path }}/?(.*)$ {{ $pathRewriteTarget }}\1
+          {{- else }}
+  http-request replace-path ^{{ $cfg.Path }}(.*)$ {{ $pathRewriteTarget }}\1
+          {{- end }}
+        {{- end }}{{/* rewrite target */}}
+  
+        {{- if not (isTrue (index $cfg.Annotations "haproxy.router.openshift.io/disable_cookies")) }}
+  cookie {{ firstMatch $cookieNamePattern (index $cfg.Annotations "router.openshift.io/cookie_name") (env "ROUTER_COOKIE_NAME" "") $cfg.RoutingKeyName }} insert indirect nocache httponly
+          {{- if and (matchValues (print $cfg.TLSTermination) "edge" "reencrypt") (ne $cfg.InsecureEdgeTerminationPolicy "Allow") }}
+            {{- with $samesite := firstMatch "Lax|Strict|None" (index $cfg.Annotations "router.openshift.io/cookie-same-site") "None" }}
+              {{- "" }} secure attr SameSite={{ $samesite }}
+            {{- end }}
+          {{- end }}
+        {{- end }}{{/* end disable cookies check */}}
+
+        {{- if matchValues (print $cfg.TLSTermination) "edge" "reencrypt" }}
+          {{- with $hsts := firstMatch $hstsPattern (index $cfg.Annotations "haproxy.router.openshift.io/hsts_header") }}
+  http-response set-header Strict-Transport-Security {{ $hsts }}
+          {{- end }}{{/* hsts header */}}
+        {{- end }}{{/* is "edge" or "reencrypt" */}}
+
+        {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
+          {{- if ge $weight 0 }}{{/* weight=0 is reasonable to keep existing connections to backends with cookies as we can see the HTTP headers */}}
+            {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
+              {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
+  server {{ $endpoint.ID }} {{ $endpoint.IP }}:{{ $endpoint.Port }} cookie {{ $endpoint.IdHash }} weight {{ $weight }}
+                {{- if (eq $cfg.TLSTermination "reencrypt") }} ssl
+                  {{- if not (isTrue $router_disable_http2) }} alpn h2,http/1.1
+                  {{- end }}
+                  {{- if $cfg.VerifyServiceHostname }} verifyhost {{ $serviceUnit.Hostname }}
+                  {{- end }}
+                  {{- if gt (len (index $cfg.Certificates (printf "%s_pod" $cfg.Host)).Contents) 0 }} verify required ca-file {{ $workingDir }}/router/cacerts/{{$cfgIdx }}.pem
+                  {{- else }}
+                    {{- if gt (len $defaultDestinationCA) 0 }} verify required ca-file {{ $defaultDestinationCA }}
+                    {{- else }} verify none
+                    {{- end }}
+                  {{- end }}
+                {{- else if or (eq $cfg.TLSTermination "") (eq $cfg.TLSTermination "edge") }}
+                {{- end }}{{/* end type specific options*/}}
+
+                {{- if and (not $endpoint.NoHealthCheck) (gt $cfg.ActiveEndpoints 1) }} check inter {{firstMatch $timeSpecPattern (index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval") (env "ROUTER_BACKEND_CHECK_INTERVAL") "5000ms" }}
+                {{- end }}{{/* end else no health check */}}
+                {{- with $podMaxConn := index $cfg.Annotations "haproxy.router.openshift.io/pod-concurrent-connections" }}
+                {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/pod-concurrent-connections")) }} maxconn {{$podMaxConn }} {{- end }}
+                {{- end }}{{/* end pod-concurrent-connections annotation */}}
+
+              {{- end }}{{/* end if cg.TLSTermination */}}
+            {{- end }}{{/* end range processEndpointsForAlias */}}
+          {{- end }}{{/* end get serviceUnit from its name */}}
+        {{- end }}{{/* end range over serviceUnitNames */}}
+
+        {{- with $dynamicConfigManager }}
+          {{- if (eq $cfg.TLSTermination "reencrypt") }}
+            {{- range $idx, $serverName := $dynamicConfigManager.GenerateDynamicServerNames $cfgIdx }}
+  server {{ $serverName }} 172.4.0.4:8765 weight 0 ssl disabled check inter {{ firstMatch $timeSpecPattern (index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval") (env "ROUTER_BACKEND_CHECK_INTERVAL") "5000ms" }}
+              {{- if gt (len (index $cfg.Certificates (printf "%s_pod" $cfg.Host)).Contents) 0 }} verify required ca-file {{ $workingDir }}/router/cacerts/{{$cfgIdx }}.pem
+              {{- else }}
+                {{- if gt (len $defaultDestinationCA) 0 }} verify required ca-file {{ $defaultDestinationCA }}
+                {{- else }} verify none
+                {{- end }}
+              {{- end }}
+              {{- with $podMaxConn := index $cfg.Annotations "haproxy.router.openshift.io/pod-concurrent-connections" }}
+              {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/pod-concurrent-connections")) }} maxconn {{$podMaxConn }} {{- end }}
+              {{- end }}{{/* end pod-concurrent-connections annotation */}}
+            {{- end }}{{/* end range over dynamic server names */}}
+
+          {{- else }}
+            {{- with $name := $dynamicConfigManager.ServerTemplateName $cfgIdx }}
+              {{- with $size := $dynamicConfigManager.ServerTemplateSize $cfgIdx }}
+  dynamic-cookie-key {{ $cfg.RoutingKeyName }}
+  server-template {{ $name }}- 1-{{ $size }} 172.4.0.4:8765 check disabled
+              {{- end }}
+            {{- end }}
+          {{- end }}
         {{- end }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
 
-  {{- end }}{{/* end if tls==edge/none/reencrypt */}}
+      {{- end }}{{/* end if tls==edge/none/reencrypt */}}
 
-  {{- if eq $cfg.TLSTermination "passthrough" }}
+      {{- if eq $cfg.TLSTermination "passthrough" }}
 
 # Secure backend, pass through
-backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
-    {{- with $balanceAlgo := firstMatch "roundrobin|leastconn|source" (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME" (env "ROUTER_LOAD_BALANCE_ALGORITHM")) }}
+backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
+        {{- with $balanceAlgo := firstMatch "roundrobin|leastconn|source" (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME" (env "ROUTER_LOAD_BALANCE_ALGORITHM")) }}
   balance {{ $balanceAlgo }}
-    {{- else }}
+        {{- else }}
   balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}source{{ end }}
-    {{- end }}
-    {{- with $ip_whiteList := firstMatch $cidrListPattern (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist") }}
-      {{- if validateHAProxyWhiteList $ip_whiteList }}
-  acl whitelist src {{$ip_whiteList}}
-      {{- else }}
-	{{- with $whiteListFileName := generateHAProxyWhiteListFile $workingDir $cfgIdx $ip_whiteList}}
-  acl whitelist src -f {{$whiteListFileName}}
         {{- end }}
-      {{- end }}
+        {{- with $ip_whiteList := firstMatch $cidrListPattern (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist") }}
+          {{- if validateHAProxyWhiteList $ip_whiteList }}
+  acl whitelist src {{ $ip_whiteList }}
+          {{- else }}
+            {{- with $whiteListFileName := generateHAProxyWhiteListFile $workingDir $cfgIdx $ip_whiteList }}
+  acl whitelist src -f {{ $whiteListFileName }}
+            {{- end }}
+          {{- end }}
   tcp-request content reject if !whitelist
-    {{- end }}
-    {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout-tunnel") (index $cfg.Annotations "haproxy.router.openshift.io/timeout")) }}
-  timeout tunnel  {{$value}}
-    {{- end }}
+        {{- end }}
+        {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout-tunnel") (index $cfg.Annotations "haproxy.router.openshift.io/timeout")) }}
+  timeout tunnel  {{ $value }}
+        {{- end }}
 
-{{- if isTrue (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections") }}
+        {{- if isTrue (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections") }}
   stick-table type ip size 100k expire 30s store conn_cur,conn_rate(3s),http_req_rate(10s)
   tcp-request content track-sc2 src
-  {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp")) }}
+          {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp")) }}
   tcp-request content reject if { src_conn_cur ge  {{ index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp" }} }
-  {{- else }}
+          {{- else }}
   # concurrent TCP connections not restricted
-  {{- end }}
+          {{- end }}
 
-  {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-tcp")) }}
+          {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-tcp")) }}
   tcp-request content reject if { src_conn_rate ge {{ index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-tcp" }} }
-  {{- else }}
+          {{- else }}
   #TCP connection rate not restricted
-  {{- end }}
-{{- end }}
+          {{- end }}
+        {{- end }}
 
   hash-type consistent
   timeout check 5000ms
-    {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
-      {{- if ne $weight 0 }}{{/* drop connections where weight=0 as we can't use cookies, leaving only r-r and src-ip as dispatch methods and weight make no sense there */}}
-        {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
-          {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
-  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} weight {{$weight}}
-            {{- if and (not $endpoint.NoHealthCheck) (gt $cfg.ActiveEndpoints 1) }} check inter {{firstMatch $timeSpecPattern (index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval") (env "ROUTER_BACKEND_CHECK_INTERVAL") "5000ms"}}
-            {{- end }}{{/* end else no health check */}}
-            {{- with $podMaxConn := index $cfg.Annotations "haproxy.router.openshift.io/pod-concurrent-connections" }}
-              {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/pod-concurrent-connections")) }} maxconn {{$podMaxConn}} {{- end }}
-            {{- end}}{{/* end pod-concurrent-connections annotation */}}
+        {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
+          {{- if ne $weight 0 }}{{/* drop connections where weight=0 as we can't use cookies, leaving only r-r and src-ip as dispatch methods and weight make no sense there */}}
+            {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
+              {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
+  server {{ $endpoint.ID }} {{ $endpoint.IP }}:{{ $endpoint.Port }} weight {{ $weight }}
+                {{- if and (not $endpoint.NoHealthCheck) (gt $cfg.ActiveEndpoints 1) }} check inter {{firstMatch $timeSpecPattern (index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval") (env "ROUTER_BACKEND_CHECK_INTERVAL") "5000ms" }}
+                {{- end }}{{/* end else no health check */}}
+                {{- with $podMaxConn := index $cfg.Annotations "haproxy.router.openshift.io/pod-concurrent-connections" }}
+                {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/pod-concurrent-connections")) }} maxconn {{$podMaxConn }} {{- end }}
+                {{- end }}{{/* end pod-concurrent-connections annotation */}}
 
-          {{- end }}{{/* end range processEndpointsForAlias */}}
-        {{- end }}{{/* end get ServiceUnit from serviceUnitName */}}
-      {{- end }}{{/* end if weight != 0 */}}
-    {{- end }}{{/* end iterate over services*/}}
+              {{- end }}{{/* end range processEndpointsForAlias */}}
+            {{- end }}{{/* end get ServiceUnit from serviceUnitName */}}
+          {{- end }}{{/* end if weight != 0 */}}
+        {{- end }}{{/* end iterate over services*/}}
 
-    {{- with $dynamicConfigManager }}
-      {{- with $name := $dynamicConfigManager.ServerTemplateName $cfgIdx }}
-        {{- with $size := $dynamicConfigManager.ServerTemplateSize $cfgIdx }}
-  dynamic-cookie-key {{$cfg.RoutingKeyName}}
-  server-template {{$name}}- 1-{{$size}} 172.4.0.4:8765 check disabled
+        {{- with $dynamicConfigManager }}
+          {{- with $name := $dynamicConfigManager.ServerTemplateName $cfgIdx }}
+            {{- with $size := $dynamicConfigManager.ServerTemplateSize $cfgIdx }}
+  dynamic-cookie-key {{ $cfg.RoutingKeyName }}
+  server-template {{ $name }}- 1-{{ $size }} 172.4.0.4:8765 check disabled
+            {{- end }}
+          {{- end }}
         {{- end }}
-      {{- end }}
-    {{- end }}
 
-  {{- end }}{{/*end tls==passthrough*/}}
+      {{- end }}{{/*end tls==passthrough*/}}
 
-{{- end }}{{/* end loop over routes */}}
-{{- else }}
+    {{- end }}{{/* end loop over routes */}}
+  {{- else }}
 # Avoiding binding ports until routing configuration has been synchronized.
-{{- end }}{{/* end bind ports after sync */}}
+  {{- end }}{{/* end bind ports after sync */}}
 {{ end }}{{/* end haproxy config template */}}
 
 {{/*--------------------------------- END OF HAPROXY CONFIG, BELOW ARE MAPPING FILES ------------------------*/}}
@@ -737,11 +737,11 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
 			a host matches a [sub]domain with has wildcard support.
 */}}
 {{ define "conf/os_wildcard_domain.map" -}}
-{{     if isTrue (env "ROUTER_ALLOW_WILDCARD_ROUTES") -}}
-{{         range $idx, $line := generateHAProxyMap . -}}
-{{$line}}
-{{         end -}}
-{{     end -}}{{/* end if router allows wildcard routes */ -}}
+{{ if isTrue (env "ROUTER_ALLOW_WILDCARD_ROUTES") -}}
+  {{ range $idx, $line := generateHAProxyMap . -}}
+    {{ $line }}
+  {{ end -}}
+{{ end -}}{{/* end if router allows wildcard routes */ -}}
 {{ end -}}{{/* end wildcard domain map template */}}
 
 
@@ -752,9 +752,9 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
                                                 be_secure for reencrypt routes with InsecureEdgeTerminationPolicy Allow
 */}}
 {{ define "conf/os_http_be.map" -}}
-{{     range $idx, $line := generateHAProxyMap . -}}
-{{$line}}
-{{     end -}}
+{{ range $idx, $line := generateHAProxyMap . -}}
+  {{ $line }}
+{{ end -}}
 {{ end -}}{{/* end http host map template */}}
 
 
@@ -765,9 +765,9 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
                                               be_secure for reencrypt routes
 */}}
 {{ define "conf/os_edge_reencrypt_be.map" -}}
-{{     range $idx, $line := generateHAProxyMap . -}}
-{{$line}}
-{{     end -}}
+{{ range $idx, $line := generateHAProxyMap . -}}
+  {{ $line }}
+{{ end -}}
 {{ end -}}{{/* end edge http host map template */}}
 
 
@@ -777,9 +777,9 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
     if acls match for routes that have the insecure option set to redirect.
 */}}
 {{ define "conf/os_route_http_redirect.map" -}}
-{{     range $idx, $line := generateHAProxyMap . -}}
-{{$line}}
-{{     end -}}
+{{ range $idx, $line := generateHAProxyMap . -}}
+  {{ $line }}
+{{ end -}}
 {{ end -}}{{/* end redirect http host map template */}}
 
 
@@ -788,9 +788,9 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
                         by use_backend statements if acls are matched.
 */}}
 {{ define "conf/os_tcp_be.map" -}}
-{{     range $idx, $line := generateHAProxyMap . -}}
-{{$line}}
-{{     end -}}
+{{ range $idx, $line := generateHAProxyMap . -}}
+  {{ $line }}
+{{ end -}}
 {{ end -}}{{/* end tcp host map template */}}
 
 
@@ -799,9 +799,9 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
     					through to the host_be.  Driven by the termination type of the ServiceAliasConfigs
 */}}
 {{ define "conf/os_sni_passthrough.map" -}}
-{{     range $idx, $line := generateHAProxyMap . -}}
-{{$line}}
-{{     end -}}
+{{ range $idx, $line := generateHAProxyMap . -}}
+  {{ $line }}
+{{ end -}}
 {{ end -}}{{/* end sni passthrough map template */}}
 
 {{/*
@@ -813,7 +813,7 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
          wildcards and/or use a deny set with !<domain> in the future.
 */}}
 {{ define "conf/cert_config.map" -}}
-{{     range $idx, $line := generateHAProxyMap . -}}
-{{$line}}
-{{     end -}}
+{{ range $idx, $line := generateHAProxyMap . -}}
+  {{ $line }}
+{{ end -}}
 {{ end -}}{{/* end cert_config map template */}}


### PR DESCRIPTION
Use consistent indentation for the HAProxy configuration template.  Note that the HAProxy configuration stanzas and the Go template stanzas are interpolated but have different indentation, which can be confusing but should be less confusing if the Go template indentation is consistent.

* `images/router/haproxy/conf/haproxy-config.template`: Re-indent Go template
actions.


---

I used [a quick-and-dirty AWK script ](https://gist.github.com/Miciah/8a2d5245ba8150a626acb16a16926021) to re-indent the template.  If this seems like a good idea, we could add some automated verification to make sure the Go template stanzas are consistently indented.