### PR TITLE
OCPBUGS-26498: Reject routes with SHA1 certs

### DIFF
--- a/pkg/router/routeapihelpers/validation.go
+++ b/pkg/router/routeapihelpers/validation.go
@@ -351,6 +351,8 @@ func validateCertificatePEM(certPEM string, options *x509.VerifyOptions) ([]*x50
 
 	// Reject any unsupported cert algorithms as HaProxy will refuse to start with them.
 	switch certs[0].SignatureAlgorithm {
+	case x509.SHA1WithRSA, x509.ECDSAWithSHA1:
+		return certs, fmt.Errorf("router does not support certs using SHA1")
 	case x509.MD5WithRSA:
 		return certs, fmt.Errorf("router does not support certs using MD5")
 	default:

--- a/pkg/router/routeapihelpers/validation.go
+++ b/pkg/router/routeapihelpers/validation.go
@@ -382,36 +382,11 @@ func validateCertificatePEM(certPEM string, options *x509.VerifyOptions) ([]*x50
 // a route. This checks for issues that will cause failures in the next
 // OpenShift version.
 func UpgradeRouteValidation(route *routev1.Route) field.ErrorList {
-	tlsConfig := route.Spec.TLS
-	result := field.ErrorList{}
-
-	if tlsConfig == nil {
-		return result
-	}
-
-	// Verify the route for incompatible SHA1 certificates within Spec.TLS.Certificate
-	// as it will prevent HaProxy from starting.
-	// There's no need to verify SHA1 certificates within Spec.TLS.CACertificate
-	// as they will be rejected by the ExtendedValidator plugin.
-	// Similarly, verifying SHA1 certificates within Spec.TLS.DestinationCACertificate
-	// is unnecessary as it will NOT prevent HaProxy from starting.
-	if len(tlsConfig.Certificate) > 0 {
-		certs, err := cert.ParseCertsPEM([]byte(tlsConfig.Certificate))
-		if err != nil {
-			// Handling cert parsing errors, like malformed or invalid certs, isn't necessary here,
-			// as the ExtendedValidator plugin is responsible for handling these errors.
-			return result
-		}
-
-		if len(certs) < 1 {
-			return result
-		}
-
-		if certs[0].SignatureAlgorithm == x509.SHA1WithRSA || certs[0].SignatureAlgorithm == x509.ECDSAWithSHA1 {
-			tlsCertFieldPath := field.NewPath("spec").Child("tls").Child("certificate")
-			message := "OpenShift 4.16 does not support certificates using SHA1 signature algorithms. This route will be rejected in OpenShift 4.16. To maintain functionality in OpenShift 4.16, generate a new certificate using a supported signature algorithm such as SHA256, SHA384, or SHA512, and update this route accordingly."
-			result = append(result, field.Invalid(tlsCertFieldPath, "redacted certificate data", message))
-		}
-	}
-	return result
+	// This function returns nil because this release has no current route upgradeable issues.
+	// Previously in 4.15, we introduced the Upgrade Validation plugin to add the
+	// UnservableInFutureVersions condition to indicate that 4.16 does not support SHA1 certs.
+	// It's important to keep the Upgrade Validation plugin active in 4.16 as always
+	// returning nil clears stale UnservableInFutureVersions conditions (SHA1 Routes
+	// are getting rejected now).
+	return nil
 }

--- a/pkg/router/routeapihelpers/validation_test.go
+++ b/pkg/router/routeapihelpers/validation_test.go
@@ -1928,7 +1928,7 @@ func TestExtendedValidateRoute(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: 0,
+			expectedErrors: 1,
 		},
 		{
 			name: "Edge termination with cert using SHA1 with ECDSA key",
@@ -1941,7 +1941,7 @@ func TestExtendedValidateRoute(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: 0,
+			expectedErrors: 1,
 		},
 	}
 

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -1174,7 +1174,7 @@ func TestHandleRouteUpgradeValidation(t *testing.T) {
 					},
 				},
 			},
-			unservableInFutureVersionsExpected: true,
+			unservableInFutureVersionsExpected: false,
 		},
 	}
 


### PR DESCRIPTION
Add logic to the extended route validation to reject any SHA1-based certs as they are no longer supported in 4.16+.

Also, the router will now clear `UnservableInFutureVersions` conditions for routes with SHA1 certs. This is desirable because the router is now rejecting routes with SHA1 cert and `UnservableInFutureVersions` no longer applies.

Previously, #555 was merged into 4.16 which sets `UnservableInFutureVersions` conditions for routes with SHA1 certs. #555  PR was intended to merge in 4.16 and backport into 4.15. This PR (#552) needs to partially reverts changes in #555 because this PR (#552) now rejects SHA1 certificates. This PR (#552) is ONLY intended for 4.16+ (it's not going to be backported).