### PR TITLE
WIP: Follow up to https://github.com/openshift/router/pull/483

### DIFF
--- a/pkg/router/template/template_helper_test.go
+++ b/pkg/router/template/template_helper_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	routev1 "github.com/openshift/api/route/v1"
+	templateutil "github.com/openshift/router/pkg/router/template/util"
 )
 
 func buildServiceAliasConfig(name, namespace, host, path string, termination routev1.TLSTerminationType, policy routev1.InsecureEdgeTerminationPolicyType, wildcard bool) ServiceAliasConfig {
@@ -791,6 +792,15 @@ func TestClipHAProxyTimeoutValue(t *testing.T) {
 			expected: "",
 		},
 		{
+			value:    "0",
+			expected: "0",
+		},
+		{
+			value:    "s",
+			expected: "",
+			// Invalid input produces blank output
+		},
+		{
 			value:    "10",
 			expected: "10",
 		},
@@ -804,11 +814,79 @@ func TestClipHAProxyTimeoutValue(t *testing.T) {
 		},
 		{
 			value:    "100d",
-			expected: haproxyMaxTimeout,
+			expected: templateutil.HaproxyMaxTimeout,
 		},
 		{
 			value:    "1000h",
-			expected: haproxyMaxTimeout,
+			expected: templateutil.HaproxyMaxTimeout,
+		},
+		{
+			value:    "+-+",
+			expected: "",
+			// Invalid input produces blank output
+		},
+		{
+			value:    "1.5.8.9",
+			expected: "",
+			// Invalid input produces blank output
+		},
+		{
+			value:    "1.5s",
+			expected: "",
+			// Invalid input produces blank output
+		},
+		{
+			value:    "9223372036855ms",
+			expected: templateutil.HaproxyMaxTimeout,
+			// Exceeds the time.ParseDuration maximum
+		},
+		{
+			value:    "2147483647ms",
+			expected: "2147483647ms",
+		},
+		{
+			value:    "922337203685477581ms",
+			expected: templateutil.HaproxyMaxTimeout,
+			// Overflow error > 1<<63/10 + 1
+		},
+		{
+			value:    "2562047.99h",
+			expected: "",
+			// Invalid input produces blank output
+		},
+		{
+			value:    "100000000000s",
+			expected: templateutil.HaproxyMaxTimeout,
+			// Exceeds the time.ParseDuration maximum
+		},
+		{
+			value:    "9999999999999999",
+			expected: templateutil.HaproxyMaxTimeout,
+			// Exceeds the time.ParseDuration maximum and has no unit
+		},
+		{
+			value:    "25d",
+			expected: templateutil.HaproxyMaxTimeout,
+			// Exceeds the HAProxy maximum
+		},
+		{
+			value:    "24d",
+			expected: "24d",
+		},
+		{
+			value:    "24d1",
+			expected: "",
+			// Invalid input produces blank output
+		},
+		{
+			value:    "1d12h",
+			expected: "",
+			// Invalid input produces blank output
+		},
+		{
+			value:    "foo",
+			expected: "",
+			// Invalid input produces blank output
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/router/template/util/haproxytime/benchmark_test.go
+++ b/pkg/router/template/util/haproxytime/benchmark_test.go
@@ -1,0 +1,42 @@
+package haproxytime_test
+
+import (
+	"testing"
+
+	"github.com/openshift/router/pkg/router/template/util/haproxytime"
+)
+
+// Run as: go test -bench=. -test.run=BenchmarkParseDuration -benchmem -count=1 -benchtime=1s
+//
+//	% go test -bench=. -test.run=BenchmarkParseDuration -benchmem -count=1 -benchtime=1s
+//	goos: linux
+//	goarch: amd64
+//	pkg: github.com/openshift/router/pkg/router/template/util/haproxytime
+//	cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+//	BenchmarkParseDuration-8   	 4414666	       275.6 ns/op	     112 B/op	       2 allocs/op
+//	PASS
+//	ok  	github.com/openshift/router/pkg/router/template/util/haproxytime	1.495s
+//
+// If you modify ParseDuration() and fictitiously remove the regexp
+// and the associated handling of numericPart and unitPart and just
+// assume the numericPart=input then the following results show the
+// cost of parsing with regular expressions.
+//
+//	% go test -bench=. -test.run=BenchmarkParseDuration -benchmem -count=1 -benchtime=1s
+//	goos: linux
+//	goarch: amd64
+//	pkg: github.com/openshift/router/pkg/router/template/util/haproxytime
+//	cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+//	BenchmarkParseDuration-8   	72849655	        16.44 ns/op	       0 B/op	       0 allocs/op
+//	PASS
+//	ok  	github.com/openshift/router/pkg/router/template/util/haproxytime	1.217s
+func BenchmarkParseDuration(b *testing.B) {
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := haproxytime.ParseDuration("2147483647")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/router/template/util/haproxytime/duration_parser.go
+++ b/pkg/router/template/util/haproxytime/duration_parser.go
@@ -1,0 +1,78 @@
+package haproxytime
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// MaxTimeout defines the maximum duration that can be represented in
+// HAProxy's configuration.
+const MaxTimeout = 2147483647 * time.Millisecond
+
+var (
+	// OverflowError is returned when the parsed value exceeds the
+	// maximum allowed.
+	OverflowError = errors.New("value out of range")
+
+	// SyntaxError is returned when the input string doesn't match
+	// HAProxy's duration format.
+	SyntaxError = errors.New("invalid duration")
+
+	durationRE = regexp.MustCompile(`^([0-9]+)(us|ms|s|m|h|d)?$`)
+)
+
+// ParseDuration takes a string representing a duration in HAProxy's
+// specific format and converts it into a time.Duration value. The
+// string can include an optional unit suffix, such as "us", "ms",
+// "s", "m", "h", or "d". If no suffix is provided, milliseconds are
+// assumed. The function returns an OverflowError if the value exceeds
+// MaxTimeout, or a SyntaxError if the input string doesn't match the
+// expected format.
+func ParseDuration(input string) (time.Duration, error) {
+	matches := durationRE.FindStringSubmatch(input)
+	if matches == nil {
+		return 0, SyntaxError
+	}
+
+	// Default unit is milliseconds, unless specified.
+	unit := time.Millisecond
+
+	numericPart := matches[1]
+	unitPart := ""
+	if len(matches) > 2 {
+		unitPart = matches[2]
+	}
+
+	switch unitPart {
+	case "us":
+		unit = time.Microsecond
+	case "ms":
+		unit = time.Millisecond
+	case "s":
+		unit = time.Second
+	case "m":
+		unit = time.Minute
+	case "h":
+		unit = time.Hour
+	case "d":
+		unit = 24 * time.Hour
+	}
+
+	value, err := strconv.ParseInt(numericPart, 10, 32)
+	if err != nil {
+		// ParseInt is documented to return only ErrSyntax or
+		// ErrRange when an error occurs. As we've already
+		// covered the ErrSyntax case with the regex, we can
+		// assume this is ErrRange.
+		return 0, OverflowError
+	}
+
+	duration := time.Duration(value) * unit
+	if duration > MaxTimeout {
+		return 0, OverflowError
+	}
+
+	return duration, nil
+}

--- a/pkg/router/template/util/haproxytime/duration_parser_test.go
+++ b/pkg/router/template/util/haproxytime/duration_parser_test.go
@@ -9,43 +9,85 @@ import (
 
 func TestParseHAProxyDuration(t *testing.T) {
 	tests := []struct {
-		input            string
-		expectedDuration time.Duration
-		expectedErr      error
+		input       string
+		value       int64
+		unit        time.Duration
+		expectedErr error
 	}{
-		// Success Cases
-		{"0", 0, nil},
-		{"123us", 123 * time.Microsecond, nil},
-		{"456ms", 456 * time.Millisecond, nil},
-		{"789s", 789 * time.Second, nil},
-		{"5m", 5 * time.Minute, nil},
-		{"2h", 2 * time.Hour, nil},
-		{"1d", 24 * time.Hour, nil},
-		{"24d", 24 * 24 * time.Hour, nil},
-		{"2147483646", haproxytime.MaxTimeout - time.Millisecond, nil},
-		{"2147483647", haproxytime.MaxTimeout, nil},
+		// Syntax error test cases.
+		{" spaces are invalid", 0, time.Microsecond, haproxytime.SyntaxError},
+		{"", 0, time.Millisecond, haproxytime.SyntaxError},
+		{"+100", 0, time.Millisecond, haproxytime.SyntaxError},
+		{"-100", 0, time.Millisecond, haproxytime.SyntaxError},
+		{"-1us", 0, time.Microsecond, haproxytime.SyntaxError},
+		{"/", 0, time.Millisecond, haproxytime.SyntaxError},
+		{"123ns", 0, time.Microsecond, haproxytime.SyntaxError},
+		{"invalid", 0, time.Millisecond, haproxytime.SyntaxError},
 
-		// Syntax Error Cases
-		{"", 0, haproxytime.SyntaxError},
-		{"invalid", 0, haproxytime.SyntaxError},
-		{"+100", 0, haproxytime.SyntaxError},
-		{"-100", 0, haproxytime.SyntaxError},
-		{"/", 0, haproxytime.SyntaxError},
-		{" spaces are invalid", 0, haproxytime.SyntaxError},
+		// Validate default unit.
+		{"0", 0, time.Millisecond, nil},
 
-		// Overflow Error Cases
-		{"25d", 0, haproxytime.OverflowError},
-		{"9999999999", 0, haproxytime.OverflowError},
-		{"1000000000000000000000000000", 0, haproxytime.OverflowError},
-		{"1000000000000000000000000000h", 0, haproxytime.OverflowError},
-		{"2147483648", 0, haproxytime.OverflowError},
+		// Small values for each unit.
+		{"0us", 0, time.Microsecond, nil},
+		{"1us", 1, time.Microsecond, nil},
+		{"0ms", 0, time.Millisecond, nil},
+		{"1ms", 1, time.Millisecond, nil},
+		{"0s", 0, time.Second, nil},
+		{"1s", 1, time.Second, nil},
+		{"0m", 0, time.Minute, nil},
+		{"1m", 1, time.Minute, nil},
+		{"0h", 0, time.Hour, nil},
+		{"1h", 1, time.Hour, nil},
+		{"0d", 0, 0 * time.Hour, nil},
+		{"1d", 1, 24 * time.Hour, nil},
+
+		// The maximum duration that can be represented in a
+		// time.Duration value is determined by the limits of
+		// int64, as time.Duration is just an alias for int64
+		// where each unit represents a nanosecond.
+		//
+		// The maximum int64 value is 9223372036854775807.
+		//
+		// Therefore, the maximum durations for various units
+		// are calculated as follows:
+		//
+		// - Nanoseconds: 9223372036854775807 (since the base unit is a nanosecond)
+		// - Microseconds: 9223372036854775 (9223372036854775807 / 1000)
+		// - Milliseconds: 9223372036854 (9223372036854775807 / 1000000)
+		// - Seconds: 9223372036 (9223372036854775807 / 1000000000)
+		// - Minutes: 153722867 (9223372036854775807 / 60000000000)
+		// - Hours: 2562047 (9223372036854775807 / 3600000000000)
+		// - Days: 106751 (9223372036854775807 / 86400000000000)
+
+		// The largest representable value for each unit.
+		{"9223372036854775807ns", 0, time.Nanosecond, haproxytime.SyntaxError},
+		{"9223372036854775us", 9223372036854775, time.Microsecond, nil},
+		{"9223372036854ms", 9223372036854, time.Millisecond, nil},
+		{"9223372036s", 9223372036, time.Second, nil},
+		{"153722867m", 153722867, time.Minute, nil},
+		{"2562047h", 2562047, time.Hour, nil},
+		{"106751d", 106751, 24 * time.Hour, nil},
+
+		// Overflow cases.
+		{"9223372036854775808ns", 0, time.Nanosecond, haproxytime.SyntaxError},
+		{"9223372036854776us", 0, time.Microsecond, haproxytime.OverflowError},
+		{"9223372036855ms", 0, time.Millisecond, haproxytime.OverflowError},
+		{"9223372037s", 0, time.Second, haproxytime.OverflowError},
+		{"153722868m", 0, time.Minute, haproxytime.OverflowError},
+		{"2562048h", 0, time.Hour, haproxytime.OverflowError},
+		{"106752d", 0, 24 * time.Hour, haproxytime.OverflowError},
+
+		// Test strconv.ParseInt errors as value is bigger
+		// than int64 max.
+		{"18446744073709551615us", 0, time.Microsecond, haproxytime.OverflowError},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
 			duration, err := haproxytime.ParseDuration(tc.input)
-			if duration != tc.expectedDuration {
-				t.Errorf("expected duration %v, got %v", tc.expectedDuration, duration)
+			expectedDuration := time.Duration(tc.value) * tc.unit
+			if duration != expectedDuration {
+				t.Errorf("expected duration %vus, got %vus", expectedDuration.Microseconds(), duration.Microseconds())
 			}
 			if err != nil && tc.expectedErr == nil {
 				t.Errorf("expected no error, got %v", err)

--- a/pkg/router/template/util/haproxytime/duration_parser_test.go
+++ b/pkg/router/template/util/haproxytime/duration_parser_test.go
@@ -1,0 +1,59 @@
+package haproxytime_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openshift/router/pkg/router/template/util/haproxytime"
+)
+
+func TestParseHAProxyDuration(t *testing.T) {
+	tests := []struct {
+		input            string
+		expectedDuration time.Duration
+		expectedErr      error
+	}{
+		// Success Cases
+		{"0", 0, nil},
+		{"123us", 123 * time.Microsecond, nil},
+		{"456ms", 456 * time.Millisecond, nil},
+		{"789s", 789 * time.Second, nil},
+		{"5m", 5 * time.Minute, nil},
+		{"2h", 2 * time.Hour, nil},
+		{"1d", 24 * time.Hour, nil},
+		{"24d", 24 * 24 * time.Hour, nil},
+		{"2147483646", haproxytime.MaxTimeout - time.Millisecond, nil},
+		{"2147483647", haproxytime.MaxTimeout, nil},
+
+		// Syntax Error Cases
+		{"", 0, haproxytime.SyntaxError},
+		{"invalid", 0, haproxytime.SyntaxError},
+		{"+100", 0, haproxytime.SyntaxError},
+		{"-100", 0, haproxytime.SyntaxError},
+		{"/", 0, haproxytime.SyntaxError},
+		{" spaces are invalid", 0, haproxytime.SyntaxError},
+
+		// Overflow Error Cases
+		{"25d", 0, haproxytime.OverflowError},
+		{"9999999999", 0, haproxytime.OverflowError},
+		{"1000000000000000000000000000", 0, haproxytime.OverflowError},
+		{"1000000000000000000000000000h", 0, haproxytime.OverflowError},
+		{"2147483648", 0, haproxytime.OverflowError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			duration, err := haproxytime.ParseDuration(tc.input)
+			if duration != tc.expectedDuration {
+				t.Errorf("expected duration %v, got %v", tc.expectedDuration, duration)
+			}
+			if err != nil && tc.expectedErr == nil {
+				t.Errorf("expected no error, got %v", err)
+			} else if err == nil && tc.expectedErr != nil {
+				t.Errorf("expected error %v, got none", tc.expectedErr)
+			} else if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {
+				t.Errorf("expected error %v, got %v", tc.expectedErr, err)
+			}
+		})
+	}
+}

--- a/pkg/router/template/util/haproxytime/duration_parser_test.go
+++ b/pkg/router/template/util/haproxytime/duration_parser_test.go
@@ -9,37 +9,36 @@ import (
 
 func TestParseHAProxyDuration(t *testing.T) {
 	tests := []struct {
-		input       string
-		value       int64
-		unit        time.Duration
-		expectedErr error
+		input            string
+		expectedDuration time.Duration
+		expectedErr      error
 	}{
 		// Syntax error test cases.
-		{" spaces are invalid", 0, time.Microsecond, haproxytime.SyntaxError},
-		{"", 0, time.Millisecond, haproxytime.SyntaxError},
-		{"+100", 0, time.Millisecond, haproxytime.SyntaxError},
-		{"-100", 0, time.Millisecond, haproxytime.SyntaxError},
-		{"-1us", 0, time.Microsecond, haproxytime.SyntaxError},
-		{"/", 0, time.Millisecond, haproxytime.SyntaxError},
-		{"123ns", 0, time.Microsecond, haproxytime.SyntaxError},
-		{"invalid", 0, time.Millisecond, haproxytime.SyntaxError},
+		{" spaces are invalid", 0, haproxytime.SyntaxError},
+		{"", 0, haproxytime.SyntaxError},
+		{"+100", 0, haproxytime.SyntaxError},
+		{"-100", 0, haproxytime.SyntaxError},
+		{"-1us", 0, haproxytime.SyntaxError},
+		{"/", 0, haproxytime.SyntaxError},
+		{"123ns", 0, haproxytime.SyntaxError},
+		{"invalid", 0, haproxytime.SyntaxError},
 
 		// Validate default unit.
-		{"0", 0, time.Millisecond, nil},
+		{"0", 0 * time.Millisecond, nil},
 
 		// Small values for each unit.
-		{"0us", 0, time.Microsecond, nil},
-		{"1us", 1, time.Microsecond, nil},
-		{"0ms", 0, time.Millisecond, nil},
-		{"1ms", 1, time.Millisecond, nil},
-		{"0s", 0, time.Second, nil},
-		{"1s", 1, time.Second, nil},
-		{"0m", 0, time.Minute, nil},
-		{"1m", 1, time.Minute, nil},
-		{"0h", 0, time.Hour, nil},
-		{"1h", 1, time.Hour, nil},
-		{"0d", 0, 0 * time.Hour, nil},
-		{"1d", 1, 24 * time.Hour, nil},
+		{"0us", 0 * time.Microsecond, nil},
+		{"1us", 1 * time.Microsecond, nil},
+		{"0ms", 0 * time.Millisecond, nil},
+		{"1ms", 1 * time.Millisecond, nil},
+		{"0s", 0 * time.Second, nil},
+		{"1s", 1 * time.Second, nil},
+		{"0m", 0 * time.Minute, nil},
+		{"1m", 1 * time.Minute, nil},
+		{"0h", 0 * time.Hour, nil},
+		{"1h", 1 * time.Hour, nil},
+		{"0d", 0 * time.Hour, nil},
+		{"1d", 24 * time.Hour, nil},
 
 		// The maximum duration that can be represented in a
 		// time.Duration value is determined by the limits of
@@ -60,34 +59,33 @@ func TestParseHAProxyDuration(t *testing.T) {
 		// - Days: 106751 (9223372036854775807 / 86400000000000)
 
 		// The largest representable value for each unit.
-		{"9223372036854775807ns", 0, time.Nanosecond, haproxytime.SyntaxError},
-		{"9223372036854775us", 9223372036854775, time.Microsecond, nil},
-		{"9223372036854ms", 9223372036854, time.Millisecond, nil},
-		{"9223372036s", 9223372036, time.Second, nil},
-		{"153722867m", 153722867, time.Minute, nil},
-		{"2562047h", 2562047, time.Hour, nil},
-		{"106751d", 106751, 24 * time.Hour, nil},
+		{"9223372036854775807ns", 0, haproxytime.SyntaxError},
+		{"9223372036854775us", 9223372036854775 * time.Microsecond, nil},
+		{"9223372036854ms", 9223372036854 * time.Millisecond, nil},
+		{"9223372036s", 9223372036 * time.Second, nil},
+		{"153722867m", 153722867 * time.Minute, nil},
+		{"2562047h", 2562047 * time.Hour, nil},
+		{"106751d", 106751 * 24 * time.Hour, nil},
 
 		// Overflow cases.
-		{"9223372036854775808ns", 0, time.Nanosecond, haproxytime.SyntaxError},
-		{"9223372036854776us", 0, time.Microsecond, haproxytime.OverflowError},
-		{"9223372036855ms", 0, time.Millisecond, haproxytime.OverflowError},
-		{"9223372037s", 0, time.Second, haproxytime.OverflowError},
-		{"153722868m", 0, time.Minute, haproxytime.OverflowError},
-		{"2562048h", 0, time.Hour, haproxytime.OverflowError},
-		{"106752d", 0, 24 * time.Hour, haproxytime.OverflowError},
+		{"9223372036854775808ns", 0, haproxytime.SyntaxError},
+		{"9223372036854776us", 0, haproxytime.OverflowError},
+		{"9223372036855ms", 0, haproxytime.OverflowError},
+		{"9223372037s", 0, haproxytime.OverflowError},
+		{"153722868m", 0, haproxytime.OverflowError},
+		{"2562048h", 0, haproxytime.OverflowError},
+		{"106752d", 0, haproxytime.OverflowError},
 
 		// Test strconv.ParseInt errors as value is bigger
 		// than int64 max.
-		{"18446744073709551615us", 0, time.Microsecond, haproxytime.OverflowError},
+		{"18446744073709551615us", 0, haproxytime.OverflowError},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
 			duration, err := haproxytime.ParseDuration(tc.input)
-			expectedDuration := time.Duration(tc.value) * tc.unit
-			if duration != expectedDuration {
-				t.Errorf("expected duration %vus, got %vus", expectedDuration.Microseconds(), duration.Microseconds())
+			if duration != tc.expectedDuration {
+				t.Errorf("expected duration %v, got %v", tc.expectedDuration, duration)
 			}
 			if err != nil && tc.expectedErr == nil {
 				t.Errorf("expected no error, got %v", err)

--- a/pkg/router/template/util/util.go
+++ b/pkg/router/template/util/util.go
@@ -1,11 +1,9 @@
 package util
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
-	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
 
@@ -103,117 +101,4 @@ func GenerateBackendNamePrefix(termination routev1.TLSTerminationType) string {
 	}
 
 	return prefix
-}
-
-var haproxyDurationRE = regexp.MustCompile(`^([0-9]+)(us|ms|s|m|h|d)?$`)
-
-// HaproxyMaxTimeoutDuration is HaproxyMaxTimeout as a time.Duration value.
-var HaproxyMaxTimeoutDuration = func() time.Duration {
-	d, err := time.ParseDuration(HaproxyMaxTimeout)
-	if err != nil {
-		panic(err)
-	}
-	return d
-}()
-
-// OverflowError represents an overflow error from ParseHAProxyDuration.
-// OverflowError is returned if the value is greater than what time.ParseDuration
-// allows (value must be representable as uint64, e.g. approximately 2562047.79 hours
-// or 9223372036854775807 nanoseconds).
-type OverflowError struct {
-	error
-}
-
-// InvalidInputError represents an error based on invalid input to ParseHAProxyDuration
-type InvalidInputError struct {
-	error
-}
-
-// ParseHAProxyDuration is similar to time.ParseDuration, but modified with meaningful
-// error messages for invalid input, with support for decimal points removed, with
-// support for the "d" unit for days, and with "ms" as the default unit.
-// It parses a duration string and returns a suitable duration. A duration string is a
-// sequence of decimal numbers followed by a unit suffix,
-// such as "300ms", "1h" or "45m".  If the unit suffix is omitted, "ms" is used.
-// Valid time units are "us", "ms", "s", "m", "h", and "d".
-func ParseHAProxyDuration(s string) (time.Duration, error) {
-	orig := s
-	var d uint64
-
-	// Compare the input to the HAProxy duration regex.
-	if !haproxyDurationRE.MatchString(s) {
-		return 0, InvalidInputError{errors.New("invalid duration, no pattern match " + s)}
-	}
-
-	if s == "0" {
-		return 0, nil
-	}
-	for s != "" {
-		// The next character must be [0-9].
-		if !('0' <= s[0] && s[0] <= '9') {
-			return 0, InvalidInputError{errors.New("invalid duration, not a number " + orig)}
-		}
-
-		// Consume [0-9]*.
-		var v uint64
-		var err error
-		v, s, err = leadingInt(s)
-		if err != nil {
-			// overflow.
-			return 0, OverflowError{errors.New(err.Error() + orig)}
-		}
-
-		// Set the default HAProxy unit of "ms", in case a unit wasn't provided.
-		u := "ms"
-		// Consume unit.
-		i := 0
-		for ; i < len(s); i++ {
-			c := s[i]
-			if '0' <= c && c <= '9' {
-				break
-			}
-		}
-		if i > 0 {
-			u = s[:i]
-		}
-		s = s[i:]
-		unit, _ := unitMap[u]
-
-		// Calculate the current value we've parsed, and check for overflow.
-		if v > 1<<63/unit {
-			// overflow.
-			return HaproxyMaxTimeoutDuration, OverflowError{errors.New("invalid duration, overflow " + orig)}
-		}
-		v *= unit
-		d += v
-	}
-	if d > 1<<63-1 {
-		return HaproxyMaxTimeoutDuration, OverflowError{errors.New("invalid duration, overflow " + orig)}
-	}
-	return time.Duration(d), nil
-}
-
-// leadingInt consumes the leading [0-9]* from s, and comes from the time package,
-// a private function used by time.ParseDuration, and needed by ParseHAProxyDuration above.
-func leadingInt[bytes []byte | string](s bytes) (x uint64, rem bytes, err error) {
-	i := 0
-	for ; i < len(s); i++ {
-		c := s[i]
-		if c < '0' || c > '9' {
-			break
-		}
-		x = x*10 + uint64(c) - '0'
-	}
-	return x, s[i:], nil
-}
-
-// unitMap is used by ParseHAProxyDuration for mapping a string-based unit
-// to a time-based uint64.
-var unitMap = map[string]uint64{
-	"us": uint64(time.Microsecond),
-	"ms": uint64(time.Millisecond),
-	"s":  uint64(time.Second),
-	"m":  uint64(time.Minute),
-	"h":  uint64(time.Hour),
-	"d":  uint64(time.Hour * 24), // HAProxy does accept d, convert to h for parsing
 }

--- a/pkg/router/template/util/util.go
+++ b/pkg/router/template/util/util.go
@@ -1,15 +1,25 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
 
 	"github.com/openshift/router/pkg/router/routeapihelpers"
 
 	logf "github.com/openshift/router/log"
+)
+
+const (
+	// HaproxyMaxTimeout is the max timeout allowable by HAProxy.
+	HaproxyMaxTimeout = "2147483647ms"
+	// HaproxyDefaultTimeout is the default timeout to use when the
+	// timeout value is not parseable for reasons other than it is too large.
+	HaproxyDefaultTimeout = "5s"
 )
 
 var log = logf.Logger.WithName("util")
@@ -93,4 +103,117 @@ func GenerateBackendNamePrefix(termination routev1.TLSTerminationType) string {
 	}
 
 	return prefix
+}
+
+var haproxyDurationRE = regexp.MustCompile(`^([0-9]+)(us|ms|s|m|h|d)?$`)
+
+// HaproxyMaxTimeoutDuration is HaproxyMaxTimeout as a time.Duration value.
+var HaproxyMaxTimeoutDuration = func() time.Duration {
+	d, err := time.ParseDuration(HaproxyMaxTimeout)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}()
+
+// OverflowError represents an overflow error from ParseHAProxyDuration.
+// OverflowError is returned if the value is greater than what time.ParseDuration
+// allows (value must be representable as uint64, e.g. approximately 2562047.79 hours
+// or 9223372036854775807 nanoseconds).
+type OverflowError struct {
+	error
+}
+
+// InvalidInputError represents an error based on invalid input to ParseHAProxyDuration
+type InvalidInputError struct {
+	error
+}
+
+// ParseHAProxyDuration is similar to time.ParseDuration, but modified with meaningful
+// error messages for invalid input, with support for decimal points removed, with
+// support for the "d" unit for days, and with "ms" as the default unit.
+// It parses a duration string and returns a suitable duration. A duration string is a
+// sequence of decimal numbers followed by a unit suffix,
+// such as "300ms", "1h" or "45m".  If the unit suffix is omitted, "ms" is used.
+// Valid time units are "us", "ms", "s", "m", "h", and "d".
+func ParseHAProxyDuration(s string) (time.Duration, error) {
+	orig := s
+	var d uint64
+
+	// Compare the input to the HAProxy duration regex.
+	if !haproxyDurationRE.MatchString(s) {
+		return 0, InvalidInputError{errors.New("invalid duration, no pattern match " + s)}
+	}
+
+	if s == "0" {
+		return 0, nil
+	}
+	for s != "" {
+		// The next character must be [0-9].
+		if !('0' <= s[0] && s[0] <= '9') {
+			return 0, InvalidInputError{errors.New("invalid duration, not a number " + orig)}
+		}
+
+		// Consume [0-9]*.
+		var v uint64
+		var err error
+		v, s, err = leadingInt(s)
+		if err != nil {
+			// overflow.
+			return 0, OverflowError{errors.New(err.Error() + orig)}
+		}
+
+		// Set the default HAProxy unit of "ms", in case a unit wasn't provided.
+		u := "ms"
+		// Consume unit.
+		i := 0
+		for ; i < len(s); i++ {
+			c := s[i]
+			if '0' <= c && c <= '9' {
+				break
+			}
+		}
+		if i > 0 {
+			u = s[:i]
+		}
+		s = s[i:]
+		unit, _ := unitMap[u]
+
+		// Calculate the current value we've parsed, and check for overflow.
+		if v > 1<<63/unit {
+			// overflow.
+			return HaproxyMaxTimeoutDuration, OverflowError{errors.New("invalid duration, overflow " + orig)}
+		}
+		v *= unit
+		d += v
+	}
+	if d > 1<<63-1 {
+		return HaproxyMaxTimeoutDuration, OverflowError{errors.New("invalid duration, overflow " + orig)}
+	}
+	return time.Duration(d), nil
+}
+
+// leadingInt consumes the leading [0-9]* from s, and comes from the time package,
+// a private function used by time.ParseDuration, and needed by ParseHAProxyDuration above.
+func leadingInt[bytes []byte | string](s bytes) (x uint64, rem bytes, err error) {
+	i := 0
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			break
+		}
+		x = x*10 + uint64(c) - '0'
+	}
+	return x, s[i:], nil
+}
+
+// unitMap is used by ParseHAProxyDuration for mapping a string-based unit
+// to a time-based uint64.
+var unitMap = map[string]uint64{
+	"us": uint64(time.Microsecond),
+	"ms": uint64(time.Millisecond),
+	"s":  uint64(time.Second),
+	"m":  uint64(time.Minute),
+	"h":  uint64(time.Hour),
+	"d":  uint64(time.Hour * 24), // HAProxy does accept d, convert to h for parsing
 }


### PR DESCRIPTION
- OCPBUGS-6958: Fix clipHAProxyTimeoutValue so that:
- add haproxytime
- use pkg/router/template/util/haproxytime
- drop existing ParseHAProxyDuration
- Refactor ParseDuration: MaxTimeout moved to caller, Add boundary tests
- Update HAProxy timeout validation following ParseDuration changes
- Add benchmark test to evaluate the performance of ParseDuration
- haproxytime: change unit tests to encode the expected duration

See https://github.com/openshift/router/pull/483

