### PR TITLE
RFE-4087: support for the haproxy.router.openshift.io/aws-cloud-front-id annotation

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -519,7 +519,11 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
         {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout-tunnel")) }}
   timeout tunnel  {{ $value }}
         {{- end }}
-
+        {{- with $awsCloudFrontAnnotation := index $cfg.Annotations "haproxy.router.openshift.io/aws-cloud-front-id" }}
+  acl awscloudfront req.hdr(X-Aws-CFID) -m str {{ $awsCloudFrontAnnotation }}
+  http-request deny unless awscloudfront
+        {{- end }}
+	
         {{- if isTrue (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections") }}
   stick-table type ip size 100k expire 30s store conn_cur,conn_rate(3s),http_req_rate(10s)
   tcp-request content track-sc2 src


### PR DESCRIPTION
This PR enables the support for the haproxy.router.openshift.io/aws-cloud-front-id annotation.
If a route is annotated with haproxy.router.openshift.io/aws-cloud-front-id only connections with the HTTP header X-Aws-CFID matching the annotation value are permitted.

This allows to secure routes that are behind an AWS CloudFront as described in AWS docs:
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html

See the RFE https://issues.redhat.com/browse/RFE-4087