### PR TITLE
Hack: Add initial hacking instructions

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,51 @@
+# OpenShift Router Hacking
+
+This is a living document containing suggestions for testing Router changes on an existing cluster.
+These "hacks" are not officially supported and are subject to change, break, etc.
+
+## Building
+
+To build the Router binary, run:
+
+```
+$ make
+```
+
+## Developing
+
+### Prerequisites
+
+* An [OpenShift cluster](https://github.com/openshift/installer)
+* An admin-scoped `KUBECONFIG` for the cluster.
+* Install [imagebuilder](https://github.com/openshift/imagebuilder)
+
+#### Building a Modified Router Image Locally & Deploying to the Cluster
+
+To test Router changes on an available cluster, utilize `Dockerfile.debug` and
+`Makefile.debug` in `hack/`.
+
+`Dockerfile.debug` is a multi-stage dockerifle for building the Router binary,
+as well as the Router image itself. The outputted image uses `centos:8` as it's base
+since installing packages on an OpenShift RHEL base image requires RHEL entitlements.
+
+`Makefile.debug` contains simple commands for "hot-swapping" the Router image running
+in an IngressController deployment.
+
+Example:
+
+1. Run `make` to ensure that your code changes compile
+1. Set the `IMAGE` environment variable. (ie. `export IMAGE=<your-quay-username>/openshift-router`)
+1. Build a modified Router image for testing your changes (`make -f hack/Makefile.debug new-openshift-router-image`)
+1. Push the new Router image to quay.io (`make -f hack/Makefile.debug push`)
+1. Use the new Router image in the default Ingress Controller's deployment (`make -f hack/Makefile.debug set-image`)
+
+Alternatively, after setting `IMAGE`, you can run `make dwim` (do what I mean) to accomplish the above steps in one command.
+
+When done testing, use `make -f hack/Makefile.debug reset` to re-enable the CVO and Ingress Operator.
+
+## Tests
+
+Run unit tests:
+```
+$ make check
+```

--- a/hack/Dockerfile.debug
+++ b/hack/Dockerfile.debug
@@ -1,0 +1,22 @@
+FROM centos:8
+RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy22-2.2.5-1.el8.x86_64.rpm
+RUN haproxy -vv
+RUN INSTALL_PKGS="rsyslog procps-ng util-linux socat" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /var/lib/haproxy/router/{certs,cacerts,whitelists} && \
+    mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log} && \
+    touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
+    setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
+    chown -R :0 /var/lib/haproxy && \
+    chmod -R g+w /var/lib/haproxy
+COPY images/router/haproxy/ /var/lib/haproxy/
+COPY openshift-router /usr/bin/openshift-router
+USER 1001
+EXPOSE 80 443 7000
+WORKDIR /var/lib/haproxy/conf
+ENV XDG_CONFIG_HOME=/tmp \
+    TEMPLATE_FILE=/var/lib/haproxy/conf/haproxy-config.template \
+    RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy
+ENTRYPOINT ["/usr/bin/openshift-router", "--v=4"]

--- a/hack/Makefile.debug
+++ b/hack/Makefile.debug
@@ -1,0 +1,29 @@
+# -*- mode: makefile -*-
+
+export GOOS=linux
+
+REGISTRY ?= quay.io
+IMAGE ?= openshift/openshift-router
+TAG ?= latest
+
+new-openshift-router-image:
+	GO111MODULE=on CGO_ENABLED=0 GOFLAGS=-mod=vendor go build -o openshift-router -gcflags=all="-N -l" ./cmd/openshift-router
+	imagebuilder -t $(IMAGE):$(TAG) -f hack/Dockerfile.debug .
+
+push:
+	docker tag $(IMAGE):$(TAG) $(REGISTRY)/$(IMAGE):$(TAG)
+	docker push $(REGISTRY)/$(IMAGE):$(TAG)
+
+set-image:
+	oc scale --replicas 0 -n openshift-cluster-version deployments/cluster-version-operator
+	oc scale --replicas 0 -n openshift-ingress-operator deployments ingress-operator
+	oc -n openshift-ingress scale deployment --replicas=0 router-default
+	oc -n openshift-ingress patch deployment router-default -p '{"spec":{"template":{"spec":{"$$setElementOrder/containers":[{"name":"router"}],"containers":[{"imagePullPolicy":"Always","name":"router"}]}}}}'
+	oc -n openshift-ingress set image deployment/router-default router=$(REGISTRY)/$(IMAGE):$(TAG)
+	oc -n openshift-ingress scale deployment --replicas=1 router-default
+
+dwim:  new-openshift-router-image push set-image
+
+reset:
+	oc scale --replicas 1 -n openshift-cluster-version deployments/cluster-version-operator
+	oc scale --replicas 1 -n openshift-ingress-operator deployments ingress-operator


### PR DESCRIPTION
This commit adds 2 new "hacking" files, `hack/Dockerfile.debug`
and `hack/Makefile.debug`, as well as a new `HACKING.md` readme file.

Note that the files and instructions provided in this commit are
intended for Router development and are not officially supported
or guaranteed to work.