### PR TITLE
[WIP] where-is-socat

### DIFF
--- a/where-is-socat
+++ b/where-is-socat
@@ -1,0 +1,1 @@
+Dummy change.


### PR DESCRIPTION
Trying to understand what's broken with the haproxy 2.8 bump; https://github.com/openshift/router/pull/561