### PR TITLE
OCPBUGS-10003: Revert "NE-1115: Update haproxy container builds to use haproxy 2.6"

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy26 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy22 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy26 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy22 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/ocp/4.13:haproxy-router-base
-RUN INSTALL_PKGS="haproxy26 rsyslog procps-ng util-linux" && \
+RUN INSTALL_PKGS="haproxy22 rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
Reverting from haproxy26 to haproxy22 due to regression finding in OCPBUGS-10003.

`images/router/haproxy/Dockerfile`:
`images/router/haproxy/Dockerfile.rhel`:
`images/router/haproxy/Dockerfile.rhel8`: Update to haproxy 22 RPM in dockerfiles

Note: This will need to be timed with the rhpkg push and rhpkg build. Once the new haproxy RPM is pushed, then mirrored (takes up to 24 hours), builds for this repo will start failing (haproxy26 rpm will be removed) and this PR will need to be merged.