### PR TITLE
Bug 1964486:  template helper - generateHAProxyWhiteListFile, use right arg type

### DIFF
--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -237,7 +237,7 @@ func validateHAProxyWhiteList(value string) bool {
 }
 
 // generateHAProxyWhiteListFile generates a whitelist file for use with an haproxy acl.
-func generateHAProxyWhiteListFile(workingDir, id, value string) string {
+func generateHAProxyWhiteListFile(workingDir string, id ServiceAliasConfigKey, value string) string {
 	name := path.Join(workingDir, whitelistDir, fmt.Sprintf("%s.txt", id))
 	cidrs, _ := haproxyutil.ValidateWhiteList(value)
 	data := []byte(strings.Join(cidrs, "\n") + "\n")


### PR DESCRIPTION
Fix for the following error: 
```
error executing template for file /tmp/router004931081/conf/haproxy.config: template: haproxy-config.template:492:84: executing "conf/haproxy.config" at <$cfgIdx>: wrong type for value; expected string; got templaterouter.ServiceAliasConfigKey
```
It happens when the whitelist of IPs has to be put into a file due to [the limitation of HAProxy config](https://github.com/openshift/router/blob/master/pkg/router/template/util/haproxy/whitelist.go#L11).