### PR TITLE
OCPBUGS-30314: Refactor logging in DoHTTPProbe to avoid serialisation errors

### DIFF
--- a/pkg/router/metrics/probehttp/probehttp.go
+++ b/pkg/router/metrics/probehttp/probehttp.go
@@ -104,7 +104,7 @@ func DoHTTPProbe(url *url.URL, headers http.Header, client HTTPGetInterface) (Re
 	}
 	body := string(b)
 	if res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusBadRequest {
-		log.V(4).Info("probe succeeded", "url", url.String(), "response", *res)
+		log.V(4).Info("probe succeeded", "url", url.String(), "StatusCode", res.StatusCode, "Status", res.Status)
 		return Success, body, nil
 	}
 	log.V(4).Info("probe failed", "url", url.String(), "headers", headers, "body", body)


### PR DESCRIPTION
This commit modifies the logging within DoHTTPProbe() to directly log
specific fields of the HTTP response (StatusCode and Status) instead
of attempting to log the entire response object.

This modification resolves issues related to logging non-serialisable
objects by directly logging specific, serialisable fields of the HTTP
response. This approach enhances log clarity and utility for
debugging, eliminating errors caused by attempting to serialise
non-serialisable types.

Prior to this change we would log (and reformatted for clarity):

```console
  I0306 12:08:49.475681       1 probehttp.go:108]
    "msg"="probe succeeded"
    "response"=<<error: json: unsupported type: func() (io.ReadCloser, error)>>
    "url"="http://localhost:80/_______internal_router_healthz".
```

With this change we now log:

```console
  I0306 12:39:04.875235       1 probehttp.go:107]
    "msg"="probe succeeded"
    "Status"="200 OK"
    "StatusCode"=200
    "url"="http://localhost:80/_______internal_router_healthz"
```
