### PR TITLE
Bug 1894431: Add missing newlines to default certificate and key

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -291,6 +291,9 @@ func secretToPem(secPath, outName string) error {
 	if err != nil {
 		return err
 	}
+	if len(pemBlock) > 0 && pemBlock[len(pemBlock)-1] != byte('\n') {
+		pemBlock = append(pemBlock, byte('\n'))
+	}
 	keys, err := privateKeysFromPEM(pemBlock)
 	if err != nil {
 		return err
@@ -300,6 +303,9 @@ func secretToPem(secPath, outName string) error {
 		keyBlock, err := ioutil.ReadFile(fileKeyName)
 		if err != nil {
 			return err
+		}
+		if len(keyBlock) > 0 && keyBlock[len(keyBlock)-1] != byte('\n') {
+			keyBlock = append(keyBlock, byte('\n'))
 		}
 		pemBlock = append(pemBlock, keyBlock...)
 	}


### PR DESCRIPTION
Before this change, if the administrator provided a default certificate that was missing the newline character for the last line, the router would write out a corrupt PEM file for HAProxy, causing HAProxy to fail to start. This change adds logic to add the missing newline character to an incomplete line when writing out the PEM file.  As a result, the router now writes out a valid PEM file so that HAProxy can start even if the input is missing a newline character.

* `pkg/router/template/router.go` (`secretToPem`): Check for missing newline characters and add them if needed.
* `pkg/router/template/router_test.go` (`testWildcardCertificate`, `testWildcardCertificateKey`): New consts.
(`TestSecretToPem`): Verify that `secretToPem` writes out the expected PEM file.