### PR TITLE
Updating ose-haproxy-router-base images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.20-openshift-4.15
+  tag: rhel-9-release-golang-1.20-openshift-4.15

--- a/images/router/base/Dockerfile.rhel
+++ b/images/router/base/Dockerfile.rhel
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder
 WORKDIR /go/src/github.com/openshift/router
 COPY . .
 RUN make
 
-FROM registry.ci.openshift.org/ocp/4.15:base
+FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/router/openshift-router /usr/bin/
 LABEL io.k8s.display-name="OpenShift Router" \
       io.k8s.description="This is the base image from which all template based routers inherit." \


### PR DESCRIPTION
Updating ose-haproxy-router-base images to be consistent with ART
__TLDR__:
Component owners, please ensure that this PR merges as it impacts the fidelity
of your CI signal. Patch-manager / leads, this PR is a no-op from a product
perspective -- feel free to manually apply any labels (e.g. jira/valid-bug) to help the
PR merge as long as tests are passing. If the PR is labeled "needs-ok-to-test", this is
to limit costs for re-testing these PRs while they wait for review. Issue /ok-to-test
to remove this tag and help the PR to merge.

__Detail__:
This repository is out of sync with the downstream product builds for this component.
One or more images differ from those being used by ART to create product builds. This
should be addressed to ensure that the component's CI testing is accurately
reflecting what customers will experience.

The information within the following ART component metadata is driving this alignment
request: [ose-haproxy-router-base.yml](https://github.com/openshift/ocp-build-data/tree/bbb8c65d1f4d443d73469d9778ca5d0e2c36568e/images/ose-haproxy-router-base.yml).

The vast majority of these PRs are opened because a different Golang version is being
used to build the downstream component. ART compiles most components with the version
of Golang being used by the control plane for a given OpenShift release. Exceptions
to this convention (i.e. you believe your component must be compiled with a Golang
version independent from the control plane) must be granted by the OpenShift
architecture team and communicated to the ART team.

__Roles & Responsibilities__:
- Component owners are responsible for ensuring these alignment PRs merge with passing
  tests OR that necessary metadata changes are reported to the ART team: `@release-artists`
  in `#forum-ocp-art` on Slack. If necessary, the changes required by this pull request can be
  introduced with a separate PR opened by the component team. Once the repository is aligned,
  this PR will be closed automatically.
- Patch-manager or those with sufficient privileges within this repository may add
  any required labels to ensure the PR merges once tests are passing. Downstream builds
  are *already* being built with these changes. Merging this PR only improves the fidelity
  of our CI.

ART has been configured to reconcile your CI build root image (see https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image).
In order for your upstream .ci-operator.yaml configuration to be honored, you must set the following in your openshift/release ci-operator configuration file:
```
build_root:
  from_repository: true
```

If you have any questions about this pull request, please reach out to `@release-artists` in the `#forum-ocp-art` coreos slack channel.
