### PR TITLE
NO-JIRA: hack - fix broken RPM link and use UBI image in Dockerfile.debug, use podman in Makefile.debug

### DIFF
--- a/hack/Dockerfile.debug
+++ b/hack/Dockerfile.debug
@@ -1,5 +1,5 @@
-FROM centos:8
-RUN yum install -y https://github.com/frobware/haproxy-hacks/raw/master/RPMs/haproxy24-2.4.1-1.el8.x86_64.rpm
+FROM registry.access.redhat.com/ubi8/ubi
+RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.14-rhel-8/haproxy26-2.6.13-2.rhaos4.14.el8.x86_64.rpm
 RUN haproxy -vv
 RUN INSTALL_PKGS="rsyslog procps-ng util-linux socat" && \
     yum install -y $INSTALL_PKGS && \

--- a/hack/Makefile.debug
+++ b/hack/Makefile.debug
@@ -5,14 +5,15 @@ export GOOS=linux
 REGISTRY ?= quay.io
 IMAGE ?= openshift/openshift-router
 TAG ?= latest
+IMAGEBUILDER ?= podman
 
 new-openshift-router-image:
 	GO111MODULE=on CGO_ENABLED=0 GOFLAGS=-mod=vendor go build -o openshift-router -gcflags=all="-N -l" ./cmd/openshift-router
-	imagebuilder -t $(IMAGE):$(TAG) -f hack/Dockerfile.debug .
+	$(IMAGEBUILDER) build -t $(IMAGE):$(TAG) -f hack/Dockerfile.debug .
 
 push:
-	docker tag $(IMAGE):$(TAG) $(REGISTRY)/$(IMAGE):$(TAG)
-	docker push $(REGISTRY)/$(IMAGE):$(TAG)
+	$(IMAGEBUILDER) tag $(IMAGE):$(TAG) $(REGISTRY)/$(IMAGE):$(TAG)
+	$(IMAGEBUILDER) push $(REGISTRY)/$(IMAGE):$(TAG)
 
 set-image:
 	oc scale --replicas 0 -n openshift-cluster-version deployments/cluster-version-operator


### PR DESCRIPTION
The PR aims at fixing the broken RPM link in `hack/Dockerfile.debug` as well as bring a better building experience by:
- migrating the base image to the universal one
- using `podman` as the image builder