### PR TITLE
NE-822 Don't scale route weight on single service routes

### DIFF
--- a/pkg/router/template/router_test.go
+++ b/pkg/router/template/router_test.go
@@ -948,6 +948,46 @@ func TestCalculateServiceWeights(t *testing.T) {
 				suKey2: 256,
 			},
 		},
+		{
+			name: "a single service with a single endpoint",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 50,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 1,
+			},
+		},
+		{
+			name: "a single service with a multiple endpoints",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep2},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 50,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 1,
+			},
+		},
+		{
+			name:            "no services with no endpoints",
+			serviceUnits:    map[ServiceUnitKey][]Endpoint{},
+			serviceWeights:  map[ServiceUnitKey]int32{},
+			expectedWeights: map[ServiceUnitKey]int32{},
+		},
+		{
+			name: "service with no endpoint",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 100,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Change to not scale weight to 256 if there is only one service for the route. More information can be found here: [NE-709 Impact of Server Weight on Memory Allocation](https://docs.google.com/document/d/1QX7GpJTWTpBAga4TMrshDCi5mHAd-4-IizcQS1CCMS4/edit)

In a nutshell, scaling the weight to 256 is redundant for single services routes since all servers in the haproxy backend will always have the same weight, so therefore weight 1 == weight 256. Reducing the weight helps with reducing the static memory allocation.