### PR TITLE
Updating ose-haproxy-router-base images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.12
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/images/router/base/Dockerfile.rhel
+++ b/images/router/base/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/router
 COPY . .
 RUN make

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -245,16 +245,16 @@ func NewCommandTemplateRouter(name string) *cobra.Command {
 // validTokenRE matches valid tokens as defined in section 2.2 of RFC 2616.
 // A token comprises 1 or more non-control and non-separator characters:
 //
-//   token          = 1*<any CHAR except CTLs or separators>
-//   CHAR           = <any US-ASCII character (octets 0 - 127)>
-//   CTL            = <any US-ASCII control character
-//                    (octets 0 - 31) and DEL (127)>
-//   separators     = "(" | ")" | "<" | ">" | "@"
-//                  | "," | ";" | ":" | "\" | <">
-//                  | "/" | "[" | "]" | "?" | "="
-//                  | "{" | "}" | SP | HT
-//   SP             = <US-ASCII SP, space (32)>
-//   HT             = <US-ASCII HT, horizontal-tab (9)>
+//	token          = 1*<any CHAR except CTLs or separators>
+//	CHAR           = <any US-ASCII character (octets 0 - 127)>
+//	CTL            = <any US-ASCII control character
+//	                 (octets 0 - 31) and DEL (127)>
+//	separators     = "(" | ")" | "<" | ">" | "@"
+//	               | "," | ";" | ":" | "\" | <">
+//	               | "/" | "[" | "]" | "?" | "="
+//	               | "{" | "}" | SP | HT
+//	SP             = <US-ASCII SP, space (32)>
+//	HT             = <US-ASCII HT, horizontal-tab (9)>
 var validTokenRE *regexp.Regexp = regexp.MustCompile(`^[\x21\x23-\x27\x2a\x2b\x2d\x2e\x30-\x39\x41-\x5a\x5e-\x7a\x7c\x7e]+$`)
 
 func parseCaptureHeaders(in string) ([]templateplugin.CaptureHTTPHeader, error) {

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -83,8 +83,8 @@ func (p *UniqueHost) HandleNode(eventType watch.EventType, node *kapi.Node) erro
 
 // HandleRoute processes watch events on the Route resource.
 // TODO: this function can probably be collapsed with the router itself, as a function that
-//   determines which component needs to be recalculated (which template) and then does so
-//   on demand.
+// determines which component needs to be recalculated (which template) and then does so
+// on demand.
 func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
 	if p.allowedNamespaces != nil && !p.allowedNamespaces.Has(route.Namespace) {
 		return nil

--- a/pkg/router/metrics/health.go
+++ b/pkg/router/metrics/health.go
@@ -54,7 +54,7 @@ func HTTPBackendAvailable(u *url.URL) healthz.HealthChecker {
 // HasSynced returns a healthz check that verifies the router has been synced at least
 // once.
 // routerPtr is a pointer because it may not yet be defined (there's a chicken-and-egg problem
-//   with when the health checker and router object are set up).
+// with when the health checker and router object are set up).
 func HasSynced(routerPtr **templateplugin.TemplatePlugin) (healthz.HealthChecker, error) {
 	if routerPtr == nil {
 		return nil, fmt.Errorf("Nil routerPtr passed to HasSynced")

--- a/pkg/router/template/certmanager_test.go
+++ b/pkg/router/template/certmanager_test.go
@@ -223,11 +223,11 @@ func TestCertManagerConfig(t *testing.T) {
 		config     *certificateManagerConfig
 		shouldPass bool
 	}{
-		"valid":                          {shouldPass: true, config: validCfg},
-		"missing certificateKeyFunc":     {shouldPass: false, config: missingCertKeyCfg},
-		"missing caCertificateKeyFunc":   {shouldPass: false, config: missingCACertKeyCfg},
-		"missing destCertificateKeyFunc": {shouldPass: false, config: missingDestCertKeyCfg},
-		"missing 	certificateDir": {shouldPass: false, config: missingCertDirCfg},
+		"valid":                                    {shouldPass: true, config: validCfg},
+		"missing certificateKeyFunc":               {shouldPass: false, config: missingCertKeyCfg},
+		"missing caCertificateKeyFunc":             {shouldPass: false, config: missingCACertKeyCfg},
+		"missing destCertificateKeyFunc":           {shouldPass: false, config: missingDestCertKeyCfg},
+		"missing 	certificateDir":                  {shouldPass: false, config: missingCertDirCfg},
 		"missing caCertificateDir":                 {shouldPass: false, config: missingCACertDirCfg},
 		"matching certificateDir/caCertificateDir": {shouldPass: false, config: matchingCertDirCfg},
 	}

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -210,8 +210,8 @@ func (p *TemplatePlugin) HandleNode(eventType watch.EventType, node *kapi.Node) 
 
 // HandleRoute processes watch events on the Route resource.
 // TODO: this function can probably be collapsed with the router itself, as a function that
-//   determines which component needs to be recalculated (which template) and then does so
-//   on demand.
+// determines which component needs to be recalculated (which template) and then does so
+// on demand.
 func (p *TemplatePlugin) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
 	switch eventType {
 	case watch.Added, watch.Modified:

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -732,7 +732,7 @@ func (r *templateRouter) removeServiceAliasAssociation(id ServiceUnitKey, alias 
 
 // dynamicallyAddRoute attempts to dynamically add a route.
 // Note: The config should have been synced at least once initially and
-//       the caller needs to acquire a lock [and release it].
+// the caller needs to acquire a lock [and release it].
 func (r *templateRouter) dynamicallyAddRoute(backendKey ServiceAliasConfigKey, route *routev1.Route, backend *ServiceAliasConfig) bool {
 	if r.dynamicConfigManager == nil {
 		return false
@@ -781,7 +781,7 @@ func (r *templateRouter) dynamicallyAddRoute(backendKey ServiceAliasConfigKey, r
 
 // dynamicallyRemoveRoute attempts to dynamically remove a route.
 // Note: The config should have been synced at least once initially and
-//       the caller needs to acquire a lock [and release it].
+// the caller needs to acquire a lock [and release it].
 func (r *templateRouter) dynamicallyRemoveRoute(backendKey ServiceAliasConfigKey, route *routev1.Route) bool {
 	if r.dynamicConfigManager == nil || !r.synced {
 		return false
@@ -800,7 +800,7 @@ func (r *templateRouter) dynamicallyRemoveRoute(backendKey ServiceAliasConfigKey
 // dynamicallyReplaceEndpoints attempts to dynamically replace endpoints
 // on all the routes associated with a given service.
 // Note: The config should have been synced at least once initially and
-//       the caller needs to acquire a lock [and release it].
+// the caller needs to acquire a lock [and release it].
 func (r *templateRouter) dynamicallyReplaceEndpoints(id ServiceUnitKey, service ServiceUnit, oldEndpoints []Endpoint) bool {
 	if r.dynamicConfigManager == nil || !r.synced {
 		return false
@@ -841,7 +841,7 @@ func (r *templateRouter) dynamicallyReplaceEndpoints(id ServiceUnitKey, service 
 // dynamicallyRemoveEndpoints attempts to dynamically remove endpoints on
 // all the routes associated with a given service.
 // Note: The config should have been synced at least once initially and
-//       the caller needs to acquire a lock [and release it].
+// the caller needs to acquire a lock [and release it].
 func (r *templateRouter) dynamicallyRemoveEndpoints(service ServiceUnit, endpoints []Endpoint) bool {
 	if r.dynamicConfigManager == nil || !r.synced {
 		return false

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -288,8 +288,8 @@ const (
 	RouterEventReloadError = "reload-error"
 )
 
-//TemplateSafeName provides a name that can be used in the template that does not contain restricted
-//characters like / which is used to concat namespace and name in the service unit key
+// TemplateSafeName provides a name that can be used in the template that does not contain restricted
+// characters like / which is used to concat namespace and name in the service unit key
 func (s ServiceUnit) TemplateSafeName() string {
 	return strings.Replace(s.Name, "/", "-", -1)
 }


### PR DESCRIPTION
Reconciling with https://github.com/openshift/ocp-build-data/tree/b44f15ec9e84d1831eac81f8c757b3bed985dbeb/images/ose-haproxy-router-base.yml

This PR is based on #422 but additionally includes formatting changes to several files to appease gofmt.  Including these changes is necessary in order for the verify job to pass.