### PR TITLE
 OCPBUGS-16375: make SSL server health checks use TCP/L4 and HTTP/1.x

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -173,23 +173,12 @@ defaults
   option h1-case-adjust-bogus-client
   {{- end }}
 
-  {{ if (gt .StatsPort -1) }}
 listen stats
-  bind :{{ if (gt .StatsPort 0) }}{{ .StatsPort }}{{ else }}1936{{ end }}
+  bind :1937
   mode http
-  # Health check monitoring uri.
-  monitor-uri /healthz
-
-    {{- if and (and (ne .StatsUser "") (ne .StatsPassword "")) (gt .StatsPort 0) }}
-  # Add your custom health check monitoring failure condition here.
-  # monitor fail if <condition>
   stats enable
-  stats hide-version
-  stats realm Haproxy\ Statistics
+  stats refresh 15s
   stats uri /
-  stats auth {{ .StatsUser }}:{{ .StatsPassword }}
-    {{- end }}
-  {{- end }}
 
   {{ if .BindPorts -}}
 frontend public

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -619,7 +619,7 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
               {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
   server {{ $endpoint.ID }} {{ $endpoint.IP }}:{{ $endpoint.Port }} cookie {{ $endpoint.IdHash }} weight {{ $weight }}
                 {{- if (eq $cfg.TLSTermination "reencrypt") }} ssl
-                  {{- if not (isTrue $router_disable_http2) }} alpn h2,http/1.1
+                  {{- if not (isTrue $router_disable_http2) }} alpn h2,http/1.1 no-check-ssl check-alpn http/1.0,http/1.1
                   {{- end }}
                   {{- if $cfg.VerifyServiceHostname }} verifyhost {{ $serviceUnit.Hostname }}
                   {{- end }}


### PR DESCRIPTION
- [WIP] [OCPBUGS-16375]: - DO NOT COMMIT - enable HAProxy stats page for debugging
- [WIP] [OCPBUGS-16375]: make SSL server health checks use TCP/L4 and HTTP/1.x
