### PR TITLE
WIP: reload-haproxy: Adjust oom_score_adj of old procs

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -69,6 +69,18 @@ function haproxyHealthCheck() {
 }
 
 
+function adjustOomScores() {
+    for pid; do
+	old_score=$(< /proc/$pid/oom_score_adj)
+	new_score=$((old_score + 10))
+	# The maximum value for oom_score_adj is 1000.
+	[[ $new_score -gt 1000 ]] && continue
+	echo $new_score > /proc/$pid/oom_score_adj
+	echo " - Adjusted oom_score_adj for haproxy[$pid] from $old_score to $new_score."
+    done
+}
+
+
 old_pids=$(pidof haproxy)
 
 # If signaled, stop accepting new connections and drain the current processes
@@ -101,3 +113,4 @@ fi
 
 [ $reload_status -ne 0 ] && exit $reload_status
 haproxyHealthCheck
+adjustOomScores $old_pids


### PR DESCRIPTION
Add logic to increase the `oom_score_adj` setting for each old `haproxy` process when reloading HAProxy.

* `images/router/haproxy/reload-haproxy` (`adjustOomScores`): New function. Increase the `oom_score_adj` setting for each of the provided pids by 10.  Call `adjustOomScores` at the end of `reload-haproxy`.