### PR TITLE
Bug 2076297: Fix gap in router's handling of graceful shutdowns.

### DIFF
--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	kclientset "k8s.io/client-go/kubernetes"
 	kcache "k8s.io/client-go/tools/cache"
@@ -127,7 +126,7 @@ func (f *RouterControllerFactory) initInformers(rc *routercontroller.RouterContr
 
 	// Wait for informers cache to be synced
 	for objType, informer := range f.informers {
-		if !kcache.WaitForCacheSync(utilwait.NeverStop, informer.HasSynced) {
+		if !kcache.WaitForCacheSync(stopCh, informer.HasSynced) {
 			utilruntime.HandleError(fmt.Errorf("failed to sync cache for %+v shared informer", objType))
 		}
 	}


### PR DESCRIPTION
  If you quickly start and send a SIGTERM to the router, it will hang indefinitely.
  The call to WaitForCacheSync wasn't listening for a SIGTERM and wouldn't terminate
  if still trying to sync cache.