### PR TITLE
NE-412: Add ROUTER_INSPECT_DELAY

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -193,7 +193,7 @@ frontend public
     {{- end }}
   {{- if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
   mode http
-  tcp-request inspect-delay 5s
+  tcp-request inspect-delay {{ env "ROUTER_INSPECT_DELAY" "5s" }}
   tcp-request content accept if HTTP
 
     {{- if (eq .StatsPort -1) }}
@@ -246,7 +246,7 @@ frontend public_ssl
   bind :{{ env "ROUTER_SERVICE_HTTPS_PORT" "443" }}
     {{- end }}
   {{- if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
-  tcp-request  inspect-delay 5s
+  tcp-request inspect-delay {{ env "ROUTER_INSPECT_DELAY" "5s" }}
   tcp-request content accept if { req_ssl_hello_type 1 }
 
   # if the connection is SNI and the route is a passthrough don't use the termination backend, just use the tcp backend


### PR DESCRIPTION
ROUTER_INSPECT_DELAY controls how long HAProxy can hold packets for inspection before it must forward to a backend. If unset, default inspect delay is 5s