### PR TITLE
NE-1444: Disable ALPN on fe_sni and fe_no_sni TLS listeners (HAProxy 2.8)

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -330,6 +330,7 @@ frontend fe_sni
         {{- if $haveCRLs }} crl-file /var/lib/haproxy/mtls/latest/crls.pem {{ end }}
       {{- end }}
     {{- end }}
+  {{- "" }} no-alpn
   mode http
 
     {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
@@ -440,6 +441,7 @@ frontend fe_no_sni
         {{- if $haveCRLs }} crl-file /var/lib/haproxy/mtls/latest/crls.pem {{ end }}
       {{- end }}
     {{- end }}
+  {{- "" }} no-alpn
   mode http
 
     {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}


### PR DESCRIPTION
**Context:**

This pull request addresses the changes introduced in HAProxy 2.8, specifically the default enabling of ALPN h2. It presents an update to our HAProxy configuration, affecting the `fe_sni` and `fe_no_sni` TLS listeners.

**Changes:**
- The introduction of an unconditional `no-alpn` directive in the HAProxy template for `fe_sni` and `fe_no_sni` listeners.
- This change is independent of the HTTP/2 status in the ingress controller and aims to maintain consistent behavior with previous OpenShift / HAProxy releases.

**Rationale:**
In the HAProxy 2.8 release notes[1], it is highlighted that HTTP/2 is now automatically advertised in ALPN for TLS listeners:

>HTTP/2 is now advertised by default in ALPN on TLS listeners. This marks a pivotal change, as HTTP/2 has been available for 5 years and enabled by default in clear text as an HTTP/1 upgrade flisteners. This marks a pivotal change, as HTTP/2 has been available for 5 years andor 4 years. However, some users were still unaware of how to enable it. Now, ALPN will default to 'h2,http/1.1' on TCP and 'h3' on QUIC, ensuring these protocol versions work by default. Adjustments to ALPN settings remain possible to enable or disable these protocols...

This is a significant change from previous versions where such default enablement was not present. To ensure backward compatibility and controlled protocol negotiation, we've introduced the `no-alpn` directive. This maintains our existing deployment behaviours and offers a more controlled approach to protocol negotiation, especially concerning HTTP/2.

**Additional Details:**
- While we disable ALPN by default, ALPN h2 remains supported for specific routes/backends that require it. This is managed through entries in the `cert-config.map`, allowing for explicit enablement of ALPN h2 where needed.
- The PR ensures that our deployments and upgrades to OCP 4.16 continue to function as expected with the new HAProxy version.

**References:**
- HAProxy 2.8 Release Notes: [HAProxy Mailing List Archive](https://www.mail-archive.com/haproxy@formilux.org/msg43600.html)