### PR TITLE
OCPBUGS-17653: haproxy/template: mitigate CVE-2023-40225

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -227,6 +227,9 @@ frontend public
   capture cookie {{ $captureCookie.Name }}{{ if eq $captureCookie.MatchType "exact" }}={{ end }} len {{ $captureCookie.MaxLength }}
     {{- end }}
 
+  # Mitigate CVE-2023-40225 (Proxy forwards malformed empty Content-Length headers)
+  http-request deny if { hdr_len(content-length) 0 }
+
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
 
@@ -336,6 +339,9 @@ frontend fe_sni
   capture cookie {{ $captureCookie.Name }}{{ if eq $captureCookie.MatchType "exact" }}={{ end }} len {{ $captureCookie.MaxLength }}
     {{- end }}
 
+  # Mitigate CVE-2023-40225 (Proxy forwards malformed empty Content-Length headers)
+  http-request deny if { hdr_len(content-length) 0 }
+
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
 
@@ -442,6 +448,9 @@ frontend fe_no_sni
     {{- with $captureCookie := .CaptureHTTPCookie }}
   capture cookie {{ $captureCookie.Name }}{{ if eq $captureCookie.MatchType "exact" }}={{ end }} len {{ $captureCookie.MaxLength }}
     {{- end }}
+
+  # Mitigate CVE-2023-40225 (Proxy forwards malformed empty Content-Length headers)
+  http-request deny if { hdr_len(content-length) 0 }
 
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy


### PR DESCRIPTION
Mitigation rule taken from the HAProxy 2.6.15 release announcement:
https://www.mail-archive.com/haproxy@formilux.org/msg43864.html

And quoting from the release notes:

  the check for invalid characters on content-length header values
  doesn't reject empty headers, which can pass through. And since they
  don't have a value, they're not merged with next ones, so it is
  possible to pass a request that has both an empty content-length and
  a populated one. Such requests are invalid and the vast majority of
  servers will reject them. But there are certainly still a few
  non-compliant servers that will only look at one of them,
  considering the empty value equals zero and be fooled with this.
  Thus the problem is not as much for mainstream users as for those
  who develop their own HTTP stack or who purposely use haproxy to
  protect a known-vulnerable server, because these ones may be at
  risk. This issue was reported by Ben Kallus of Dartmouth College and
  Narf Industries. A CVE was filed for this one. There is a
  work-around, though: simply rejecting requests containing an empty
  content-length header will do the job.
