### PR TITLE
[WIP] - DO NOT MERGE - validate-haproxy22-2.2.19-3.el8.x86_64.rpm (4.10)

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy22 rsyslog sysvinit-tools" && \
+RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/ocpbugs-3553-optimized/haproxy22-2.2.19-3.el8.x86_64.rpm
+RUN haproxy -vv
+RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,7 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy22 rsyslog sysvinit-tools" && \
+RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/ocpbugs-3553-optimized/haproxy22-2.2.19-3.el8.x86_64.rpm
+RUN haproxy -vv
+RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -1,5 +1,7 @@
 FROM registry.ci.openshift.org/ocp/4.10:haproxy-router-base
-RUN INSTALL_PKGS="haproxy22 rsyslog procps-ng util-linux" && \
+RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/ocpbugs-3553-optimized/haproxy22-2.2.19-3.el8.x86_64.rpm
+RUN haproxy -vv
+RUN INSTALL_PKGS="rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
This is a debug build of haproxy-2.2.19 to aid debugging  https://issues.redhat.com/browse/OCPBUGS-3553.

Build artefacts:
- ~~https://github.com/frobware/haproxy-builds/blob/master/ocpbugs-3553/haproxy22-2.2.19-3.el8.x86_64.rpm~~
- ~~https://github.com/frobware/haproxy-builds/blob/master/ocpbugs-3553/haproxy-2.2.13-3.el8.src.rpm~~

- https://github.com/frobware/haproxy-builds/blob/master/ocpbugs-3553-optimized/haproxy22-2.2.19-3.el8.x86_64.rpm
- https://github.com/frobware/haproxy-builds/blob/master/ocpbugs-3553-optimized/haproxy-2.2.13-3.el8.src.rpm


 

