### PR TITLE
[WIP] [release-4.12] OCPBUGS-29690: Count active services before setting weight to 1

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -553,10 +553,10 @@ func (r *templateRouter) writeConfig() error {
 
 		// calculate the server weight for the endpoints in each service
 		// called here to make sure we have the actual number of endpoints.
-		cfg.ServiceUnitNames = r.calculateServiceWeights(cfg.ServiceUnits)
+		cfg.ServiceUnitNames = r.calculateServiceWeights(cfg.ServiceUnits, cfg.PreferPort)
 
 		// Calculate the number of active endpoints for the route.
-		cfg.ActiveEndpoints = r.getActiveEndpoints(cfg.ServiceUnits)
+		cfg.ActiveEndpoints = r.getActiveEndpoints(cfg.ServiceUnits, cfg.PreferPort)
 
 		cfg.Status = ServiceAliasConfigStatusSaved
 		r.state[k] = cfg
@@ -774,7 +774,7 @@ func (r *templateRouter) dynamicallyAddRoute(backendKey ServiceAliasConfigKey, r
 	oldEndpoints := []Endpoint{}
 
 	// As the endpoints have changed, recalculate the weights.
-	newWeights := r.calculateServiceWeights(backend.ServiceUnits)
+	newWeights := r.calculateServiceWeights(backend.ServiceUnits, backend.PreferPort)
 	for key := range backend.ServiceUnits {
 		if service, ok := r.findMatchingServiceUnit(key); ok {
 			newEndpoints := endpointsForAlias(*backend, service)
@@ -836,7 +836,7 @@ func (r *templateRouter) dynamicallyReplaceEndpoints(id ServiceUnitKey, service 
 		newEndpoints := endpointsForAlias(cfg, service)
 
 		// As the endpoints have changed, recalculate the weights.
-		newWeights := r.calculateServiceWeights(cfg.ServiceUnits)
+		newWeights := r.calculateServiceWeights(cfg.ServiceUnits, cfg.PreferPort)
 
 		// Get the weight for this service unit.
 		weight, ok := newWeights[id]
@@ -1084,12 +1084,21 @@ func (r *templateRouter) removeRouteInternal(route *routev1.Route) {
 }
 
 // numberOfEndpoints returns the number of endpoints
+// If port parameter is non-empty string, then only endpoints matching port will be counted.
 // Must be called while holding r.lock
-func (r *templateRouter) numberOfEndpoints(id ServiceUnitKey) int32 {
+func (r *templateRouter) numberOfEndpoints(id ServiceUnitKey, port string) int32 {
 	var eps = 0
 	svc, ok := r.findMatchingServiceUnit(id)
 	if ok && len(svc.EndpointTable) > eps {
-		eps = len(svc.EndpointTable)
+		if len(port) == 0 {
+			eps = len(svc.EndpointTable)
+		} else {
+			for _, ep := range svc.EndpointTable {
+				if ep.Port == port || ep.PortName == port {
+					eps += 1
+				}
+			}
+		}
 	}
 	return int32(eps)
 }
@@ -1280,12 +1289,12 @@ func getServiceUnitWeight(weightRef *int32) int32 {
 
 // getActiveEndpoints calculates the number of endpoints that are not associated
 // with service units with a zero weight and returns the count.
-func (r *templateRouter) getActiveEndpoints(serviceUnits map[ServiceUnitKey]int32) int {
+func (r *templateRouter) getActiveEndpoints(serviceUnits map[ServiceUnitKey]int32, port string) int {
 	var activeEndpoints int32 = 0
 
 	for key, weight := range serviceUnits {
 		if weight > 0 {
-			activeEndpoints += r.numberOfEndpoints(key)
+			activeEndpoints += r.numberOfEndpoints(key, port)
 		}
 	}
 
@@ -1296,29 +1305,33 @@ func (r *templateRouter) getActiveEndpoints(serviceUnits map[ServiceUnitKey]int3
 // Each service gets (weight/sum_of_weights) fraction of the requests.
 // For each service, the requests are distributed among the endpoints.
 // Each endpoint gets weight/numberOfEndpoints portion of the requests.
-// The largest weight per endpoint is scaled to 256 to permit better
-// percision results.  The remainder are scaled using the same scale factor.
+// If there is more than one active service, the largest weight per endpoint
+// is scaled to 256 to permit better precision results.  The remainder are
+// scaled using the same scale factor. If there is only one active service,
+// then non-zero weights are configured with a weight of 1.
 // Inaccuracies occur when converting float32 to int32 and when the scaled
 // weight per endpoint is less than 1.0, the minimum.
 // The above assumes roundRobin scheduling.
-func (r *templateRouter) calculateServiceWeights(serviceUnits map[ServiceUnitKey]int32) map[ServiceUnitKey]int32 {
+func (r *templateRouter) calculateServiceWeights(serviceUnits map[ServiceUnitKey]int32, port string) map[ServiceUnitKey]int32 {
 	serviceUnitNames := make(map[ServiceUnitKey]int32)
 
-	// If there is only 1 service unit, then always set the weight 1
-	// for all the endpoints, except when the service weight is 0.
+	// If there is only 1 active service unit, then always reduce the weight to 1
+	// for all the endpoints, except when the service weight is 0, or it contains no endpoints.
 	// Scaling the weight to 256 is redundant and causes haproxy to allocate more memory on startup.
-	if len(serviceUnits) == 1 {
-
-		for key, weight := range serviceUnits {
-			if r.numberOfEndpoints(key) > 0 {
-				if weight == 0 {
-					serviceUnitNames[key] = 0
-				} else {
-					serviceUnitNames[key] = 1
-				}
+	activeServiceUnits := 0
+	serviceUnitsWeightReduced := make(map[ServiceUnitKey]int32)
+	for key, weight := range serviceUnits {
+		if r.numberOfEndpoints(key, port) > 0 {
+			if weight > 0 {
+				activeServiceUnits++
+				serviceUnitsWeightReduced[key] = 1
+			} else if weight == 0 {
+				serviceUnitsWeightReduced[key] = 0
 			}
 		}
-		return serviceUnitNames
+	}
+	if activeServiceUnits == 1 {
+		return serviceUnitsWeightReduced
 	}
 
 	// portion of service weight for each endpoint
@@ -1329,7 +1342,7 @@ func (r *templateRouter) calculateServiceWeights(serviceUnits map[ServiceUnitKey
 	// distribute service weight over the service's endpoints
 	// to get weight per endpoint
 	for key, weight := range serviceUnits {
-		numEp := r.numberOfEndpoints(key)
+		numEp := r.numberOfEndpoints(key, port)
 		if numEp > 0 {
 			epWeight[key] = float32(weight) / float32(numEp)
 		}
@@ -1360,7 +1373,7 @@ func (r *templateRouter) calculateServiceWeights(serviceUnits map[ServiceUnitKey
 		serviceUnitNames[key] = int32(weight * scaleWeight)
 		if weight > 0.0 && serviceUnitNames[key] < 1 {
 			serviceUnitNames[key] = 1
-			numEp := r.numberOfEndpoints(key)
+			numEp := r.numberOfEndpoints(key, port)
 			log.V(4).Info("WARNING: Too many service endpoints to achieve desired weight for route.",
 				"key", key, "maxEndpoints", int32(weight*float32(numEp)), "actualEndpoints", numEp)
 		}

--- a/pkg/router/template/router_test.go
+++ b/pkg/router/template/router_test.go
@@ -844,37 +844,48 @@ func TestFilterNamespaces(t *testing.T) {
 // TestCalculateServiceWeights tests calculating the service
 // endpoint weights
 func TestCalculateServiceWeights(t *testing.T) {
-	router := NewFakeTemplateRouter()
-
 	suKey1 := ServiceUnitKey("ns/svc1")
 	suKey2 := ServiceUnitKey("ns/svc2")
+	suKey3 := ServiceUnitKey("ns/svc3")
 	ep1 := Endpoint{
-		ID:     "ep1",
-		IP:     "ip",
-		Port:   "port",
-		IdHash: fmt.Sprintf("%x", md5.Sum([]byte("ep1ipport"))),
+		ID:       "ep1",
+		IP:       "ip",
+		Port:     "8080",
+		PortName: "port",
+		IdHash:   fmt.Sprintf("%x", md5.Sum([]byte("ep1ipport"))),
 	}
 	ep2 := Endpoint{
-		ID:     "ep2",
-		IP:     "ip",
-		Port:   "port",
-		IdHash: fmt.Sprintf("%x", md5.Sum([]byte("ep2ipport"))),
+		ID:       "ep2",
+		IP:       "ip",
+		Port:     "8080",
+		PortName: "port",
+		IdHash:   fmt.Sprintf("%x", md5.Sum([]byte("ep2ipport"))),
 	}
 	ep3 := Endpoint{
-		ID:     "ep3",
-		IP:     "ip",
-		Port:   "port",
-		IdHash: fmt.Sprintf("%x", md5.Sum([]byte("ep3ipport"))),
+		ID:       "ep3",
+		IP:       "ip",
+		Port:     "8080",
+		PortName: "port",
+		IdHash:   fmt.Sprintf("%x", md5.Sum([]byte("ep3ipport"))),
+	}
+	ep4 := Endpoint{
+		ID:       "ep4",
+		IP:       "ip2",
+		Port:     "8081",
+		PortName: "port2",
+		IdHash:   fmt.Sprintf("%x", md5.Sum([]byte("ep3ipport"))),
 	}
 
 	testCases := []struct {
 		name            string
 		serviceUnits    map[ServiceUnitKey][]Endpoint
+		routePort       string
 		serviceWeights  map[ServiceUnitKey]int32
 		expectedWeights map[ServiceUnitKey]int32
 	}{
 		{
-			name: "equally weighted services with same number of endpoints",
+			name:      "equally weighted services with same number of endpoints",
+			routePort: "8080",
 			serviceUnits: map[ServiceUnitKey][]Endpoint{
 				suKey1: {ep1},
 				suKey2: {ep2},
@@ -889,7 +900,8 @@ func TestCalculateServiceWeights(t *testing.T) {
 			},
 		},
 		{
-			name: "unequally weighted services with same number of endpoints",
+			name:      "unequally weighted services with same number of endpoints",
+			routePort: "8080",
 			serviceUnits: map[ServiceUnitKey][]Endpoint{
 				suKey1: {ep1},
 				suKey2: {ep2},
@@ -904,7 +916,8 @@ func TestCalculateServiceWeights(t *testing.T) {
 			},
 		},
 		{
-			name: "services with equal weights and a different number of endpoints",
+			name:      "services with equal weights and a different number of endpoints",
+			routePort: "8080",
 			serviceUnits: map[ServiceUnitKey][]Endpoint{
 				suKey1: {ep1, ep2},
 				suKey2: {ep3},
@@ -919,7 +932,8 @@ func TestCalculateServiceWeights(t *testing.T) {
 			},
 		},
 		{
-			name: "services with unequal weights and a different number of endpoints",
+			name:      "services with unequal weights and a different number of endpoints",
+			routePort: "8080",
 			serviceUnits: map[ServiceUnitKey][]Endpoint{
 				suKey1: {ep1, ep2},
 				suKey2: {ep3},
@@ -934,7 +948,8 @@ func TestCalculateServiceWeights(t *testing.T) {
 			},
 		},
 		{
-			name: "services with equal weights and a different number of endpoints, one of which is common",
+			name:      "services with equal weights and a different number of endpoints, one of which is common",
+			routePort: "8080",
 			serviceUnits: map[ServiceUnitKey][]Endpoint{
 				suKey1: {ep1, ep2},
 				suKey2: {ep2},
@@ -949,7 +964,8 @@ func TestCalculateServiceWeights(t *testing.T) {
 			},
 		},
 		{
-			name: "a single service with a single endpoint",
+			name:      "a single service with a single endpoint",
+			routePort: "8080",
 			serviceUnits: map[ServiceUnitKey][]Endpoint{
 				suKey1: {ep1},
 			},
@@ -961,7 +977,8 @@ func TestCalculateServiceWeights(t *testing.T) {
 			},
 		},
 		{
-			name: "a single service with a multiple endpoints",
+			name:      "a single service with a multiple endpoints",
+			routePort: "8080",
 			serviceUnits: map[ServiceUnitKey][]Endpoint{
 				suKey1: {ep1, ep2},
 			},
@@ -973,13 +990,103 @@ func TestCalculateServiceWeights(t *testing.T) {
 			},
 		},
 		{
+			name:      "a single service with multiple endpoints, but no endpoint ports match the route port",
+			routePort: "9090",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep2},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 50,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{},
+		},
+		{
+			name:      "services with multiple endpoints with different ports",
+			routePort: "8080",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep4},
+				suKey2: {ep3},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 50,
+				suKey2: 50,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 256,
+				suKey2: 256,
+			},
+		},
+		{
+			name:      "services with multiple endpoints with different ports and route port is portName",
+			routePort: "port",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep4},
+				suKey2: {ep3},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 50,
+				suKey2: 50,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 256,
+				suKey2: 256,
+			},
+		},
+		{
+			name: "services with multiple endpoints with different ports and route has no port",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep4},
+				suKey2: {ep3},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 50,
+				suKey2: 50,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 128, // counts endpoints of all ports
+				suKey2: 256,
+			},
+		},
+		{
+			name: "services with multiple endpoints and route has no port",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep2},
+				suKey2: {ep3},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 50,
+				suKey2: 50,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 128, // counts endpoints of all ports
+				suKey2: 256,
+			},
+		},
+		{
+			name: "services with too many endpoints to achieve desired weight",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep2, ep2, ep3, ep3},
+				suKey2: {ep3},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 3,   // less than number of endpoints
+				suKey2: 256, // maxed out at 256
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 1,
+				suKey2: 256,
+			},
+		},
+		{
 			name:            "no services with no endpoints",
+			routePort:       "port",
 			serviceUnits:    map[ServiceUnitKey][]Endpoint{},
 			serviceWeights:  map[ServiceUnitKey]int32{},
 			expectedWeights: map[ServiceUnitKey]int32{},
 		},
 		{
-			name: "service with no endpoint",
+			name:      "service with no endpoint",
+			routePort: "port",
 			serviceUnits: map[ServiceUnitKey][]Endpoint{
 				suKey1: {},
 			},
@@ -989,7 +1096,8 @@ func TestCalculateServiceWeights(t *testing.T) {
 			expectedWeights: map[ServiceUnitKey]int32{},
 		},
 		{
-			name: "a single service with weight 0 with multiple endpoints",
+			name:      "a single service with weight 0 with multiple endpoints",
+			routePort: "8080",
 			serviceUnits: map[ServiceUnitKey][]Endpoint{
 				suKey1: {ep1, ep2},
 			},
@@ -1001,7 +1109,8 @@ func TestCalculateServiceWeights(t *testing.T) {
 			},
 		},
 		{
-			name: "services with one of weight 0",
+			name:      "services with one of weight 0",
+			routePort: "8080",
 			serviceUnits: map[ServiceUnitKey][]Endpoint{
 				suKey1: {ep1, ep2},
 				suKey2: {ep2},
@@ -1011,12 +1120,13 @@ func TestCalculateServiceWeights(t *testing.T) {
 				suKey2: 0,
 			},
 			expectedWeights: map[ServiceUnitKey]int32{
-				suKey1: 256,
+				suKey1: 1,
 				suKey2: 0,
 			},
 		},
 		{
-			name: "services with all weight 0",
+			name:      "services with all weight 0",
+			routePort: "8080",
 			serviceUnits: map[ServiceUnitKey][]Endpoint{
 				suKey1: {ep1, ep2},
 				suKey2: {ep2},
@@ -1030,23 +1140,72 @@ func TestCalculateServiceWeights(t *testing.T) {
 				suKey2: 0,
 			},
 		},
+		{
+			name:      "two services with weight 0",
+			routePort: "8080",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep2},
+				suKey2: {ep2},
+				suKey3: {ep3},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 100,
+				suKey3: 0,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 1,
+				suKey3: 0,
+			},
+		},
+		{
+			name:      "one service with no endpoints",
+			routePort: "8080",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {},
+				suKey2: {ep2},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 100,
+				suKey2: 100,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey2: 1,
+			},
+		},
+		{
+			name:      "two services with no endpoints",
+			routePort: "8080",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {},
+				suKey2: {ep2},
+				suKey3: {},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 100,
+				suKey3: 75,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey2: 1,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
-		for suKey, eps := range tc.serviceUnits {
-			router.CreateServiceUnit(suKey)
-			router.AddEndpoints(suKey, eps)
-		}
-		endpointWeights := router.calculateServiceWeights(tc.serviceWeights)
-		if !reflect.DeepEqual(endpointWeights, tc.expectedWeights) {
-			t.Errorf("test %s: expected endpointWeights to be %v, got %v", tc.name, tc.expectedWeights, endpointWeights)
-		}
-		// Remove endpoints and service units so the same sample template router
-		// can be re-used.
-		for suKey := range tc.serviceUnits {
-			router.DeleteEndpoints(suKey)
-			router.DeleteServiceUnit(suKey)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			router := NewFakeTemplateRouter()
+
+			for suKey, eps := range tc.serviceUnits {
+				router.CreateServiceUnit(suKey)
+				router.AddEndpoints(suKey, eps)
+			}
+			endpointWeights := router.calculateServiceWeights(tc.serviceWeights, tc.routePort)
+			if !reflect.DeepEqual(endpointWeights, tc.expectedWeights) {
+				t.Errorf("expected endpointWeights to be %v, got %v", tc.expectedWeights, endpointWeights)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
**DO NOT MERGE**

Temporary PR in release-4.12 so I can build an image via cluster-bot.

This is taken from: https://github.com/openshift/router/pull/576.

The previous logic, which reduced the weight to 1 when there was only one service, didn't filter out inactive services. If there's only one active service, there's no need for a weight greater than 1 because traffic is directed only to active services.

Additionally, the template logic correctly accounted for active services when setting the algorithm, resulting in "random" being set in situations where our logic didn't reduce the active service's weight to 1.

While this isn't inherently problematic, using the "random" algorithm with higher weights significantly increases memory usage on HaProxy startup. This can lead to excessive memory usage in scenarios where a user has many inactive services or routes backends using weight 0.