### PR TITLE
[WIP] Add new metrics to track router reloads

### DIFF
--- a/pkg/router/template/fake.go
+++ b/pkg/router/template/fake.go
@@ -1,5 +1,7 @@
 package templaterouter
 
+import "github.com/prometheus/client_golang/prometheus"
+
 // NewFakeTemplateRouter provides an empty template router with a simple certificate manager
 // backed by a fake cert writer for testing
 func NewFakeTemplateRouter() *templateRouter {
@@ -9,6 +11,7 @@ func NewFakeTemplateRouter() *templateRouter {
 		serviceUnits:              make(map[ServiceUnitKey]ServiceUnit),
 		certManager:               fakeCertManager,
 		rateLimitedCommitFunction: nil,
+		metricConfigChanges:       *prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"operation"}),
 	}
 }
 


### PR DESCRIPTION
- When debugging production issues we don't have a clear picture of the number of HAProxy reloads that take place
- Experiment with a metric that allows us to track route_{add,delete,modified}

