### PR TITLE
Bug 1947478: Switch from discovery v1beta1 to discovery v1

### DIFF
--- a/pkg/router/controller/endpointsubset/converter.go
+++ b/pkg/router/controller/endpointsubset/converter.go
@@ -1,22 +1,22 @@
 package endpointsubset
 
 import (
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/discovery/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 )
 
 // ConvertEndpointSlice converts items to a slice of EndpointSubset's.
-func ConvertEndpointSlice(items []v1beta1.EndpointSlice, addressOrderByFuncs []EndpointAddressLessFunc, portOrderByFuncs []EndpointPortLessFunc) []v1.EndpointSubset {
-	var subsets []v1.EndpointSubset
+func ConvertEndpointSlice(items []discoveryv1.EndpointSlice, addressOrderByFuncs []EndpointAddressLessFunc, portOrderByFuncs []EndpointPortLessFunc) []corev1.EndpointSubset {
+	var subsets []corev1.EndpointSubset
 
 	for i := range items {
-		var ports []v1.EndpointPort
-		var addresses []v1.EndpointAddress
-		var notReadyAddresses []v1.EndpointAddress
+		var ports []corev1.EndpointPort
+		var addresses []corev1.EndpointAddress
+		var notReadyAddresses []corev1.EndpointAddress
 
 		for j := range items[i].Endpoints {
 			for k := range items[i].Endpoints[j].Addresses {
-				epa := v1.EndpointAddress{
+				epa := corev1.EndpointAddress{
 					IP:        items[i].Endpoints[j].Addresses[k],
 					TargetRef: items[i].Endpoints[j].TargetRef,
 				}
@@ -33,7 +33,7 @@ func ConvertEndpointSlice(items []v1beta1.EndpointSlice, addressOrderByFuncs []E
 		}
 
 		for j := range items[i].Ports {
-			endpointPort := v1.EndpointPort{
+			endpointPort := corev1.EndpointPort{
 				AppProtocol: items[i].Ports[j].AppProtocol,
 			}
 			if items[i].Ports[j].Name != nil {
@@ -52,7 +52,7 @@ func ConvertEndpointSlice(items []v1beta1.EndpointSlice, addressOrderByFuncs []E
 		SortAddresses(notReadyAddresses, addressOrderByFuncs)
 		SortPorts(ports, portOrderByFuncs)
 
-		subsets = append(subsets, v1.EndpointSubset{
+		subsets = append(subsets, corev1.EndpointSubset{
 			Addresses:         addresses,
 			NotReadyAddresses: notReadyAddresses,
 			Ports:             ports,

--- a/pkg/router/controller/endpointsubset/converter_test.go
+++ b/pkg/router/controller/endpointsubset/converter_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/router/pkg/router/controller/endpointsubset"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/discovery/v1beta1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,10 +26,10 @@ func TestConvertEndpointSlice(t *testing.T) {
 	tests := []struct {
 		name       string
 		want       []v1.EndpointSubset
-		conditions v1beta1.EndpointConditions
+		conditions discoveryv1.EndpointConditions
 	}{{
 		name: "no Ready condition set, expect zero NotReadyAddresses",
-		conditions: v1beta1.EndpointConditions{
+		conditions: discoveryv1.EndpointConditions{
 			Ready: nil,
 		},
 		want: []v1.EndpointSubset{{
@@ -43,7 +43,7 @@ func TestConvertEndpointSlice(t *testing.T) {
 		}},
 	}, {
 		name: "Ready condition set to true, expect zero NotReadyAddresses",
-		conditions: v1beta1.EndpointConditions{
+		conditions: discoveryv1.EndpointConditions{
 			Ready: boolPtr(true),
 		},
 		want: []v1.EndpointSubset{{
@@ -57,7 +57,7 @@ func TestConvertEndpointSlice(t *testing.T) {
 		}},
 	}, {
 		name: "Ready condition set to false, expect zero ReadyAddresses and non-zero NotReadyAddresses",
-		conditions: v1beta1.EndpointConditions{
+		conditions: discoveryv1.EndpointConditions{
 			Ready: boolPtr(false),
 		},
 		want: []v1.EndpointSubset{{
@@ -73,26 +73,26 @@ func TestConvertEndpointSlice(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			items := []v1beta1.EndpointSlice{{
+			items := []discoveryv1.EndpointSlice{{
 				TypeMeta: metav1.TypeMeta{
-					Kind:       "endpointslices",
-					APIVersion: "discovery.k8s.io/v1beta1",
+					Kind:       "EndpointSlice",
+					APIVersion: "discovery.k8s.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "slice-1",
 					Namespace: "namespace-a",
 					Labels: map[string]string{
-						v1beta1.LabelServiceName: "service-a",
+						discoveryv1.LabelServiceName: "service-a",
 					},
 				},
-				AddressType: v1beta1.AddressTypeIPv4,
-				Endpoints: []v1beta1.Endpoint{{
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{{
 					Addresses: []string{
 						"192.168.0.1",
 					},
 					Conditions: tc.conditions,
 				}},
-				Ports: []v1beta1.EndpointPort{{
+				Ports: []discoveryv1.EndpointPort{{
 					Port: int32Ptr(8080),
 				}},
 			}}

--- a/pkg/router/controller/factory/factory_endpointslices_test.go
+++ b/pkg/router/controller/factory/factory_endpointslices_test.go
@@ -11,7 +11,7 @@ import (
 	fakeproject "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1/fake"
 	fakerouterclient "github.com/openshift/client-go/route/clientset/versioned/fake"
 	kapi "k8s.io/api/core/v1"
-	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -100,23 +100,23 @@ func TestEndpointSlicesAdd(t *testing.T) {
 	defer close(stopCh)
 
 	type testCase struct {
-		sliceToAdd              discoveryv1beta1.EndpointSlice
+		sliceToAdd              discoveryv1.EndpointSlice
 		expectedServiceName     string
 		expectedEventType       watch.EventType
 		expectedEndpointSubsets []kapi.EndpointSubset
 	}
 
 	testCases := []testCase{{
-		sliceToAdd: discoveryv1beta1.EndpointSlice{
+		sliceToAdd: discoveryv1.EndpointSlice{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "slice-1",
 				Namespace: "namespace-a",
 				Labels: map[string]string{
-					discoveryv1beta1.LabelServiceName: "service-a",
+					discoveryv1.LabelServiceName: "service-a",
 				},
 			},
-			AddressType: discoveryv1beta1.AddressTypeIPv4,
-			Endpoints: []discoveryv1beta1.Endpoint{{
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{{
 				Addresses: []string{
 					"192.168.0.1",
 					"10.0.0.1",
@@ -124,7 +124,7 @@ func TestEndpointSlicesAdd(t *testing.T) {
 				},
 				Hostname: stringPtr("service.com"),
 			}},
-			Ports: []discoveryv1beta1.EndpointPort{{
+			Ports: []discoveryv1.EndpointPort{{
 				Port: int32Ptr(8080),
 			}, {
 				Name:     stringPtr("https"),
@@ -162,22 +162,22 @@ func TestEndpointSlicesAdd(t *testing.T) {
 			}},
 		}},
 	}, {
-		sliceToAdd: discoveryv1beta1.EndpointSlice{
+		sliceToAdd: discoveryv1.EndpointSlice{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "slice-2",
 				Namespace: "namespace-a",
 				Labels: map[string]string{
-					discoveryv1beta1.LabelServiceName: "service-a",
+					discoveryv1.LabelServiceName: "service-a",
 				},
 			},
-			AddressType: discoveryv1beta1.AddressTypeIPv4,
-			Endpoints: []discoveryv1beta1.Endpoint{{
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{{
 				Addresses: []string{
 					"172.16.10.2",
 					"172.16.10.1",
 				},
 			}},
-			Ports: []discoveryv1beta1.EndpointPort{{
+			Ports: []discoveryv1.EndpointPort{{
 				Port: int32Ptr(101),
 			}, {
 				Port: int32Ptr(100),
@@ -220,12 +220,12 @@ func TestEndpointSlicesAdd(t *testing.T) {
 			}},
 		}},
 	}, {
-		sliceToAdd: discoveryv1beta1.EndpointSlice{
+		sliceToAdd: discoveryv1.EndpointSlice{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "slice-1",
 				Namespace: "namespace-b",
 				Labels: map[string]string{
-					discoveryv1beta1.LabelServiceName: "service-b",
+					discoveryv1.LabelServiceName: "service-b",
 				},
 			},
 		},
@@ -236,7 +236,7 @@ func TestEndpointSlicesAdd(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			if _, err := client.DiscoveryV1beta1().EndpointSlices(tc.sliceToAdd.Namespace).Create(context.TODO(), &tc.sliceToAdd, metav1.CreateOptions{}); err != nil {
+			if _, err := client.DiscoveryV1().EndpointSlices(tc.sliceToAdd.Namespace).Create(context.TODO(), &tc.sliceToAdd, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("failed to create endpointslice %s: %v", tc.sliceToAdd.Name, err)
 			}
 
@@ -266,20 +266,20 @@ func TestEndpointSlicesAdd(t *testing.T) {
 func TestEndpointSlicesDelete(t *testing.T) {
 	defer leaktest.CheckTimeout(t, endpointSliceTestTimeout)()
 
-	eps1 := discoveryv1beta1.EndpointSlice{
+	eps1 := discoveryv1.EndpointSlice{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "endpointslices",
-			APIVersion: "discovery.k8s.io/v1beta1",
+			Kind:       "EndpointSlice",
+			APIVersion: "discovery.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "slice-1",
 			Namespace: "namespace-a",
 			Labels: map[string]string{
-				discoveryv1beta1.LabelServiceName: "service-a",
+				discoveryv1.LabelServiceName: "service-a",
 			},
 		},
-		AddressType: discoveryv1beta1.AddressTypeIPv4,
-		Endpoints: []discoveryv1beta1.Endpoint{{
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{{
 			Addresses: []string{
 				"192.168.0.1",
 				"10.0.0.1",
@@ -287,7 +287,7 @@ func TestEndpointSlicesDelete(t *testing.T) {
 			},
 			Hostname: stringPtr("service.com"),
 		}},
-		Ports: []discoveryv1beta1.EndpointPort{{
+		Ports: []discoveryv1.EndpointPort{{
 			Port: int32Ptr(8080),
 		}, {
 			Name:     stringPtr("https"),
@@ -300,26 +300,26 @@ func TestEndpointSlicesDelete(t *testing.T) {
 		}},
 	}
 
-	eps2 := discoveryv1beta1.EndpointSlice{
+	eps2 := discoveryv1.EndpointSlice{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "endpointslices",
-			APIVersion: "discovery.k8s.io/v1beta1",
+			Kind:       "EndpointSlice",
+			APIVersion: "discovery.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "slice-2",
 			Namespace: "namespace-a",
 			Labels: map[string]string{
-				discoveryv1beta1.LabelServiceName: "service-a",
+				discoveryv1.LabelServiceName: "service-a",
 			},
 		},
-		AddressType: discoveryv1beta1.AddressTypeIPv4,
-		Endpoints: []discoveryv1beta1.Endpoint{{
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{{
 			Addresses: []string{
 				"172.16.10.2",
 				"172.16.10.1",
 			},
 		}},
-		Ports: []discoveryv1beta1.EndpointPort{{
+		Ports: []discoveryv1.EndpointPort{{
 			Port: int32Ptr(101),
 		}, {
 			Port: int32Ptr(100),
@@ -333,8 +333,8 @@ func TestEndpointSlicesDelete(t *testing.T) {
 	client, stopCh := newEndpointSliceTestSetup(plugin)
 	defer close(stopCh)
 
-	for _, eps := range []discoveryv1beta1.EndpointSlice{eps1, eps2} {
-		if _, err := client.DiscoveryV1beta1().EndpointSlices(eps.Namespace).Create(context.TODO(), &eps, metav1.CreateOptions{}); err != nil {
+	for _, eps := range []discoveryv1.EndpointSlice{eps1, eps2} {
+		if _, err := client.DiscoveryV1().EndpointSlices(eps.Namespace).Create(context.TODO(), &eps, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("failed to create endpointslice %s: %v", eps.Name, err)
 		}
 
@@ -347,7 +347,7 @@ func TestEndpointSlicesDelete(t *testing.T) {
 
 	type testCase struct {
 		description             string
-		sliceToDelete           discoveryv1beta1.EndpointSlice
+		sliceToDelete           discoveryv1.EndpointSlice
 		expectedEndpointSubsets []kapi.EndpointSubset
 		expectedEventType       watch.EventType
 		expectDeleteError       bool
@@ -381,7 +381,7 @@ func TestEndpointSlicesDelete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			if err := client.DiscoveryV1beta1().EndpointSlices(tc.sliceToDelete.Namespace).Delete(context.TODO(), tc.sliceToDelete.Name, metav1.DeleteOptions{}); err != nil {
+			if err := client.DiscoveryV1().EndpointSlices(tc.sliceToDelete.Namespace).Delete(context.TODO(), tc.sliceToDelete.Name, metav1.DeleteOptions{}); err != nil {
 				if tc.expectDeleteError {
 					return
 				}

--- a/pkg/router/controller/router_controller.go
+++ b/pkg/router/controller/router_controller.go
@@ -9,7 +9,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	projectclient "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
 	kapi "k8s.io/api/core/v1"
-	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -230,7 +230,7 @@ func (c *RouterController) HandleEndpoints(eventType watch.EventType, obj interf
 }
 
 // HandleEndpointSlice handles a single EndpointSlice event and refreshes the router backend.
-func (c *RouterController) HandleEndpointSlice(eventType watch.EventType, objMeta metav1.ObjectMeta, items []discoveryv1beta1.EndpointSlice) {
+func (c *RouterController) HandleEndpointSlice(eventType watch.EventType, objMeta metav1.ObjectMeta, items []discoveryv1.EndpointSlice) {
 	endpoints := &kapi.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            objMeta.Name,


### PR DESCRIPTION
Discovery.k8s.io/v1beta1 EndpointSlices are deprecated in favor of
discovery.k8s.io/v1 in Kubernetes 1.21.

pkg/router/controller/factory/factory.go &
pkg/router/controller/endpointsubset/converter.go &
pkg/router/controller/endpointsubset/converter_test.go &
pkg/router/controller/factory/factory_endpointslices_test.go:

Import `discoveryv1` and `corev1` explicitly. Update calling sites.
Update inline EndpointSlice resource API Version and Kind fields.
Update kube client API calls to use `discoveryv1`.