### PR TITLE
added support for syslog max length configurability

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -58,7 +58,7 @@ global
 
   daemon
 {{- with (env "ROUTER_SYSLOG_ADDRESS") }}
-  log {{ . }} {{ env "ROUTER_LOG_FACILITY" "local1" }} {{ env "ROUTER_LOG_LEVEL" "warning" }}
+  log {{ . }} len {{ env "ROUTER_LOG_MAX_LENGTH" "1024" }} {{ env "ROUTER_LOG_FACILITY" "local1" }} {{ env "ROUTER_LOG_LEVEL" "warning" }}
   log-send-hostname
 {{- end }}
   ca-base /etc/ssl


### PR DESCRIPTION
Updated to support the syslog's maximum message length in the HA proxy config template