### PR TITLE
WIP: reload-haproxy: Log diff of old and new configs

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -2,6 +2,7 @@
 
 set -o nounset
 
+old_config_file=/tmp/haproxy.config.old
 config_file=/var/lib/haproxy/conf/haproxy.config
 pid_file=/var/lib/haproxy/run/haproxy.pid
 readonly timeout_opts="-m 1 --connect-timeout 1"
@@ -89,6 +90,12 @@ if [ -n "${ROUTER_SHUTDOWN-}" ]; then
   echo "error: Some processes did not exit within ${shutdown_wait_time}s"
   exit 1
 fi
+
+if [[ -e "$old_config_file" ]]; then
+  echo " - Diff of new haproxy.config to old one:"
+  /bin/diff -u "$old_config_file" "$config_file"
+fi
+/bin/cp -f "$config_file" "$old_config_file"
 
 reload_status=0
 if [ -n "$old_pids" ]; then

--- a/pkg/router/controller/router_controller.go
+++ b/pkg/router/controller/router_controller.go
@@ -187,7 +187,7 @@ func (c *RouterController) HandleNamespace(eventType watch.EventType, obj interf
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	log.V(4).Info("processing namespace", "namespace", ns.Name, "event", eventType)
+	log.V(0).Info("processing namespace", "namespace", ns.Name, "event", eventType)
 
 	c.processNamespace(eventType, ns)
 	c.Commit()
@@ -199,7 +199,7 @@ func (c *RouterController) HandleNode(eventType watch.EventType, obj interface{}
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	log.V(4).Info("processing node", "node", node.Name, "event", eventType)
+	log.V(0).Info("processing node", "node", node.Name, "event", eventType)
 
 	if err := c.Plugin.HandleNode(eventType, node); err != nil {
 		utilruntime.HandleError(err)
@@ -267,7 +267,7 @@ func (c *RouterController) Commit() {
 
 // processRoute logs and propagates a route event to the plugin
 func (c *RouterController) processRoute(eventType watch.EventType, route *routev1.Route) {
-	log.V(4).Info("processing route", "event", eventType, "route", route)
+	log.V(0).Info("processing route", "event", eventType, "route", route)
 
 	c.RecordNamespaceRoutes(eventType, route)
 	if err := c.Plugin.HandleRoute(eventType, route); err != nil {

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -177,10 +177,10 @@ func (p *TemplatePlugin) Stop() error {
 func (p *TemplatePlugin) HandleEndpoints(eventType watch.EventType, endpoints *kapi.Endpoints) error {
 	key := endpointsKey(endpoints)
 
-	log.V(4).Info("processing endpoints", "endpointCount", len(endpoints.Subsets), "namespace", endpoints.Namespace, "name", endpoints.Name, "eventType", eventType)
+	log.V(0).Info("processing endpoints", "endpointCount", len(endpoints.Subsets), "namespace", endpoints.Namespace, "name", endpoints.Name, "eventType", eventType)
 
 	for i, s := range endpoints.Subsets {
-		log.V(4).Info("processing subset", "index", i, "subset", s)
+		log.V(0).Info("processing subset", "index", i, "subset", s)
 	}
 
 	if _, ok := p.Router.FindServiceUnit(key); !ok {


### PR DESCRIPTION
* `images/router/haproxy/reload-haproxy`: When reloading `haproxy.config`, save a copy of the new config, and log a diff of the old config and the new if an old config was saved during an earlier reload.

---

This is a proof-of-concept, and a way to check in CI if `reload-haproxy` logs any spurious reloads.  We may or may not ultimately merge some form of this change.