### PR TITLE
Bug 2025624: Fix certificate reloader

### DIFF
--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -786,7 +786,7 @@ func makeTLSConfig(reloadPeriod time.Duration) (*tls.Config, error) {
 				}
 
 				// Something changed, reload the certificate.
-				latest, err := tls.X509KeyPair(certBytes, keyBytes)
+				latest, err := tls.X509KeyPair(latestCertBytes, latestKeyBytes)
 				if err != nil {
 					log.Error(err, "failed to reload certificate", "cert", certFile, "key", keyFile)
 					break


### PR DESCRIPTION
Ingress router metrics endpoint was still serving old certificates after certificate rotation. This fixes the logic to reload the certificate when there is a change.