### PR TITLE
Bug 1826225: Support edge-terminated h2 connections

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -631,6 +631,8 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
                     {{- end }}
                   {{- end }}
                 {{- else if or (eq $cfg.TLSTermination "") (eq $cfg.TLSTermination "edge") }}
+                  {{- if eq $endpoint.AppProtocol "h2c" }} proto h2
+                  {{- end }}
                 {{- end }}{{/* end type specific options*/}}
 
                 {{- if and (not $endpoint.NoHealthCheck) (gt $cfg.ActiveEndpoints 1) }} check inter {{firstMatch $timeSpecPattern (index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval") (env "ROUTER_BACKEND_CHECK_INTERVAL") "5000ms" }}

--- a/pkg/router/template/configmanager/haproxy/backend.go
+++ b/pkg/router/template/configmanager/haproxy/backend.go
@@ -258,7 +258,7 @@ func (b *Backend) Servers() ([]BackendServerInfo, error) {
 }
 
 // UpdateServerInfo updates the information for a haproxy backend server.
-func (b *Backend) UpdateServerInfo(id, ipaddr, port string, weight int32, relativeWeight bool) error {
+func (b *Backend) UpdateServerInfo(id, ipaddr, port, appProtocol string, weight int32, relativeWeight bool) error {
 	server, err := b.FindServer(id)
 	if err != nil {
 		return err
@@ -269,6 +269,9 @@ func (b *Backend) UpdateServerInfo(id, ipaddr, port string, weight int32, relati
 	}
 	if n, err := strconv.Atoi(port); err == nil && n > 0 {
 		server.updatedPort = n
+	}
+	if appProtocol == "h2c" {
+		return errors.New("dynamically updating proto is unsupported")
 	}
 	if weight > -1 {
 		suffix := ""

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -300,9 +300,10 @@ func createRouterEndpoints(endpoints *kapi.Endpoints, excludeUDP bool, lookupSvc
 
 			for _, port := range service.Spec.Ports {
 				endptPort := kapi.EndpointPort{
-					Name:     port.Name,
-					Port:     port.Port,
-					Protocol: port.Protocol,
+					Name:        port.Name,
+					Port:        port.Port,
+					Protocol:    port.Protocol,
+					AppProtocol: port.AppProtocol,
 				}
 				svcSubset.Ports = append(svcSubset.Ports, endptPort)
 			}
@@ -353,6 +354,10 @@ func createRouterEndpoints(endpoints *kapi.Endpoints, excludeUDP bool, lookupSvc
 				} else {
 					ep.TargetName = a.IP
 					ep.ID = fmt.Sprintf("ept:%s:%s:%s:%d", endpoints.Name, p.Name, a.IP, p.Port)
+				}
+
+				if p.AppProtocol != nil {
+					ep.AppProtocol = *p.AppProtocol
 				}
 
 				// IdHash contains an obfuscated internal IP address

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -356,7 +356,7 @@ func TestHandleEndpoints(t *testing.T) {
 	}
 }
 
-// TestHandleCPEndpoints test endpoint watch events with UDP excluded
+// TestHandleTCPEndpoints test endpoint watch events with UDP excluded
 func TestHandleTCPEndpoints(t *testing.T) {
 	testCases := []struct {
 		name                string          //human readable name for test case

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -654,8 +654,9 @@ func (r *templateRouter) CreateServiceUnit(id ServiceUnitKey) {
 	r.createServiceUnitInternal(id)
 }
 
-// CreateServiceUnit creates a new service named with the given id - internal
-// lockless form, caller needs to ensure lock acquisition [and release].
+// createServiceUnitInternal creates a new service named with the given id -
+// internal lockless form, caller needs to ensure lock acquisition [and
+// release].
 func (r *templateRouter) createServiceUnitInternal(id ServiceUnitKey) {
 	namespace, name := getPartsFromEndpointsKey(id)
 	service := ServiceUnit{

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -103,6 +103,7 @@ type Endpoint struct {
 	PortName      string
 	IdHash        string
 	NoHealthCheck bool
+	AppProtocol   string
 }
 
 // certificateManager provides the ability to write certificates for a ServiceAliasConfig


### PR DESCRIPTION
#### Fix a couple of godoc typos

* `pkg/router/template/plugin_test.go` (`TestHandleTCPEndpoints`):
* `pkg/router/template/router.go` (`createServiceUnitInternal`): Fix typos in the godoc for these functions.


#### Use HTTP/2 if endpoint's AppProtocol is "h2" or "h2c"

Check the `appProtocol` field on ports in Kubernetes `Endpoints` objects.  If the route is a reencrypt route with `appProtocol` "h2" or a non-TLS or edge-terminated route with `appProtocol` "h2c", configure HAProxy to use HTTP/2 for the endpoint.

Add checks in the dynamic config manager to force a full reload when a new endpoint specifies `appProtocol: h2` or `appProtocol: h2c` or an existing endpoint is modified to change it to or from specifying one of these appProtocol values on a port.  Dynamically configuring such an endpoint would require a way to set proto on the HAProxy server, and HAProxy's management interface does not provide any way to do so.

* `images/router/haproxy/conf/haproxy-config.template`: Specify `proto h2` for the server corresponding to an endpoint associated with a reencrypt route if the endpoint specifies the "h2" application protocol, and likewise for an endpoint associated with a non-TLS or edge-terminated route if the endpoint specifies the "h2c" application protocol.
* `pkg/router/template/configmanager/haproxy/backend.go` (`UpdateServerInfo`): Add `appProtocol` parameter.  If `appProtocol` is "h2" or "h2c", return an error.
* `pkg/router/template/configmanager/haproxy/manager.go` (`ReplaceRouteEndpoints`): Return an error if an endpoint's `AppProtocol` is changed to or from "h2" or "h2c".  Log `AppProtocol` and pass it to `UpdateServerInfo`.
* `pkg/router/template/plugin.go` (`createRouterEndpoints`): Copy the `AppProtocol` field from the Kubernetes `Endpoints` object to the internal `Endpoints` object.
* `pkg/router/template/types.go` (`Endpoint`): Add `AppProtocol` field.