### PR TITLE
Revert "Merge pull request #314 from frobware/bump-haproxy-2.4.1"

### DIFF
--- a/hack/Dockerfile.debug
+++ b/hack/Dockerfile.debug
@@ -1,5 +1,5 @@
 FROM centos:8
-RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy24-2.4.1-1.el8.x86_64.rpm
+RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy22-2.2.5-1.el8.x86_64.rpm
 RUN haproxy -vv
 RUN INSTALL_PKGS="rsyslog procps-ng util-linux socat" && \
     yum install -y $INSTALL_PKGS && \

--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy24 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy22 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy24 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy22 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/ocp/4.9:haproxy-router-base
-RUN INSTALL_PKGS="haproxy24 rsyslog procps-ng util-linux" && \
+RUN INSTALL_PKGS="haproxy22 rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
This reverts commit 9c39f5887c671ec0a69949ee9bb7a6b4a26b51ce, reversing
changes made to 9dc58cb877bbefd13e75ff4d6ae7f4f87935b78b.

Our performance analysis shows there are degradations compared to
haproxy-2.2 series so we're reverting for now until these are
understood.