### PR TITLE
Bug 2093454: HAProxy: enable PROXY protocol for all listeners

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -192,14 +192,13 @@ listen stats
   {{ if .BindPorts -}}
 frontend public
     {{ if eq "v4v6" $router_ip_v4_v6_mode }}
-  bind :{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }}
-  bind :::{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }} v6only
+  bind :{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }}{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
+  bind :::{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }} v6only{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
     {{- else if eq "v6" $router_ip_v4_v6_mode }}
-  bind :::{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }} v6only
+  bind :::{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }} v6only{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
     {{- else }}
-  bind :{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }}
+  bind :{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }}{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
     {{- end }}
-  {{- if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
   mode http
   tcp-request inspect-delay {{ firstMatch $timeSpecPattern (env "ROUTER_INSPECT_DELAY") "5s" }}
   tcp-request content accept if HTTP
@@ -246,14 +245,13 @@ frontend public_ssl
   option tcplog
     {{- end }}
     {{ if eq "v4v6" $router_ip_v4_v6_mode }}
-  bind :{{ env "ROUTER_SERVICE_HTTPS_PORT" "443" }}
-  bind :::{{ env "ROUTER_SERVICE_HTTPS_PORT" "443" }} v6only
+  bind :{{ env "ROUTER_SERVICE_HTTPS_PORT" "443" }}{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
+  bind :::{{ env "ROUTER_SERVICE_HTTPS_PORT" "443" }} v6only{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
     {{- else if eq "v6" $router_ip_v4_v6_mode }}
-  bind :::{{ env "ROUTER_SERVICE_HTTPS_PORT" "443" }} v6only
+  bind :::{{ env "ROUTER_SERVICE_HTTPS_PORT" "443" }} v6only{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
     {{- else }}
-  bind :{{ env "ROUTER_SERVICE_HTTPS_PORT" "443" }}
+  bind :{{ env "ROUTER_SERVICE_HTTPS_PORT" "443" }}{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
     {{- end }}
-  {{- if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
   tcp-request inspect-delay {{ firstMatch $timeSpecPattern (env "ROUTER_INSPECT_DELAY") "5s" }}
   tcp-request content accept if { req_ssl_hello_type 1 }
 


### PR DESCRIPTION
Previously, the `accept-proxy` directive (which enables HAProxy to
listen for PROXY protocol instead of regular HTTP traffic) was only
appended to the last entry in the section.
This worked fine for the IPv4 or IPv6 single-stack use-case, but not
for the dual-stack use-case. The following configuration is generated,
which means HAProxy listens for HTTP traffic via IPv4 and PROXY
protocol traffic via IPv6:

> bind :80
> bind :::80 v6only accept-proxy

This patch corrects the behavior such that the following configuration
is generated, where HAProxy correctly listens for PROXY protocol on
IPv4 and IPv6:

> bind :80 accept-proxy
> bind :::80 v6only accept-proxy

Signed-off-by: Jack Henschel <jackdev@mailbox.org>