### PR TITLE
OCPBUGS-18639: properly handle weight=0

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -1304,12 +1304,18 @@ func (r *templateRouter) getActiveEndpoints(serviceUnits map[ServiceUnitKey]int3
 func (r *templateRouter) calculateServiceWeights(serviceUnits map[ServiceUnitKey]int32) map[ServiceUnitKey]int32 {
 	serviceUnitNames := make(map[ServiceUnitKey]int32)
 
-	// If there is only 1 service unit, then always set the weight 1 for all the endpoints.
+	// If there is only 1 service unit, then always set the weight 1
+	// for all the endpoints, except when the service weight is 0.
 	// Scaling the weight to 256 is redundant and causes haproxy to allocate more memory on startup.
 	if len(serviceUnits) == 1 {
-		for key := range serviceUnits {
+
+		for key, weight := range serviceUnits {
 			if r.numberOfEndpoints(key) > 0 {
-				serviceUnitNames[key] = 1
+				if weight == 0 {
+					serviceUnitNames[key] = 0
+				} else {
+					serviceUnitNames[key] = 1
+				}
 			}
 		}
 		return serviceUnitNames
@@ -1322,10 +1328,10 @@ func (r *templateRouter) calculateServiceWeights(serviceUnits map[ServiceUnitKey
 
 	// distribute service weight over the service's endpoints
 	// to get weight per endpoint
-	for key, units := range serviceUnits {
+	for key, weight := range serviceUnits {
 		numEp := r.numberOfEndpoints(key)
 		if numEp > 0 {
-			epWeight[key] = float32(units) / float32(numEp)
+			epWeight[key] = float32(weight) / float32(numEp)
 		}
 		if epWeight[key] > maxEpWeight {
 			maxEpWeight = epWeight[key]

--- a/pkg/router/template/router_test.go
+++ b/pkg/router/template/router_test.go
@@ -988,6 +988,48 @@ func TestCalculateServiceWeights(t *testing.T) {
 			},
 			expectedWeights: map[ServiceUnitKey]int32{},
 		},
+		{
+			name: "a single service with weight 0 with multiple endpoints",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep2},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+			},
+		},
+		{
+			name: "services with one of weight 0",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep2},
+				suKey2: {ep2},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 50,
+				suKey2: 0,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 256,
+				suKey2: 0,
+			},
+		},
+		{
+			name: "services with all weight 0",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep2},
+				suKey2: {ep2},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 0,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 0,
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fix regression introduced with [NE-822](https://issues.redhat.com//browse/NE-822) for services with a single endpoint having weight=0 that are wrongly sent traffic to.

Modified for backport to 4.12 to remove dependencies on https://github.com/openshift/router/pull/439.

`pkg/router/template/router.go`: Fix logic for single endpoint services to use weight=0. Change `units` variable to `weight` `pkg/router/template/router_test.go`: Add unit tests for weight=0

Modified-by: Grant Spence <gspence@redhat.com>