### PR TITLE
OCPBUGS-21803: haproxy-template: Add 'no strict-limits' to address HAProxy 2.6 issue

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -43,6 +43,9 @@
 {{- $pathRewriteTargetPattern := `^/.*$` -}}
 
 global
+  # Drop resource limit checks to mitigate https://issues.redhat.com/browse/OCPBUGS-21803 in HAProxy 2.6.
+  no strict-limits
+
 {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (env "ROUTER_HARD_STOP_AFTER")) }}
   hard-stop-after {{ $value }}
 {{- end }}


### PR DESCRIPTION
In HAProxy 2.6, the 'strict limits' setting, which enforces resource
limits (e.g., the number of open files), became the default behaviour.
Consequently, any failure to configure resource limits now results in
fatal errors. This change introduces 'no strict-limits' in the
template to revert to the behaviour of HAProxy 2.2. This is necessary
to ensure the router starts successfully when a maxconn setting cannot
be satisfied.

The HAProxy documentation for 'strict-limits' states:

    Makes process fail at startup when a setrlimit fails. HAProxy
    tries to set the best setrlimit according to what has been
    calculated. If it fails, it will emit a warning. This option is
    here to guarantee an explicit failure of HAProxy when those limits
    fail. It is enabled by default. It may still be forcibly disabled
    by prefixing it with the "no" keyword.

For example, and without this change, if you tune the
IngressController to have maxConnections: 2000000, and if the
requirement for 2000000 connections cannot be satisfied at runtime,
then the router pod will log the following message, and the HAProxy
process will exit with:

    sh-4.4$ ../reload-haproxy
    [NOTICE]   (62) : haproxy version is 2.6.13-234aa6d
    [NOTICE]   (62) : path to executable is /usr/sbin/haproxy
    [ALERT]    (62) : [/usr/sbin/haproxy.main()] Cannot raise FD limit to 4000237, limit is 1048576.

Setting 'no strict-limits' changes this to:

    sh-4.4$ ../reload-haproxy
    [NOTICE]   (50) : haproxy version is 2.6.13-234aa6d
    [NOTICE]   (50) : path to executable is /usr/sbin/haproxy
    [WARNING]  (50) : [/usr/sbin/haproxy.main()] Cannot raise FD limit to 4000237, limit is 1048576.
    [ALERT]    (50) : [/usr/sbin/haproxy.main()] FD limit (1048576) too low for maxconn=2000000/maxsock=4000237. Please raise 'ulimit-n' to 4000237 or more to avoid any trouble.
     - Checking http://localhost:80 ...
     - Health check ok : 0 retry attempt(s).

And, despite the ALERT, the haproxy process will not exit.

I always recommend using -1 (or 'auto') for the maxConnections setting
if you want to increase the limit beyond the current default. This
choice results in HAProxy dynamically calculating the maximum value
based on the available resource limits in the running container.
Importantly, when using the 'auto' setting, there are no warnings
emitted, regardless of whether 'no strict-limits' is used or not.

This solution will be re-evaluated after the 4.14.0 release.

Fixes: https://issues.redhat.com/browse/OCPBUGS-21803
