### PR TITLE
NE-1071: Default HAProxy maxconn value to 50000 for OCP 4.12

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -44,7 +44,7 @@ global
 {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (env "ROUTER_HARD_STOP_AFTER")) }}
   hard-stop-after {{ $value }}
 {{- end }}
-{{- with $value := env "ROUTER_MAX_CONNECTIONS" "20000" }}
+{{- with $value := env "ROUTER_MAX_CONNECTIONS" "50000" }}
   {{- if isInteger $value }}
   maxconn {{ $value }}
   {{- end }}
@@ -122,7 +122,7 @@ global
   {{- end }}
 
 defaults
-  {{- with $value := env "ROUTER_MAX_CONNECTIONS" "20000" }}
+  {{- with $value := env "ROUTER_MAX_CONNECTIONS" "50000" }}
     {{- if isInteger $value }}
   maxconn {{ $value }}
     {{- end }}


### PR DESCRIPTION
This change increases the maximum number of simultaneous connections
that HAProxy will accommodate to 50000. This change will improve
router throughput at the expense of a modest increase in memory usage.

Using the following parameters we see a 3MB increase per-process.

## algorithm=random weight=1 backends=1000 threads=4

```
maxconn  maxconn (HAProxy)  maxsock (HAProxy)  Process Size (MB)
-------  -----------------  -----------------  -----------------
   2000               2000               4054                 53
  20000              20000              40054                 56
  50000              50000             100054                 59
 100000             100000             200054                 66
 200000             200000             400054                 78
   auto             524261            1048576                119
```

And with 64 threads (the current HAProxy maximum) a 4MB increase
per-process:

## algorithm=random weight=1 backends=1000 threads=64

```
maxconn  maxconn (HAProxy)  maxsock (HAProxy)  Process Size (MB)
-------  -----------------  -----------------  -----------------
   2000               2000               4234                 90
  20000              20000              40234                 91
  50000              50000             100234                 95
 100000             100000             200234                101
 200000             200000             400234                114
   auto             524171            1048576                154
```

[1] https://github.com/openshift/enhancements/blob/master/enhancements/ingress/haproxy-max-connections-tuning.md#increased-resource-usage
