### PR TITLE
TRT-1507: Revert #551 "NE-1444: Upgrade OpenShift Router to HAProxy 2.8"

### DIFF
--- a/hack/Dockerfile.debug
+++ b/hack/Dockerfile.debug
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi
-RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.16-rhel-9/haproxy28-2.8.5-1.rhaos4.16.el9.x86_64.rpm
+RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.14-rhel-8/haproxy26-2.6.13-2.rhaos4.14.el8.x86_64.rpm
 RUN haproxy -vv
 RUN INSTALL_PKGS="rsyslog procps-ng util-linux socat" && \
     yum install -y $INSTALL_PKGS && \

--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy28 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy26 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy28 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy26 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/ocp/4.16:haproxy-router-base
-RUN INSTALL_PKGS="haproxy28 rsyslog procps-ng util-linux" && \
+RUN INSTALL_PKGS="haproxy26 rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -330,7 +330,6 @@ frontend fe_sni
         {{- if $haveCRLs }} crl-file /var/lib/haproxy/mtls/latest/crls.pem {{ end }}
       {{- end }}
     {{- end }}
-  {{- "" }} no-alpn
   mode http
 
     {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
@@ -441,7 +440,6 @@ frontend fe_no_sni
         {{- if $haveCRLs }} crl-file /var/lib/haproxy/mtls/latest/crls.pem {{ end }}
       {{- end }}
     {{- end }}
-  {{- "" }} no-alpn
   mode http
 
     {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}


### PR DESCRIPTION

Reverts #551 ; tracked by [TRT-1507](https://issues.redhat.com//browse/TRT-1507)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Testing a revert here, we are seeing a crash in metal-ipi jobs on missing socat binary in an haproxy container.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-nightly-4.16-e2e-metal-ipi-sdn-bm
```

CC: @frobware

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
