### PR TITLE
Bug 1967228: error pages - don't use bootstrap/normalize

### DIFF
--- a/images/router/haproxy/conf/error-page-404.http
+++ b/images/router/haproxy/conf/error-page-404.http
@@ -8,108 +8,67 @@ Content-Type: text/html
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <style type="text/css">
-  /*!
-   * Bootstrap v3.3.5 (http://getbootstrap.com)
-   * Copyright 2011-2015 Twitter, Inc.
-   * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
-   */
-  /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
-  html {
-    font-family: sans-serif;
-    -ms-text-size-adjust: 100%;
-    -webkit-text-size-adjust: 100%;
-  }
-  body {
-    margin: 0;
-  }
-  h1 {
-    font-size: 1.7em;
-    font-weight: 400;
-    line-height: 1.3;
-    margin: 0.68em 0;
-  }
-  * {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-  }
-  *:before,
-  *:after {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-  }
-  html {
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  }
-  body {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    line-height: 1.66666667;
-    font-size: 13px;
-    color: #333333;
-    background-color: #ffffff;
-    margin: 2em 1em;
-  }
-  p {
-    margin: 0 0 10px;
-    font-size: 13px;
-  }
-  .alert.alert-info {
-    padding: 15px;
-    margin-bottom: 20px;
-    border: 1px solid transparent;
-    background-color: #f5f5f5;
-    border-color: #8b8d8f;
-    color: #363636;
-    margin-top: 30px;
-  }
-  .alert p {
-    padding-left: 35px;
-  }
-  a {
-    color: #0088ce;
-  }
+    <style type="text/css">
+      body {
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        line-height: 1.66666667;
+        font-size: 16px;
+        color: #333;
+        background-color: #fff;
+        margin: 2em 1em;
+      }
+      h1 {
+        font-size: 28px;
+        font-weight: 400;
+      }
+      p {
+        margin: 0 0 10px;
+      }
+      .alert.alert-info {
+        background-color: #F0F0F0;
+        margin-top: 30px;
+        padding: 30px;
+      }
+      .alert p {
+        padding-left: 35px;
+      }
+      ul {
+        padding-left: 51px;
+        position: relative;
+      }
+      li {
+        font-size: 14px;
+        margin-bottom: 1em;
+      }
+      p.info {
+        position: relative;
+        font-size: 20px;
+      }
+      p.info:before, p.info:after {
+        content: "";
+        left: 0;
+        position: absolute;
+        top: 0;
+      }
+      p.info:before {
+        background: #0066CC;
+        border-radius: 16px;
+        color: #fff;
+        content: "i";
+        font: bold 16px/24px serif;
+        height: 24px;
+        left: 0px;
+        text-align: center;
+        top: 4px;
+        width: 24px;
+      }
 
-  ul {
-    position: relative;
-    padding-left: 51px;
-  }
-  p.info {
-    position: relative;
-    font-size: 15px;
-    margin-bottom: 10px;
-  }
-  p.info:before, p.info:after {
-    content: "";
-    position: absolute;
-    top: 9%;
-    left: 0;
-  }
-  p.info:before {
-    content: "i";
-    left: 3px;
-    width: 20px;
-    height: 20px;
-    font-family: serif;
-    font-size: 15px;
-    font-weight: bold;
-    line-height: 21px;
-    text-align: center;
-    color: #fff;
-    background: #4d5258;
-    border-radius: 16px;
-  }
-
-  @media (min-width: 768px) {
-    body {
-      margin: 4em 3em;
-    }
-    h1 {
-      font-size: 2.15em;}
-  }
-
-  </style>
+      @media (min-width: 768px) {
+        body {
+          margin: 6em;
+        }
+      }
+    </style>
   </head>
   <body>
     <div>

--- a/images/router/haproxy/conf/error-page-503.http
+++ b/images/router/haproxy/conf/error-page-503.http
@@ -8,108 +8,67 @@ Content-Type: text/html
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <style type="text/css">
-  /*!
-   * Bootstrap v3.3.5 (http://getbootstrap.com)
-   * Copyright 2011-2015 Twitter, Inc.
-   * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
-   */
-  /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
-  html {
-    font-family: sans-serif;
-    -ms-text-size-adjust: 100%;
-    -webkit-text-size-adjust: 100%;
-  }
-  body {
-    margin: 0;
-  }
-  h1 {
-    font-size: 1.7em;
-    font-weight: 400;
-    line-height: 1.3;
-    margin: 0.68em 0;
-  }
-  * {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-  }
-  *:before,
-  *:after {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-  }
-  html {
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  }
-  body {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    line-height: 1.66666667;
-    font-size: 13px;
-    color: #333333;
-    background-color: #ffffff;
-    margin: 2em 1em;
-  }
-  p {
-    margin: 0 0 10px;
-    font-size: 13px;
-  }
-  .alert.alert-info {
-    padding: 15px;
-    margin-bottom: 20px;
-    border: 1px solid transparent;
-    background-color: #f5f5f5;
-    border-color: #8b8d8f;
-    color: #363636;
-    margin-top: 30px;
-  }
-  .alert p {
-    padding-left: 35px;
-  }
-  a {
-    color: #0088ce;
-  }
+    <style type="text/css">
+      body {
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        line-height: 1.66666667;
+        font-size: 16px;
+        color: #333;
+        background-color: #fff;
+        margin: 2em 1em;
+      }
+      h1 {
+        font-size: 28px;
+        font-weight: 400;
+      }
+      p {
+        margin: 0 0 10px;
+      }
+      .alert.alert-info {
+        background-color: #F0F0F0;
+        margin-top: 30px;
+        padding: 30px;
+      }
+      .alert p {
+        padding-left: 35px;
+      }
+      ul {
+        padding-left: 51px;
+        position: relative;
+      }
+      li {
+        font-size: 14px;
+        margin-bottom: 1em;
+      }
+      p.info {
+        position: relative;
+        font-size: 20px;
+      }
+      p.info:before, p.info:after {
+        content: "";
+        left: 0;
+        position: absolute;
+        top: 0;
+      }
+      p.info:before {
+        background: #0066CC;
+        border-radius: 16px;
+        color: #fff;
+        content: "i";
+        font: bold 16px/24px serif;
+        height: 24px;
+        left: 0px;
+        text-align: center;
+        top: 4px;
+        width: 24px;
+      }
 
-  ul {
-    position: relative;
-    padding-left: 51px;
-  }
-  p.info {
-    position: relative;
-    font-size: 15px;
-    margin-bottom: 10px;
-  }
-  p.info:before, p.info:after {
-    content: "";
-    position: absolute;
-    top: 9%;
-    left: 0;
-  }
-  p.info:before {
-    content: "i";
-    left: 3px;
-    width: 20px;
-    height: 20px;
-    font-family: serif;
-    font-size: 15px;
-    font-weight: bold;
-    line-height: 21px;
-    text-align: center;
-    color: #fff;
-    background: #4d5258;
-    border-radius: 16px;
-  }
-
-  @media (min-width: 768px) {
-    body {
-      margin: 4em 3em;
-    }
-    h1 {
-      font-size: 2.15em;}
-  }
-
-  </style>
+      @media (min-width: 768px) {
+        body {
+          margin: 6em;
+        }
+      }
+    </style>
   </head>
   <body>
     <div>

--- a/images/router/nginx/conf/error-page-503.html
+++ b/images/router/nginx/conf/error-page-503.html
@@ -2,108 +2,67 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <style type="text/css">
-  /*!
-   * Bootstrap v3.3.5 (http://getbootstrap.com)
-   * Copyright 2011-2015 Twitter, Inc.
-   * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
-   */
-  /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
-  html {
-    font-family: sans-serif;
-    -ms-text-size-adjust: 100%;
-    -webkit-text-size-adjust: 100%;
-  }
-  body {
-    margin: 0;
-  }
-  h1 {
-    font-size: 1.7em;
-    font-weight: 400;
-    line-height: 1.3;
-    margin: 0.68em 0;
-  }
-  * {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-  }
-  *:before,
-  *:after {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-  }
-  html {
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  }
-  body {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    line-height: 1.66666667;
-    font-size: 13px;
-    color: #333333;
-    background-color: #ffffff;
-    margin: 2em 1em;
-  }
-  p {
-    margin: 0 0 10px;
-    font-size: 13px;
-  }
-  .alert.alert-info {
-    padding: 15px;
-    margin-bottom: 20px;
-    border: 1px solid transparent;
-    background-color: #f5f5f5;
-    border-color: #8b8d8f;
-    color: #363636;
-    margin-top: 30px;
-  }
-  .alert p {
-    padding-left: 35px;
-  }
-  a {
-    color: #0088ce;
-  }
+    <style type="text/css">
+      body {
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        line-height: 1.66666667;
+        font-size: 16px;
+        color: #333;
+        background-color: #fff;
+        margin: 2em 1em;
+      }
+      h1 {
+        font-size: 28px;
+        font-weight: 400;
+      }
+      p {
+        margin: 0 0 10px;
+      }
+      .alert.alert-info {
+        background-color: #F0F0F0;
+        margin-top: 30px;
+        padding: 30px;
+      }
+      .alert p {
+        padding-left: 35px;
+      }
+      ul {
+        padding-left: 51px;
+        position: relative;
+      }
+      li {
+        font-size: 14px;
+        margin-bottom: 1em;
+      }
+      p.info {
+        position: relative;
+        font-size: 20px;
+      }
+      p.info:before, p.info:after {
+        content: "";
+        left: 0;
+        position: absolute;
+        top: 0;
+      }
+      p.info:before {
+        background: #0066CC;
+        border-radius: 16px;
+        color: #fff;
+        content: "i";
+        font: bold 16px/24px serif;
+        height: 24px;
+        left: 0px;
+        text-align: center;
+        top: 4px;
+        width: 24px;
+      }
 
-  ul {
-    position: relative;
-    padding-left: 51px;
-  }
-  p.info {
-    position: relative;
-    font-size: 15px;
-    margin-bottom: 10px;
-  }
-  p.info:before, p.info:after {
-    content: "";
-    position: absolute;
-    top: 9%;
-    left: 0;
-  }
-  p.info:before {
-    content: "i";
-    left: 3px;
-    width: 20px;
-    height: 20px;
-    font-family: serif;
-    font-size: 15px;
-    font-weight: bold;
-    line-height: 21px;
-    text-align: center;
-    color: #fff;
-    background: #4d5258;
-    border-radius: 16px;
-  }
-
-  @media (min-width: 768px) {
-    body {
-      margin: 4em 3em;
-    }
-    h1 {
-      font-size: 2.15em;}
-  }
-
-  </style>
+      @media (min-width: 768px) {
+        body {
+          margin: 6em;
+        }
+      }
+    </style>
   </head>
   <body>
     <div>


### PR DESCRIPTION
@sg00dwin proposed me new CSS which they are using for the management console. It's based on PatternFly4 which is not using bootstrap and normalize.css anymore.

This is [how 503 page looked before](https://codepen.io/alebedev87/pen/NWpBGdP).
This is [how it looks now.](https://codepen.io/alebedev87/pen/bGqjVEX).
This is [how 404 page looks now](https://codepen.io/alebedev87/pen/mdWjJKL).

Note that nginx 503 page was not using CRLF, I kept it this way.