### PR TITLE
haproxy: Support annotation in Route that enables http response code …

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -604,7 +604,11 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
           {{- end }}
 
           {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-http")) }}
+            {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-http-code")) }}
+  http-request deny deny_status {{ index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-http-code" }} if { src_http_req_rate ge {{ index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-http" }} }
+            {{- else }}
   tcp-request content reject if { src_http_req_rate ge {{ index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-http" }} }
+            {{- end }}
           {{- else }}
   #HTTP request rate not restricted
           {{- end }}

--- a/pkg/router/template/configmanager/haproxy/manager.go
+++ b/pkg/router/template/configmanager/haproxy/manager.go
@@ -1096,6 +1096,7 @@ func modAnnotationsList(termination routev1.TLSTerminationType) []string {
 		"haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp",
 		"haproxy.router.openshift.io/rate-limit-connections.rate-tcp",
 		"haproxy.router.openshift.io/rate-limit-connections.rate-http",
+		"haproxy.router.openshift.io/rate-limit-connections.rate-http-code",
 		"haproxy.router.openshift.io/pod-concurrent-connections",
 		"router.openshift.io/haproxy.health.check.interval",
 	}


### PR DESCRIPTION
…for http rate limiting

The driver for this change is that we had an [incident](https://issues.redhat.com/browse/RHOBS-962) in RHOBS summarised as the rate limiting is ineffective against the Prometheus remote write client that was writing via a Route. Adding the existing annotations didn't help as the client expects a status code in order to backoff gracefully. The actual result was the cluster ingress became overwhelmed and took down access to the cluster. 

This change adds a new annotation `haproxy.router.openshift.io/rate-limit-connections.rate-http-code` which when specified with an integer, will return the status code as specified for a rate limited request. 

The default behaviour remains the same as before.

Fixes #382 