### PR TITLE
OCPBUGS-3356: Add support for tuning tune.http.cookielen

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -122,6 +122,11 @@ global
   {{- with $ciphersuites := (env "ROUTER_CIPHERSUITES") }}
   ssl-default-bind-ciphersuites {{ $ciphersuites }}
   {{- end }}
+  {{- with $captureCookie := .CaptureHTTPCookie }}
+    {{- if (gt $captureCookie.MaxLength 63) }}
+  tune.http.cookielen {{ $captureCookie.MaxLength }}
+    {{- end }}
+  {{- end }}
 
 defaults
   {{- with $value := env "ROUTER_MAX_CONNECTIONS" "50000" }}


### PR DESCRIPTION
When access logging is enabled, the user may specify a cookie to log. If the user specifies the length as longer than `tune.http.cookielen` (or 63 bytes if `tune.http.cookielen` is unset), it will be truncated. This PR sets `tune.http.cookielen` to an appropriate value when the capture cookie length would not fit in the default `tune.http.cookielen` size.