### PR TITLE
NO-JIRA: hack/Dockerfile.debug: use ubi9 for base image

### DIFF
--- a/hack/Dockerfile.debug
+++ b/hack/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi9/ubi
 RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.16-rhel-9/haproxy28-2.8.5-1.rhaos4.16.el9.x86_64.rpm
 RUN haproxy -vv
 RUN INSTALL_PKGS="rsyslog procps-ng util-linux socat" && \


### PR DESCRIPTION
In line with OCP-4.16's upgrade to RHEL 9, this PR updates
`hack/Dockerfile.debug` to use a RHEL 9 base image (`ubi9`) instead of
the previous RHEL 8 base (`ubi8`). This ensures our debug environment
mirrors the production environment's underlying OS.

Related change: https://github.com/openshift/router/pull/544
