### PR TITLE
NE-1446: Update to RHEL9 base image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.20-openshift-4.16
+  tag: rhel-9-release-golang-1.20-openshift-4.16

--- a/images/router/base/Dockerfile.rhel
+++ b/images/router/base/Dockerfile.rhel
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/router
 COPY . .
 RUN make
 
-FROM registry.ci.openshift.org/ocp/4.16:base
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/router/openshift-router /usr/bin/
 LABEL io.k8s.display-name="OpenShift Router" \
       io.k8s.description="This is the base image from which all template based routers inherit." \


### PR DESCRIPTION
Update the base image for the router from RHEL8 to RHEL9.
    
`.ci-operator.yaml`: Update ci-operator build_root imagestream
`images/router/base/Dockerfile.rhel`: Update builder and router image

Perf & Scale run documented in [NE-1448](https://issues.redhat.com//browse/NE-1448)