### PR TITLE
[WIP] NE-1267: DO NOT MERGE: validate-haproxy26-2.6.13-1.rhaos4.14.el8.x86_64.rpm (4.14)

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,8 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy22 rsyslog sysvinit-tools" && \
+RUN rpm -qp --changelog https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.14-rhel-8/haproxy26-2.6.13-1.rhaos4.14.el8.x86_64.rpm
+RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.14-rhel-8/haproxy26-2.6.13-1.rhaos4.14.el8.x86_64.rpm
+RUN haproxy -vv
+RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,8 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy22 rsyslog sysvinit-tools" && \
+RUN rpm -qp --changelog https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.14-rhel-8/haproxy26-2.6.13-1.rhaos4.14.el8.x86_64.rpm
+RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.14-rhel-8/haproxy26-2.6.13-1.rhaos4.14.el8.x86_64.rpm
+RUN haproxy -vv
+RUN INSTALL_PKGS="rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -1,5 +1,8 @@
 FROM registry.ci.openshift.org/ocp/4.14:haproxy-router-base
-RUN INSTALL_PKGS="haproxy22 rsyslog procps-ng util-linux" && \
+RUN rpm -qp --changelog https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.14-rhel-8/haproxy26-2.6.13-1.rhaos4.14.el8.x86_64.rpm
+RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.14-rhel-8/haproxy26-2.6.13-1.rhaos4.14.el8.x86_64.rpm
+RUN haproxy -vv
+RUN INSTALL_PKGS="rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
~~RPM build: https://brew-task-repos.engineering.redhat.com/repos/scratch/amcdermo/haproxy/2.6.13/1.rhaos4.14.el8/~~

Thu 11 May 13:43:14 BST 2023
Build replaced: https://github.com/frobware/haproxy-builds/commit/bc62fa8b0c3e3db2442da544791e0f91ca3cc901 to include the fix for https://github.com/haproxy/haproxy/issues/2114.
