### PR TITLE
[WIP] OCPBUGS-32250: Prevent UniqueHost from stopping plugin chain

### DIFF
--- a/pkg/router/controller/hostindex/hostindex.go
+++ b/pkg/router/controller/hostindex/hostindex.go
@@ -106,10 +106,6 @@ func (hi *hostIndex) add(route *routev1.Route, changes *routeChanges) bool {
 			// duplicate claim in the index.
 			hi.remove(existing, false, changes)
 		default:
-			// if no changes have been made, we don't need to note a change
-			if existing.ResourceVersion == route.ResourceVersion {
-				return false
-			}
 			// no other significant changes, we can update the cache and then exit
 			rules.replace(existing, route)
 			// a route that is active should be notified

--- a/pkg/router/controller/hostindex/hostindex_test.go
+++ b/pkg/router/controller/hostindex/hostindex_test.go
@@ -152,7 +152,8 @@ func Test_hostIndex(t *testing.T) {
 				{route: newRoute("test", "1", 1, 1, routev1.RouteSpec{Host: "test.com"})},
 				{route: newRoute("test", "1", 1, 1, routev1.RouteSpec{Host: "test.com"})},
 			},
-			active: map[string][]string{"test.com": {"001"}},
+			active:    map[string][]string{"test.com": {"001"}},
+			activates: map[string]struct{}{"001": {}},
 		},
 		{
 			name: "update - inactive",


### PR DESCRIPTION
Fix UniqueHost so that it doesn't completely stop the plugin chain if the route is not "activated" because the the ResourceVersion on the route didn't change. This is a problem for resyncs as the ResourceVersion doesn't change, but the plugin change should continue.

WIP because I need to test more, and possibly develop E2Es to reproduce this scenario.