### PR TITLE
Bug 1988801: haproxy-config.template: Fix power-of-two balancing

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -19,7 +19,7 @@
 {{- $cookieNamePattern := `[a-zA-Z0-9_-]+` -}}
 
 {{- /* balanceAlgoPattern matches valid options for the haproxy.router.openshift.io/balance annotation. */}}
-{{- $balanceAlgoPattern := "roundrobin|leastconn|source" -}}
+{{- $balanceAlgoPattern := "roundrobin|leastconn|source|random" -}}
 
 {{- $timeSpecPattern := `[1-9][0-9]*(us|ms|s|m|h|d)?` }}
 


### PR DESCRIPTION
Update the set of allowed balancing algorithms to include "random", i.e., the "Power of Two Random Choices" algorithm.  An earlier change was supposed to make "random" the default algorithm but failed to add it to the set of allowed algorithms.  As a result, the template would configure HAProxy to the "roundrobin" algorithm by default.  This change makes it so the effective default is "random", as intended in the earlier change.

Follow-up to https://github.com/openshift/router/pull/192/commits/dbc994cd367c1d162772a189d969d64d0b8f1341.

* `images/router/haproxy/conf/haproxy-config.template`: Fix `$balanceAlgoPattern` to match "random".


---

/cherry-pick release-4.8