### PR TITLE
haproxy-config.template: Make maxconn optional

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -53,7 +53,11 @@ global
 {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (env "ROUTER_HARD_STOP_AFTER")) }}
   hard-stop-after {{ $value }}
 {{- end }}
-  maxconn {{ env "ROUTER_MAX_CONNECTIONS" "20000" }}
+{{- with $value := env "ROUTER_MAX_CONNECTIONS" "20000" }}
+  {{- if isInteger $value }}
+  maxconn {{ $value }}
+  {{- end }}
+{{- end }}
 {{- $threads := env "ROUTER_THREADS" }}
 {{- if ne "" (firstMatch "[1-9][0-9]*" $threads) }}
   nbthread {{ $threads }}
@@ -119,7 +123,11 @@ global
   {{- end }}
 
 defaults
-  maxconn {{ env "ROUTER_MAX_CONNECTIONS" "20000" }}
+  {{- with $value := env "ROUTER_MAX_CONNECTIONS" "20000" }}
+    {{- if isInteger $value }}
+  maxconn {{ $value }}
+    {{- end }}
+  {{- end }}
 
   {{- if ne (env "ROUTER_SYSLOG_ADDRESS") "" }}
     {{- if ne (env "ROUTER_SYSLOG_FORMAT") "" }}


### PR DESCRIPTION
If the `ROUTER_MAX_CONNECTIONS` environment variable is not set, omit the `maxconn` option in the generated `haproxy.config` file.

HAProxy 2.2 and later compute a default value for maxconn based on the value of `ulimit -n`, which leaves performance tuning and handling of resource exhaustion to the platform where it belongs.

* `images/router/haproxy/conf/haproxy-config.template`: Omit `maxconn` if `ROUTER_MAX_CONNECTIONS` is empty or unset.