### PR TITLE
OCPBUGS-11595: Revert "[NE-1267] container builds: switch to haproxy26 package"

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy26 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy22 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy26 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy22 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/ocp/4.13:haproxy-router-base
-RUN INSTALL_PKGS="haproxy26 rsyslog procps-ng util-linux" && \
+RUN INSTALL_PKGS="haproxy22 rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
Reverts openshift/router#466

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

* This change is breaking ci 4.14 or nightly 4.14 payloads:
  * https://amd64.ocp.releases.ci.openshift.org/releasestream/4.14.0-0.ci/release/4.14.0-0.ci-2023-04-09-091435 
  * https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.14-e2e-gcp-ovn-upgrade/1644993213582282752 
* This test breaks some functionality or is a regression



To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of (job/X or job/X, test/Y tuple) to confirm the fix has corrected the problem:

<!-- pick the appropriate required lines from this list, where “4.y” is the latest minor version of Openshift -->
  `/payload 4.y ci blocking` (for changes that broke ci payloads)
  `/payload 4.y ci informing` (for changes that broke ci payloads)
  `/payload 4.y nightly blocking` (for changes that broke nightly payloads)
  `/payload 4.y nightly informing` (for changes that broke nightly payloads)
  `/test xxxx` (for any PR related test that should also be run)


CC: @frobware , @gcs278 , @openshift/openshift-team-network-edge 
