### PR TITLE
Bug 1909906: Exit immediately if stats port is taken

### DIFF
--- a/pkg/router/metrics/metrics.go
+++ b/pkg/router/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"os"
 	"strings"
 
 	"github.com/cockroachdb/cmux"
@@ -129,7 +130,7 @@ func (l Listener) Listen() {
 	tcpl, err := net.Listen("tcp", l.Addr)
 	if err != nil {
 		log.Error(err, "listening on the metrics port failed")
-		shutdown.RequestShutdown()
+		os.Exit(1)
 	}
 
 	// if a TLS connection was requested, set up a connection mux that will send TLS requests to


### PR DESCRIPTION
Call `os.Exit(1)` in the metrics `Listen` method if `net.Listen` fails (for example, because the stats port is already taken) so that the user immediately gets a nonzero exit code with a clear error message indicating that OpenShift router failed to start and why.

Before this change, the metrics `Listen` method called `shutdown.RequestShutdown()` when `net.Listen` returned an error.  This approach has at least four issues:

* Calling `shutdown.RequestShutdown()` doesn't cause the `Listen` method to return, so it continues to set up a cmux etc. with a nil value for `tcpl`,which causes cmux eventually to segfault.  (This is an issue only with the first call to `RequestShutdown` in the `Listen` method; the other calls to `RequestShutdown` are inside goroutines that already return immediately after they call `RequestShutdown`.)  We could simply add a return statement after the call to `RequestShutdown`, except...

* We really do want to exit immediately if `Listen` fails.  The graceful shutdown is only needed if the listener, controller, etc. have started and then one of the listener's goroutines encounters an error.  More importantly though...

* Calling `shutdown.RequestShutdown()` before the controller has started the informer cache causes the stop channel that is passed to the informer cache initialization to be already closed before the informer cache starts, which prevents the graceful shutdown from happening at all.

* Lastly, if `Listen` fails to bind the stats port, the process should exit with a nonzero status code, but a graceful shutdown exits with a zero status code.

Follow-up to https://github.com/openshift/router/pull/266.

* `pkg/router/metrics/metrics.go` (`Listen`): Call `os.Exit` if `net.Listen` fails.