### PR TITLE
NE-472: haproxy-config.template: Add ROUTER_CIPHERSUITES

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -116,6 +116,14 @@ global
       {{- end }}
     {{- end }}
   {{- end }}
+  {{/*
+    The ssl-default-bind-ciphers option above configures ciphers for TLSv1.0,
+    TLSv1.1, and TLSv1.2; for TLSv1.3, cipher suites are configured using the
+    ssl-default-bind-ciphersuites option below.
+  */}}
+  {{- with $ciphersuites := (env "ROUTER_CIPHERSUITES") }}
+  ssl-default-bind-ciphersuites {{ $ciphersuites }}
+  {{- end }}
 
 defaults
   maxconn {{ env "ROUTER_MAX_CONNECTIONS" "20000" }}


### PR DESCRIPTION
https://issues.redhat.com/browse/NE-472

Add an environment variable for specifying cipher suites for TLSv1.3.

The existing ROUTER_CIPHERS environment variable sets HAProxy's
ssl-default-bind-ciphers option.  However, this option configures ciphers
only for TLS versions other than TLSv1.3.  To configure cipher suites for
TLSv1.3, HAProxy requires the ssl-default-bind-ciphersuites option.

* images/router/haproxy/conf/haproxy-config.template: Check for the
ROUTER_CIPHERSUITES environment variable.  If its value is nonempty,
use it to set the ssl-default-bind-ciphersuites option.