### PR TITLE
[release-4.12] OCPBUGS-33517: Count active services before setting weight to 1

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -1296,28 +1296,32 @@ func (r *templateRouter) getActiveEndpoints(serviceUnits map[ServiceUnitKey]int3
 // Each service gets (weight/sum_of_weights) fraction of the requests.
 // For each service, the requests are distributed among the endpoints.
 // Each endpoint gets weight/numberOfEndpoints portion of the requests.
-// The largest weight per endpoint is scaled to 256 to permit better
-// percision results.  The remainder are scaled using the same scale factor.
+// If there is more than one active service, the largest weight per endpoint
+// is scaled to 256 to permit better precision results.  The remainder are
+// scaled using the same scale factor. If there is only one active service,
+// then non-zero weights are configured with a weight of 1.
 // Inaccuracies occur when converting float32 to int32 and when the scaled
 // weight per endpoint is less than 1.0, the minimum.
 // The above assumes roundRobin scheduling.
 func (r *templateRouter) calculateServiceWeights(serviceUnits map[ServiceUnitKey]int32) map[ServiceUnitKey]int32 {
 	serviceUnitNames := make(map[ServiceUnitKey]int32)
 
-	// If there is only 1 service unit, then always set the weight 1
-	// for all the endpoints, except when the service weight is 0.
-	// Scaling the weight to 256 is redundant and causes haproxy to allocate more memory on startup.
-	if len(serviceUnits) == 1 {
-
-		for key, weight := range serviceUnits {
-			if r.numberOfEndpoints(key) > 0 {
-				if weight == 0 {
-					serviceUnitNames[key] = 0
-				} else {
-					serviceUnitNames[key] = 1
-				}
+	// If there is only 1 active service unit, then always reduce the weight to 1
+	// for all the endpoints, except when the service weight is 0, or it contains no endpoints.
+	// Scaling the weight to 256 in this case is redundant and causes haproxy to allocate more
+	// memory on startup.
+	activeServiceUnits := 0
+	for key, weight := range serviceUnits {
+		if r.numberOfEndpoints(key) > 0 {
+			if weight > 0 {
+				activeServiceUnits++
+				serviceUnitNames[key] = 1
+			} else if weight == 0 {
+				serviceUnitNames[key] = 0
 			}
 		}
+	}
+	if activeServiceUnits == 1 {
 		return serviceUnitNames
 	}
 

--- a/pkg/router/template/router_test.go
+++ b/pkg/router/template/router_test.go
@@ -848,6 +848,7 @@ func TestCalculateServiceWeights(t *testing.T) {
 
 	suKey1 := ServiceUnitKey("ns/svc1")
 	suKey2 := ServiceUnitKey("ns/svc2")
+	suKey3 := ServiceUnitKey("ns/svc3")
 	ep1 := Endpoint{
 		ID:     "ep1",
 		IP:     "ip",
@@ -1011,7 +1012,7 @@ func TestCalculateServiceWeights(t *testing.T) {
 				suKey2: 0,
 			},
 			expectedWeights: map[ServiceUnitKey]int32{
-				suKey1: 256,
+				suKey1: 1,
 				suKey2: 0,
 			},
 		},
@@ -1028,6 +1029,54 @@ func TestCalculateServiceWeights(t *testing.T) {
 			expectedWeights: map[ServiceUnitKey]int32{
 				suKey1: 0,
 				suKey2: 0,
+			},
+		},
+		{
+			name: "two services with weight 0",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {ep1, ep2},
+				suKey2: {ep2},
+				suKey3: {ep3},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 100,
+				suKey3: 0,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 1,
+				suKey3: 0,
+			},
+		},
+		{
+			name: "one service with no endpoints",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {},
+				suKey2: {ep2},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 100,
+				suKey2: 100,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey2: 1,
+			},
+		},
+		{
+			name: "two services with no endpoints",
+			serviceUnits: map[ServiceUnitKey][]Endpoint{
+				suKey1: {},
+				suKey2: {ep2},
+				suKey3: {},
+			},
+			serviceWeights: map[ServiceUnitKey]int32{
+				suKey1: 0,
+				suKey2: 100,
+				suKey3: 75,
+			},
+			expectedWeights: map[ServiceUnitKey]int32{
+				suKey2: 1,
 			},
 		},
 	}


### PR DESCRIPTION
**This is a manual cherry-pick of https://github.com/openshift/router/pull/576**

**Merge Conflict Resolution:**

- A merge conflict occurred because https://github.com/openshift/router/pull/439 is not backported to 4.12
  - We added the port parameter in  `numberOfEndpoints(key, port)` so it counts endpoints only for the port that the router is using.
  - Without backporting https://github.com/openshift/router/pull/439, it will double count the endpoints if you have 2 ports.
  - Our backport logic, we now additionally leverage `r.numberOfEndpoints(key)` to see if it's an active endpoint, i.e. if endpoints are > 0. `port` only matters if there are > 0 endpoints. Filtering by `port` might cause > 0 endpoint situations to change, but when there are 0 endpoints, number of ports has no impact.
  - **Summary**: the port counting fix doesn't impact the use of `r.numberOfEndpoints(key)` in our backport as we are only concerned with whether it is zero or non-zero. Additionally, filtering by port only influences situations where endpoints are greater than 0. ([Slack Discussion](https://redhat-internal.slack.com/archives/CCH60A77E/p1713458411878909?thread_ts=1709895019.274599&cid=CCH60A77E)) 