### PR TITLE
NE-1811: Rename the allowlist route annotation

### DIFF
--- a/hack/Dockerfile.debug
+++ b/hack/Dockerfile.debug
@@ -5,7 +5,7 @@ RUN INSTALL_PKGS="rsyslog procps-ng util-linux socat" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    mkdir -p /var/lib/haproxy/router/{certs,cacerts,whitelists} && \
+    mkdir -p /var/lib/haproxy/router/{certs,cacerts,allowlists} && \
     mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log} && \
     touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
     setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \

--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -3,7 +3,7 @@ RUN INSTALL_PKGS="socat haproxy28 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    mkdir -p /var/lib/haproxy/router/{certs,cacerts,whitelists} && \
+    mkdir -p /var/lib/haproxy/router/{certs,cacerts,allowlists} && \
     mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log,mtls} && \
     touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
     setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \

--- a/images/router/haproxy/Dockerfile.ocp
+++ b/images/router/haproxy/Dockerfile.ocp
@@ -3,7 +3,7 @@ RUN INSTALL_PKGS="socat haproxy28 rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    mkdir -p /var/lib/haproxy/router/{certs,cacerts,whitelists} && \
+    mkdir -p /var/lib/haproxy/router/{certs,cacerts,allowlists} && \
     mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log,mtls} && \
     touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
     setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \

--- a/images/router/haproxy/Dockerfile.rhel
+++ b/images/router/haproxy/Dockerfile.rhel
@@ -3,7 +3,7 @@ RUN INSTALL_PKGS="socat haproxy28 rsyslog sysvinit-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    mkdir -p /var/lib/haproxy/router/{certs,cacerts,whitelists} && \
+    mkdir -p /var/lib/haproxy/router/{certs,cacerts,allowlists} && \
     mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log,mtls} && \
     touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
     setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -583,15 +583,15 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
         {{- else }}
   balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}{{ firstMatch $balanceAlgoPattern (env "ROUTER_LOAD_BALANCE_ALGORITHM") "random" }}{{ end }}
         {{- end }}
-        {{- with $ip_whiteList := parseIPList (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist") }}
-          {{- if validateHAProxyWhiteList $ip_whiteList }}
-  acl whitelist src {{ $ip_whiteList }}
+        {{- with $ip_allowlist := parseIPList (firstMatch ".+" (index $cfg.Annotations "haproxy.router.openshift.io/ip_allowlist") (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist")) }}
+          {{- if validateHAProxyAllowlist $ip_allowlist }}
+  acl allowlist src {{ $ip_allowlist }}
           {{- else }}
-            {{- with $whiteListFileName := generateHAProxyWhiteListFile $workingDir $cfgIdx $ip_whiteList }}
-  acl whitelist src -f {{ $whiteListFileName }}
+            {{- with $allowlistFileName := generateHAProxyAllowlistFile $workingDir $cfgIdx $ip_allowlist }}
+  acl allowlist src -f {{ $allowlistFileName }}
             {{- end }}
           {{- end }}
-  tcp-request content reject if !whitelist
+  tcp-request content reject if !allowlist
         {{- end }}
         {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout")) }}
   timeout server  {{ $value }}
@@ -787,15 +787,15 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
         {{- else }}
   balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}{{ firstMatch $balanceAlgoPattern (env "ROUTER_TCP_BALANCE_SCHEME") (env "ROUTER_LOAD_BALANCE_ALGORITHM") "source" }}{{ end }}
         {{- end }}
-        {{- with $ip_whiteList := parseIPList (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist") }}
-          {{- if validateHAProxyWhiteList $ip_whiteList }}
-  acl whitelist src {{ $ip_whiteList }}
+        {{- with $ip_allowlist := parseIPList (firstMatch ".+" (index $cfg.Annotations "haproxy.router.openshift.io/ip_allowlist") (index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist")) }}
+          {{- if validateHAProxyAllowlist $ip_allowlist }}
+  acl allowlist src {{ $ip_allowlist }}
           {{- else }}
-            {{- with $whiteListFileName := generateHAProxyWhiteListFile $workingDir $cfgIdx $ip_whiteList }}
-  acl whitelist src -f {{ $whiteListFileName }}
+            {{- with $allowlistFileName := generateHAProxyAllowlistFile $workingDir $cfgIdx $ip_allowlist }}
+  acl allowlist src -f {{ $allowlistFileName }}
             {{- end }}
           {{- end }}
-  tcp-request content reject if !whitelist
+  tcp-request content reject if !allowlist
         {{- end }}
         {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout-tunnel") (index $cfg.Annotations "haproxy.router.openshift.io/timeout")) }}
   timeout tunnel  {{ $value }}

--- a/pkg/router/template/configmanager/haproxy/manager.go
+++ b/pkg/router/template/configmanager/haproxy/manager.go
@@ -1090,6 +1090,7 @@ func backendModAnnotations(route *routev1.Route) map[string]string {
 func modAnnotationsList(termination routev1.TLSTerminationType) []string {
 	annotations := []string{
 		"haproxy.router.openshift.io/balance",
+		"haproxy.router.openshift.io/ip_allowlist",
 		"haproxy.router.openshift.io/ip_whitelist",
 		"haproxy.router.openshift.io/timeout",
 		"haproxy.router.openshift.io/rate-limit-connections",

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -40,7 +40,7 @@ const (
 	caCertDir       = "router/cacerts"
 	defaultCertName = "default"
 
-	whitelistDir = "router/whitelists"
+	allowlistDir = "router/allowlists"
 
 	caCertPostfix   = "_ca"
 	destCertPostfix = "_pod"

--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -231,19 +231,19 @@ func generateHAProxyCertConfigMap(td templateData) []string {
 	return lines
 }
 
-// validateHAProxyWhiteList validates a whitelist for use with an haproxy acl.
-func validateHAProxyWhiteList(value string) bool {
-	_, valid := haproxyutil.ValidateWhiteList(value)
+// validateHAProxyAllowlist validates an allowlist for use with an haproxy acl.
+func validateHAProxyAllowlist(value string) bool {
+	_, valid := haproxyutil.ValidateAllowlist(value)
 	return valid
 }
 
-// generateHAProxyWhiteListFile generates a whitelist file for use with an haproxy acl.
-func generateHAProxyWhiteListFile(workingDir string, id ServiceAliasConfigKey, value string) string {
-	name := path.Join(workingDir, whitelistDir, fmt.Sprintf("%s.txt", id))
-	cidrs, _ := haproxyutil.ValidateWhiteList(value)
+// generateHAProxyAllowlistFile generates an allowlist file for use with an haproxy acl.
+func generateHAProxyAllowlistFile(workingDir string, id ServiceAliasConfigKey, value string) string {
+	name := path.Join(workingDir, allowlistDir, fmt.Sprintf("%s.txt", id))
+	cidrs, _ := haproxyutil.ValidateAllowlist(value)
 	data := []byte(strings.Join(cidrs, "\n") + "\n")
 	if err := ioutil.WriteFile(name, data, 0644); err != nil {
-		log.Error(err, "error writing haproxy whitelist contents")
+		log.Error(err, "error writing haproxy allowlist contents")
 		return ""
 	}
 
@@ -409,8 +409,8 @@ var helperFunctions = template.FuncMap{
 	"getPrimaryAliasKey":          getPrimaryAliasKey,          //returns the key of the primary alias for a group of aliases
 
 	"generateHAProxyMap":           generateHAProxyMap,           //generates a haproxy map content
-	"validateHAProxyWhiteList":     validateHAProxyWhiteList,     //validates a haproxy whitelist (acl) content
-	"generateHAProxyWhiteListFile": generateHAProxyWhiteListFile, //generates a haproxy whitelist file for use in an acl
+	"validateHAProxyAllowlist":     validateHAProxyAllowlist,     //validates a haproxy allowlist (acl) content
+	"generateHAProxyAllowlistFile": generateHAProxyAllowlistFile, //generates a haproxy allowlist file for use in an acl
 
 	"clipHAProxyTimeoutValue": clipHAProxyTimeoutValue, //clips extrodinarily high timeout values to be below the maximum allowed timeout value
 	"parseIPList":             parseIPList,             //parses the list of IPs/CIDRs (IPv4/IPv6)

--- a/pkg/router/template/template_helper_test.go
+++ b/pkg/router/template/template_helper_test.go
@@ -915,26 +915,26 @@ func TestClipHAProxyTimeoutValue(t *testing.T) {
 	}
 }
 
-func TestGenerateHAProxyWhiteListFile(t *testing.T) {
+func Test_generateHAProxyAllowlistFile(t *testing.T) {
 	workDir := t.TempDir()
 
-	err := os.MkdirAll(path.Join(workDir, whitelistDir), 0740)
+	err := os.MkdirAll(path.Join(workDir, allowlistDir), 0740)
 	if err != nil {
-		t.Fatal("Unable to create the whitelist directory")
+		t.Fatal("Unable to create the allowlist directory")
 	}
 
 	testCases := []struct {
 		name              string
 		workDir           string
 		id                ServiceAliasConfigKey
-		expectedWhiteList []string
+		expectedAllowlist []string
 		failureExpected   bool
 	}{
 		{
 			name:    "Nominal",
 			workDir: workDir,
 			id:      ServiceAliasConfigKey("test1"),
-			expectedWhiteList: []string{
+			expectedAllowlist: []string{
 				"192.168.0.1",
 				"192.168.0.2",
 				"192.168.0.3",
@@ -944,7 +944,7 @@ func TestGenerateHAProxyWhiteListFile(t *testing.T) {
 			name:    "Nominal failure",
 			workDir: workDir + "-notexisting",
 			id:      ServiceAliasConfigKey("test2"),
-			expectedWhiteList: []string{
+			expectedAllowlist: []string{
 				"192.168.0.1",
 				"192.168.0.2",
 				"192.168.0.3",
@@ -955,7 +955,7 @@ func TestGenerateHAProxyWhiteListFile(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			file := generateHAProxyWhiteListFile(tc.workDir, tc.id, strings.Join(tc.expectedWhiteList, " "))
+			file := generateHAProxyAllowlistFile(tc.workDir, tc.id, strings.Join(tc.expectedAllowlist, " "))
 			if tc.failureExpected {
 				if file != "" {
 					t.Fatal("Failure expected but didn't happen")
@@ -971,9 +971,9 @@ func TestGenerateHAProxyWhiteListFile(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unable to read from the generated file: %v", err)
 			}
-			gotWhiteList := strings.Fields(string(contents))
-			if !reflect.DeepEqual(tc.expectedWhiteList, gotWhiteList) {
-				t.Errorf("Wrong whitelist written: expected %q, got %q", tc.expectedWhiteList, gotWhiteList)
+			gotAllowlist := strings.Fields(string(contents))
+			if !reflect.DeepEqual(tc.expectedAllowlist, gotAllowlist) {
+				t.Errorf("Wrong allowlist written: expected %q, got %q", tc.expectedAllowlist, gotAllowlist)
 			}
 		})
 	}

--- a/pkg/router/template/util/haproxy/allowlist.go
+++ b/pkg/router/template/util/haproxy/allowlist.go
@@ -10,13 +10,13 @@ const (
 	// Ref: https://github.com/haproxy/haproxy/blob/master/include/common/defaults.h#L75
 	HAPROXY_MAX_LINE_ARGS = 64
 
-	// HAPROXY_MAX_WHITELIST_LENGTH is the maximum number of CIDRs allowed
-	// for an "acl whitelist src [<cidr>]*" config line.
-	HAPROXY_MAX_WHITELIST_LENGTH = HAPROXY_MAX_LINE_ARGS - 3
+	// HAPROXY_MAX_ALLOWLIST_LENGTH is the maximum number of CIDRs allowed
+	// for an "acl allowlist src [<cidr>]*" config line.
+	HAPROXY_MAX_ALLOWLIST_LENGTH = HAPROXY_MAX_LINE_ARGS - 3
 )
 
-// ValidateWhiteList validates a haproxy acl whitelist from an annotation value.
-func ValidateWhiteList(value string) ([]string, bool) {
+// ValidateAllowlist validates a haproxy acl allowlist from an annotation value.
+func ValidateAllowlist(value string) ([]string, bool) {
 	values := strings.Split(value, " ")
 
 	cidrs := make([]string, 0)
@@ -26,5 +26,5 @@ func ValidateWhiteList(value string) ([]string, bool) {
 		}
 	}
 
-	return cidrs, len(cidrs) <= HAPROXY_MAX_WHITELIST_LENGTH
+	return cidrs, len(cidrs) <= HAPROXY_MAX_ALLOWLIST_LENGTH
 }

--- a/pkg/router/template/util/haproxy/allowlist_test.go
+++ b/pkg/router/template/util/haproxy/allowlist_test.go
@@ -27,7 +27,7 @@ func generateTestData(n int) []string {
 	return cidrs
 }
 
-func TestValidateWhiteList(t *testing.T) {
+func Test_ValidateAllowlist(t *testing.T) {
 	tests := []struct {
 		name        string
 		data        []string
@@ -66,7 +66,7 @@ func TestValidateWhiteList(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		values, ok := ValidateWhiteList(strings.Join(tc.data, " "))
+		values, ok := ValidateAllowlist(strings.Join(tc.data, " "))
 		if !reflect.DeepEqual(tc.expectation, values) {
 			t.Errorf("%s: expected validated data %+v, got %+v", tc.name, tc.expectation, values)
 		}
@@ -80,7 +80,7 @@ func TestValidateWhiteList(t *testing.T) {
 	for _, v := range limitsTest {
 		name := fmt.Sprintf("limits-test-%d", v)
 		data := generateTestData(v)
-		values, ok := ValidateWhiteList(strings.Join(data, " "))
+		values, ok := ValidateAllowlist(strings.Join(data, " "))
 		if !reflect.DeepEqual(data, values) {
 			t.Errorf("%s: expected validated data %+v, got %+v", name, data, values)
 		}


### PR DESCRIPTION
Use the new annotation key "haproxy.router.openshift.io/ip_allowlist" in addition to the old "haproxy.router.openshift.io/ip_whitelist" annotation key. Continue to allow the old annotation key for now, but use the new one if it is present.

If a route has annotations with both keys, the annotation with the new key is used, and the annotation with the old key is ignored.

Also rename some template helper functions.  **Note that this is technically a breaking change for custom config templates!**

Also rename internal consts, variables, functions, struct fields, and HAProxy ACLs to change "whitelist" to "allowlist" and "blacklist" to "denylist".

* `images/router/haproxy/conf/haproxy-config.template`: Check for both the old annotation and new annotation keys.  Rename the associated acl and file name.
* `pkg/cmd/infra/router/router.go` (`RouterSelection`): Rename `BlacklistedDomains` to `DenylistedDomains` and `WhitelistedDomains` to `AllowlistedDomains`.
(`AdmissionCheck`, `RouteAdmissionFunc`): Update for changes in `RouterSelection`.
* `pkg/router/router_test.go` (`TestMain`): Use the new HAProxy allowlist file name.
(`TestConfigTemplate`): Update tests to use the new annotation key and to check for the new HAProxy ACL name and file name.  Add a test for the old annotation key to ensure we don't break existing routes.
* `pkg/router/template/configmanager/haproxy/manager.go` (`modAnnotationsList`): Add the new annotation key (but keep the old one as well as it is still recognized in the template).
* `pkg/router/template/router.go` (`whitelistDir`): Rename...
(`allowlistDir`): ...to this.
* `pkg/router/template/template_helper.go` (`validateHAProxyWhiteList`): Rename...
(`validateHAProxyAllowlist`): ...to this.  Use the new `ValidateAllowlist` helper.
(`generateHAProxyWhiteListFile`): Rename...
(`generateHAProxyAllowlistFile`): ...to this.  Use the new `ValidateAllowlist` helper and `allowlistDir` const, and update an error message.
(`helperFunctions`): Rename `validateHAProxyWhiteList` and `generateHAProxyWhiteListFile` to `validateHAProxyAllowlist` and `generateHAProxyAllowlistFile`, respectively.
* `pkg/router/template/template_helper_test.go` (`TestGenerateHAProxyWhiteListFile`): Rename...
(`Test_generateHAProxyAllowlistFile`): ...to this.  Use the new `allowlistDir` const.  Update some error messages and internal struct field names.
* `pkg/router/template/util/haproxy/whitelist.go`: Rename file...
* `pkg/router/template/util/haproxy/allowlist.go`: ...to this.
(`HAPROXY_MAX_WHITELIST_LENGTH`): Rename const...
(`HAPROXY_MAX_ALLOWLIST_LENGTH`): ...to this.
(`ValidateWhiteList`): Rename...
(`ValidateAllowlist`): ...to this.
* `pkg/router/template/util/haproxy/whitelist_test.go`: Rename file...
* `pkg/router/template/util/haproxy/allowlist_test.go`: ...to this.
(`TestValidateWhitelist`): Rename...
(`Test_ValidateAllowlist`): ...to this.