### PR TITLE
Updating openshift-enterprise-haproxy-router images to be consistent with ART

### DIFF
--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.15:haproxy-router-base
+FROM registry.ci.openshift.org/ocp/4.15:haproxy-router-base-rhel9
 RUN INSTALL_PKGS="haproxy26 rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
Updating openshift-enterprise-haproxy-router images to be consistent with ART
__TLDR__:
Component owners, please ensure that this PR merges as it impacts the fidelity
of your CI signal. Patch-manager / leads, this PR is a no-op from a product
perspective -- feel free to manually apply any labels (e.g. jira/valid-bug) to help the
PR merge as long as tests are passing. If the PR is labeled "needs-ok-to-test", this is
to limit costs for re-testing these PRs while they wait for review. Issue /ok-to-test
to remove this tag and help the PR to merge.

__Detail__:
This repository is out of sync with the downstream product builds for this component.
One or more images differ from those being used by ART to create product builds. This
should be addressed to ensure that the component's CI testing is accurately
reflecting what customers will experience.

The information within the following ART component metadata is driving this alignment
request: [openshift-enterprise-haproxy-router.yml](https://github.com/openshift/ocp-build-data/tree/bbb8c65d1f4d443d73469d9778ca5d0e2c36568e/images/openshift-enterprise-haproxy-router.yml).

The vast majority of these PRs are opened because a different Golang version is being
used to build the downstream component. ART compiles most components with the version
of Golang being used by the control plane for a given OpenShift release. Exceptions
to this convention (i.e. you believe your component must be compiled with a Golang
version independent from the control plane) must be granted by the OpenShift
architecture team and communicated to the ART team.

__Roles & Responsibilities__:
- Component owners are responsible for ensuring these alignment PRs merge with passing
  tests OR that necessary metadata changes are reported to the ART team: `@release-artists`
  in `#forum-ocp-art` on Slack. If necessary, the changes required by this pull request can be
  introduced with a separate PR opened by the component team. Once the repository is aligned,
  this PR will be closed automatically.
- Patch-manager or those with sufficient privileges within this repository may add
  any required labels to ensure the PR merges once tests are passing. Downstream builds
  are *already* being built with these changes. Merging this PR only improves the fidelity
  of our CI.

If you have any questions about this pull request, please reach out to `@release-artists` in the `#forum-ocp-art` coreos slack channel.

Depends on PullRequest(title="Updating ose-haproxy-router-base images to be consistent with ART", number=540) . Allow it to merge and then run `/test all` on this PR.