### PR TITLE
NE-1444: Upgrade OpenShift Router to HAProxy 2.8

### DIFF
--- a/hack/Dockerfile.debug
+++ b/hack/Dockerfile.debug
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi
-RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.14-rhel-8/haproxy26-2.6.13-2.rhaos4.14.el8.x86_64.rpm
+RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.16-rhel-9/haproxy28-2.8.5-1.rhaos4.16.el9.x86_64.rpm
 RUN haproxy -vv
 RUN INSTALL_PKGS="rsyslog procps-ng util-linux socat" && \
     yum install -y $INSTALL_PKGS && \

--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy26 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy28 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy26 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy28 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/ocp/4.16:haproxy-router-base
-RUN INSTALL_PKGS="haproxy26 rsyslog procps-ng util-linux" && \
+RUN INSTALL_PKGS="haproxy28 rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -330,6 +330,7 @@ frontend fe_sni
         {{- if $haveCRLs }} crl-file /var/lib/haproxy/mtls/latest/crls.pem {{ end }}
       {{- end }}
     {{- end }}
+  {{- "" }} no-alpn
   mode http
 
     {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
@@ -440,6 +441,7 @@ frontend fe_no_sni
         {{- if $haveCRLs }} crl-file /var/lib/haproxy/mtls/latest/crls.pem {{ end }}
       {{- end }}
     {{- end }}
+  {{- "" }} no-alpn
   mode http
 
     {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}


### PR DESCRIPTION
**Context:**

This pull request bumps HAProxy to the haproxy28 RPM. It also addresses the changes introduced in HAProxy 2.8, specifically the default enabling of ALPN h2. It presents an update to our HAProxy configuration, affecting the `fe_sni` and `fe_no_sni` TLS listeners.

**Changes:**
- The introduction of an unconditional `no-alpn` directive in the HAProxy template for `fe_sni` and `fe_no_sni` listeners.
- This change is independent of the HTTP/2 status in the ingress controller and aims to maintain consistent behavior with previous OpenShift / HAProxy releases.
- Updates the RPM package from haproxy26 to haproxy28.

**Rationale:**
In the HAProxy 2.8 [release notes](https://www.mail-archive.com/haproxy@formilux.org/msg43600.html), it is highlighted that HTTP/2 is now automatically advertised in ALPN for TLS listeners:

>HTTP/2 is now advertised by default in ALPN on TLS listeners. This marks a pivotal change, as HTTP/2 has been available for 5 years and enabled by default in clear text as an HTTP/1 upgrade flisteners. This marks a pivotal change, as HTTP/2 has been available for 5 years andor 4 years. However, some users were still unaware of how to enable it. Now, ALPN will default to 'h2,http/1.1' on TCP and 'h3' on QUIC, ensuring these protocol versions work by default. Adjustments to ALPN settings remain possible to enable or disable these protocols...

This is a significant change from previous versions where such default enablement was not present. To ensure backward compatibility and controlled protocol negotiation, we've introduced the `no-alpn` directive. This maintains our existing deployment behaviours and offers a more controlled approach to protocol negotiation, especially concerning HTTP/2. Note: the `no-alpn` directive is new with HAProxy 2.8 and if the RPM bump from haproxy26 to haproxy28 should ever require a revert then the change that introduces the `no-alpn` addition to the haproxy template would also need to be reverted.

**Additional Details:**
- While we disable ALPN by default, ALPN h2 remains supported for specific routes/backends that require it. This is managed through entries in the `cert-config.map`, allowing for explicit enablement of ALPN h2 where needed.
- The PR ensures that our deployments and upgrades to OCP 4.16 continue to function as expected with the new HAProxy version.

**References:**

- Slack discussion with TRT w.r.t the payload tests: https://redhat-internal.slack.com/archives/C01CQA76KMX/p1706092351389319

**Related changes:**
- https://github.com/openshift/images/pull/160
- https://github.com/openshift/origin/pull/28514
- https://github.com/openshift/origin/pull/28522