### PR TITLE
[WIP] [release-4.14] OCPBUGS-29690: Count active services before setting weight to 1

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -1360,8 +1360,10 @@ func (r *templateRouter) getActiveEndpoints(serviceUnits map[ServiceUnitKey]int3
 // Each service gets (weight/sum_of_weights) fraction of the requests.
 // For each service, the requests are distributed among the endpoints.
 // Each endpoint gets weight/numberOfEndpoints portion of the requests.
-// The largest weight per endpoint is scaled to 256 to permit better
-// precision results.  The remainder are scaled using the same scale factor.
+// If there is more than one active service, the largest weight per endpoint
+// is scaled to 256 to permit better precision results.  The remainder are
+// scaled using the same scale factor. If there is only one active service,
+// then non-zero weights are configured with a weight of 1.
 // Inaccuracies occur when converting float32 to int32 and when the scaled
 // weight per endpoint is less than 1.0, the minimum.
 // The above assumes roundRobin scheduling.
@@ -1369,20 +1371,23 @@ func (r *templateRouter) getActiveEndpoints(serviceUnits map[ServiceUnitKey]int3
 func (r *templateRouter) calculateServiceWeights(serviceUnits map[ServiceUnitKey]int32, port string) map[ServiceUnitKey]int32 {
 	serviceUnitNames := make(map[ServiceUnitKey]int32)
 
-	// If there is only 1 service unit, then always set the weight 1
-	// for all the endpoints, except when the service weight is 0.
+	// If there is only 1 active service unit, then always reduce the weight to 1
+	// for all the endpoints, except when the service weight is 0, or it contains no endpoints.
 	// Scaling the weight to 256 is redundant and causes haproxy to allocate more memory on startup.
-	if len(serviceUnits) == 1 {
-		for key, weight := range serviceUnits {
-			if r.numberOfEndpoints(key, port) > 0 {
-				if weight == 0 {
-					serviceUnitNames[key] = 0
-				} else {
-					serviceUnitNames[key] = 1
-				}
+	activeServiceUnits := 0
+	serviceUnitsWeightReduced := make(map[ServiceUnitKey]int32)
+	for key, weight := range serviceUnits {
+		if r.numberOfEndpoints(key, port) > 0 {
+			if weight > 0 {
+				activeServiceUnits++
+				serviceUnitsWeightReduced[key] = 1
+			} else if weight == 0 {
+				serviceUnitsWeightReduced[key] = 0
 			}
 		}
-		return serviceUnitNames
+	}
+	if activeServiceUnits == 1 {
+		return serviceUnitsWeightReduced
 	}
 
 	// portion of service weight for each endpoint

--- a/pkg/router/template/router_test.go
+++ b/pkg/router/template/router_test.go
@@ -942,6 +942,7 @@ func TestFilterNamespaces(t *testing.T) {
 func TestCalculateServiceWeights(t *testing.T) {
 	suKey1 := ServiceUnitKey("ns/svc1")
 	suKey2 := ServiceUnitKey("ns/svc2")
+	suKey3 := ServiceUnitKey("ns/svc3")
 	ep1 := Endpoint{
 		ID:       "ep1",
 		IP:       "ip",
@@ -1215,7 +1216,7 @@ func TestCalculateServiceWeights(t *testing.T) {
 				suKey2: 0,
 			},
 			expectedWeights: map[ServiceUnitKey]int32{
-				suKey1: 256,
+				suKey1: 1,
 				suKey2: 0,
 			},
 		},
@@ -1233,6 +1234,57 @@ func TestCalculateServiceWeights(t *testing.T) {
 			expectedWeights: map[ServiceUnitKey]int32{
 				suKey1: 0,
 				suKey2: 0,
+			},
+		},
+		{
+			name:      "two services with weight 0",
+			routePort: "8080",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep2},
+				suKey2: {ep2},
+				suKey3: {ep3},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 100,
+				suKey3: 0,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 1,
+				suKey3: 0,
+			},
+		},
+		{
+			name:      "one service with no endpoints",
+			routePort: "8080",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {},
+				suKey2: {ep2},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 100,
+				suKey2: 100,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey2: 1,
+			},
+		},
+		{
+			name:      "two services with no endpoints",
+			routePort: "8080",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {},
+				suKey2: {ep2},
+				suKey3: {},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 100,
+				suKey3: 75,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey2: 1,
 			},
 		},
 	}


### PR DESCRIPTION
**DO NOT MERGE**

Temporary PR in release-4.14 to build an image via cluster-bot.

This is taken from: https://github.com/openshift/router/pull/576.

The previous logic, which reduced the weight to 1 when there was only one service, didn't filter out inactive services. If there's only one active service, there's no need for a weight greater than 1 because traffic is directed only to active services.

Additionally, the template logic correctly accounted for active services when setting the algorithm, resulting in "random" being set in situations where our logic didn't reduce the active service's weight to 1.

While this isn't inherently problematic, using the "random" algorithm with higher weights significantly increases memory usage on HaProxy startup. This can lead to excessive memory usage in scenarios where a user has many inactive services or routes backends using weight 0.