### PR TITLE
OCPBUGS-29690: Count active services before setting weight to 1

### DIFF
--- a/pkg/router/template/router_test.go
+++ b/pkg/router/template/router_test.go
@@ -942,6 +942,7 @@ func TestFilterNamespaces(t *testing.T) {
 func TestCalculateServiceWeights(t *testing.T) {
 	suKey1 := ServiceUnitKey("ns/svc1")
 	suKey2 := ServiceUnitKey("ns/svc2")
+	suKey3 := ServiceUnitKey("ns/svc3")
 	ep1 := Endpoint{
 		ID:       "ep1",
 		IP:       "ip",
@@ -1215,7 +1216,7 @@ func TestCalculateServiceWeights(t *testing.T) {
 				suKey2: 0,
 			},
 			expectedWeights: map[ServiceUnitKey]int32{
-				suKey1: 256,
+				suKey1: 1,
 				suKey2: 0,
 			},
 		},
@@ -1233,6 +1234,57 @@ func TestCalculateServiceWeights(t *testing.T) {
 			expectedWeights: map[ServiceUnitKey]int32{
 				suKey1: 0,
 				suKey2: 0,
+			},
+		},
+		{
+			name:      "two services with weight 0",
+			routePort: "8080",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep2},
+				suKey2: {ep2},
+				suKey3: {ep3},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 100,
+				suKey3: 0,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 1,
+				suKey3: 0,
+			},
+		},
+		{
+			name:      "one service with no endpoints",
+			routePort: "8080",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {},
+				suKey2: {ep2},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 100,
+				suKey2: 100,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey2: 1,
+			},
+		},
+		{
+			name:      "two services with no endpoints",
+			routePort: "8080",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {},
+				suKey2: {ep2},
+				suKey3: {},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 100,
+				suKey3: 75,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey2: 1,
 			},
 		},
 	}


### PR DESCRIPTION
The previous logic, which reduced the weight to 1 when there was only one service, didn't filter out inactive services. If there's only one active service, there's no need for a weight greater than 1 because traffic is directed only to active services.

Additionally, the template logic correctly accounted for active services when setting the algorithm, resulting in "random" being set in situations where our logic didn't reduce the active service's weight to 1.

While this isn't inherently problematic, using the "random" algorithm with higher weights significantly increases memory usage on HaProxy startup. This can lead to excessive memory usage in scenarios where a user has many inactive services or routes backends using weight 0.