### PR TITLE
Bug 1964482: config template: accept IPv6 IPs for whitelisting

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -15,15 +15,6 @@
 {{- /* quadPattern: Match a quad in an IP address; e.g. 123 */}}
 {{- $quadPattern := `(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])` -}}
 
-{{- /* ipPattern: Match an IPv4 address; e.g. 192.168.21.23 */}}
-{{- $ipPattern := printf `(?:%s\.%s\.%s\.%s)` $quadPattern $quadPattern $quadPattern $quadPattern -}}
-
-{{- /* cidrPattern: Match an IP and network size in CIDR form; e.g. 192.168.21.23/24 */}}
-{{- $cidrPattern := printf `(?:%s(?:/(?:[0-9]|[1-2][0-9]|3[0-2]))?)` $ipPattern -}}
-
-{{- /* cidrListPattern: Match a space separated list of CIDRs; e.g. 192.168.21.23/24 192.10.2.12 */}}
-{{- $cidrListPattern := printf `(?:%s(?: +%s)*)` $cidrPattern $cidrPattern -}}
-
 {{- /* cookie name pattern: */}}
 {{- $cookieNamePattern := `[a-zA-Z0-9_-]+` -}}
 
@@ -494,7 +485,7 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
         {{- else }}
   balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}{{ firstMatch $balanceAlgoPattern (env "ROUTER_LOAD_BALANCE_ALGORITHM") "random" }}{{ end }}
         {{- end }}
-        {{- with $ip_whiteList := firstMatch $cidrListPattern (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist") }}
+        {{- with $ip_whiteList := parseIPList (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist") }}
           {{- if validateHAProxyWhiteList $ip_whiteList }}
   acl whitelist src {{ $ip_whiteList }}
           {{- else }}
@@ -681,7 +672,7 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
         {{- else }}
   balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}{{ firstMatch $balanceAlgoPattern (env "ROUTER_TCP_BALANCE_SCHEME") (env "ROUTER_LOAD_BALANCE_ALGORITHM") "source" }}{{ end }}
         {{- end }}
-        {{- with $ip_whiteList := firstMatch $cidrListPattern (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist") }}
+        {{- with $ip_whiteList := parseIPList (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist") }}
           {{- if validateHAProxyWhiteList $ip_whiteList }}
   acl whitelist src {{ $ip_whiteList }}
           {{- else }}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -216,6 +216,21 @@ func TestConfigTemplate(t *testing.T) {
 				configSnippet: "acl whitelist src -f " + filepath.Join(h.dirs["whitelist"], h.namespace+":a.txt"),
 			},
 		},
+		"Whitelist of mixed IPs": {
+			mustCreateWithConfig{
+				mustCreate: mustCreate{
+					name: "a1",
+					host: "a1example.com",
+					path: "",
+					time: start,
+					annotations: map[string]string{
+						"haproxy.router.openshift.io/ip_whitelist": "192.168.1.0 2001:0db8:85a3:0000:0000:8a2e:0370:7334 172.16.14.10/24 2001:0db8:85a3::8a2e:370:10/64 64:ff9b::192.168.0.1 2600:14a0::/40",
+					},
+					tlsTermination: routev1.TLSTerminationEdge,
+				},
+				configSnippet: "acl whitelist src 192.168.1.0 2001:0db8:85a3:0000:0000:8a2e:0370:7334 172.16.14.10/24 2001:0db8:85a3::8a2e:370:10/64 64:ff9b::192.168.0.1 2600:14a0::/40",
+			},
+		},
 		"Simple HSTS header": {
 			mustCreateWithConfig{
 				mustCreate: mustCreate{


### PR DESCRIPTION
New template helper to parse a list of IPs/CIDRs for the whitelisting.
Takes a different approach than https://github.com/openshift/router/pull/262 which uses a long regexp for IPv6 IPs/CIDRs.
The new function aims to keep the same behavior as the previous approach hence some corner cases (i.e. leading/trailing spaces).

