### PR TITLE
Bug 1961550: Add a condition to check if the Endpoints ID is duplicated

### DIFF
--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -313,6 +313,8 @@ func createRouterEndpoints(endpoints *kapi.Endpoints, excludeUDP bool, lookupSvc
 	}
 
 	out := make([]Endpoint, 0, len(endpoints.Subsets)*4)
+	// For checking if the endpoints ID is duplicated.
+	duplicated := map[string]bool{}
 
 	// Return address as "[<address>]" if an IPv6 address,
 	// otherwise address is returned unadorned.
@@ -360,7 +362,13 @@ func createRouterEndpoints(endpoints *kapi.Endpoints, excludeUDP bool, lookupSvc
 				s := ep.ID
 				ep.IdHash = fmt.Sprintf("%x", md5.Sum([]byte(s)))
 
-				out = append(out, ep)
+				// Add only not duplicated endpoints.
+				if !duplicated[ep.ID] {
+					out = append(out, ep)
+					duplicated[ep.ID] = true
+				} else {
+					log.V(4).Info("skip a duplicated endpoints to add", ep.ID)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
* Description: EndpointSlice can be duplicated. For suppressing broken haproxy.config, add a condition to check if the Endpoints is duplicated before adding the new endpoints actually.
* Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1961550