### PR TITLE
NE-1444: Bump HaProxy to the latest version 2.8

### DIFF
--- a/hack/Dockerfile.debug
+++ b/hack/Dockerfile.debug
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi
-RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.14-rhel-8/haproxy26-2.6.13-2.rhaos4.14.el8.x86_64.rpm
+RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.16-rhel-9/haproxy28-2.8.5-1.rhaos4.16.el9.x86_64.rpm
 RUN haproxy -vv
 RUN INSTALL_PKGS="rsyslog procps-ng util-linux socat" && \
     yum install -y $INSTALL_PKGS && \

--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy26 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy28 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN INSTALL_PKGS="haproxy28 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="socat haproxy28 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy26 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="haproxy28 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -1,5 +1,5 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN INSTALL_PKGS="haproxy28 rsyslog sysvinit-tools" && \
+RUN INSTALL_PKGS="socat haproxy28 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/ocp/4.16:haproxy-router-base
-RUN INSTALL_PKGS="haproxy28 rsyslog procps-ng util-linux" && \
+RUN INSTALL_PKGS="socat haproxy28 rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/Dockerfile.rhel8
+++ b/images/router/haproxy/Dockerfile.rhel8
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/ocp/4.16:haproxy-router-base
-RUN INSTALL_PKGS="haproxy26 rsyslog procps-ng util-linux" && \
+RUN INSTALL_PKGS="haproxy28 rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -330,6 +330,7 @@ frontend fe_sni
         {{- if $haveCRLs }} crl-file /var/lib/haproxy/mtls/latest/crls.pem {{ end }}
       {{- end }}
     {{- end }}
+  {{- "" }} no-alpn
   mode http
 
     {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
@@ -440,6 +441,7 @@ frontend fe_no_sni
         {{- if $haveCRLs }} crl-file /var/lib/haproxy/mtls/latest/crls.pem {{ end }}
       {{- end }}
     {{- end }}
+  {{- "" }} no-alpn
   mode http
 
     {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}


### PR DESCRIPTION
This PR addresses the absence of the `socat` package in container builds, which has been reported as missing in metal-ipi jobs. It explicitly adds the `socat` package to the container builds to rectify this issue. The need for a direct inclusion of `socat` suggests a potential change in the baseline environment provided by RHEL 9, given that in previous RHEL 8 builds, `socat` was not explicitly included but was nonetheless present and extensively used for debugging HAProxy issues through its stats socket.

This PR reverts [openshift/router#561](https://github.com/openshift/router/pull/561).

cc @dgoodwin