### PR TITLE
OCPBUGS-32044: Introduce 'idle-close-on-response' option for frontends

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -213,6 +213,12 @@ frontend public
   bind :{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }}{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}
     {{- end }}
   mode http
+
+  # Workaround for a known issue encountered with certain HTTP clients,
+  # particularly the Apache HTTP client (prior to version 5),
+  # where closed idle connections are erroneously reused.
+  # Bug reference: https://issues.redhat.com/browse/OCPBUGS-32044.
+  option idle-close-on-response
   tcp-request inspect-delay {{ firstMatch $timeSpecPattern (env "ROUTER_INSPECT_DELAY") "5s" }}
   tcp-request content accept if HTTP
 
@@ -333,6 +339,8 @@ frontend fe_sni
   {{- "" }} no-alpn
   mode http
 
+  option idle-close-on-response
+
     {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
   capture request header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
     {{- end }}
@@ -443,6 +451,8 @@ frontend fe_no_sni
     {{- end }}
   {{- "" }} no-alpn
   mode http
+
+  option idle-close-on-response
 
     {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
   capture request header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}


### PR DESCRIPTION
This PR addresses a known issue ([OCPBUGS-32044](https://issues.redhat.com//browse/OCPBUGS-32044)) encountered with certain HTTP clients, notably the Apache HTTP client (prior to version 5), where closed idle connections are erroneously reused. To mitigate this, we introduce the `idle-close-on-response` option, which is now applied to all frontends operating in HTTP mode. Note that the `public_ssl` frontend remains in TCP mode and is unaffected by this change.

Spin off of https://github.com/openshift/router/pull/572.