### PR TITLE
[release-4.15] OCPBUGS-28928: Upgrade Validation plugin for SHA1 certs

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+[allowlist]
+  description = "Global Allowlist"
+
+  # Ignore based on any subset of the file path
+  paths = [
+    # Ignore all example certs used for testing
+    '''pkg\/router\/routeapihelpers\/validation_test.go$''',
+    '''pkg\/router\/template\/plugin_test.go$''',
+    '''pkg\/router\/template\/router_test.go$''',
+  ]
+       

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gocarina/gocsv v0.0.0-20190927101021-3ecffd272576
 	github.com/google/go-cmp v0.5.9
 	github.com/haproxytech/config-parser/v4 v4.0.0-rc1
-	github.com/openshift/api v0.0.0-20230807132801-600991d550ac
+	github.com/openshift/api v0.0.0-20240522145529-93d6bda14341
 	github.com/openshift/client-go v0.0.0-20230120202327-72f107311084
 	github.com/openshift/library-go v0.0.0-20230120202744-256994f916c4
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
-github.com/openshift/api v0.0.0-20230807132801-600991d550ac h1:HqT8MmYGXiUGUW0BjygTGOOvqO2wIsTaG3q8nboJyPY=
-github.com/openshift/api v0.0.0-20230807132801-600991d550ac/go.mod h1:yimSGmjsI+XF1mr+AKBs2//fSXIOhhetHGbMlBEfXbs=
+github.com/openshift/api v0.0.0-20240522145529-93d6bda14341 h1:JQpzgk+p24rkgNbNsrNR0yLm63WTKapuT60INU5BqT8=
+github.com/openshift/api v0.0.0-20240522145529-93d6bda14341/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084 h1:66uaqNwA+qYyQDwsMWUfjjau8ezmg1dzCqub13KZOcE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084/go.mod h1:M3h9m001PWac3eAudGG3isUud6yBjr5XpzLYLLTlHKo=
 github.com/openshift/library-go v0.0.0-20230120202744-256994f916c4 h1:cFYg18OROQMHlrGWL9HpV1elDKbnRFLz/ED5VvP3qvw=

--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -68,6 +68,8 @@ type RouterSelection struct {
 
 	ExtendedValidation bool
 
+	UpgradeValidation bool
+
 	ListenAddr string
 
 	// WatchEndpoints when true will watch Endpoints instead of
@@ -94,7 +96,8 @@ func (o *RouterSelection) Bind(flag *pflag.FlagSet) {
 	flag.StringSliceVar(&o.AllowedDomains, "allowed-domains", envVarAsStrings("ROUTER_ALLOWED_DOMAINS", "", ","), "List of comma separated domains to allow in routes. If specified, only the domains in this list will be allowed routes. Note that domains in the denied list take precedence over the ones in the allowed list")
 	flag.BoolVar(&o.AllowWildcardRoutes, "allow-wildcard-routes", isTrue(env("ROUTER_ALLOW_WILDCARD_ROUTES", "")), "Allow wildcard host names for routes")
 	flag.BoolVar(&o.DisableNamespaceOwnershipCheck, "disable-namespace-ownership-check", isTrue(env("ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK", "")), "Disables the namespace ownership checks for a route host with different paths or for overlapping host names in the case of wildcard routes. Please be aware that if namespace ownership checks are disabled, routes in a different namespace can use this mechanism to 'steal' sub-paths for existing domains. This is only safe if route creation privileges are restricted, or if all the users can be trusted.")
-	flag.BoolVar(&o.ExtendedValidation, "extended-validation", isTrue(env("EXTENDED_VALIDATION", "true")), "If set, then an additional extended validation step is performed on all routes admitted in by this router. Defaults to true and enables the extended validation checks.")
+	flag.BoolVar(&o.ExtendedValidation, "extended-validation", isTrue(env("EXTENDED_VALIDATION", "true")), "If set, then an additional extended validation step is performed on all routes processed by this router. Defaults to true and enables the extended validation checks.")
+	flag.BoolVar(&o.UpgradeValidation, "upgrade-validation", isTrue(env("UPGRADE_VALIDATION", "true")), "If set, then an additional upgrade validation step is performed on all routes processed by this router. Defaults to true and enables the upgrade validation checks.")
 	flag.Bool("enable-ingress", false, "Enable configuration via ingress resources.")
 	flag.MarkDeprecated("enable-ingress", "Ingress resources are now synchronized to routes automatically.")
 	flag.StringVar(&o.ListenAddr, "listen-addr", env("ROUTER_LISTEN_ADDR", ""), "The name of an interface to listen on to expose metrics and health checking. If not specified, will not listen. Overrides stats port.")

--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -70,6 +70,9 @@ type RouterSelection struct {
 
 	UpgradeValidation bool
 
+	UpgradeValidationForceAddCondition    bool
+	UpgradeValidationForceRemoveCondition bool
+
 	ListenAddr string
 
 	// WatchEndpoints when true will watch Endpoints instead of
@@ -98,6 +101,8 @@ func (o *RouterSelection) Bind(flag *pflag.FlagSet) {
 	flag.BoolVar(&o.DisableNamespaceOwnershipCheck, "disable-namespace-ownership-check", isTrue(env("ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK", "")), "Disables the namespace ownership checks for a route host with different paths or for overlapping host names in the case of wildcard routes. Please be aware that if namespace ownership checks are disabled, routes in a different namespace can use this mechanism to 'steal' sub-paths for existing domains. This is only safe if route creation privileges are restricted, or if all the users can be trusted.")
 	flag.BoolVar(&o.ExtendedValidation, "extended-validation", isTrue(env("EXTENDED_VALIDATION", "true")), "If set, then an additional extended validation step is performed on all routes processed by this router. Defaults to true and enables the extended validation checks.")
 	flag.BoolVar(&o.UpgradeValidation, "upgrade-validation", isTrue(env("UPGRADE_VALIDATION", "true")), "If set, then an additional upgrade validation step is performed on all routes processed by this router. Defaults to true and enables the upgrade validation checks.")
+	flag.BoolVar(&o.UpgradeValidationForceAddCondition, "debug-upgrade-validation-force-add-condition", isTrue(env("DEBUG_UPGRADE_VALIDATION_FORCE_ADD_CONDITION", "")), "If set, then the upgrade validation plugin will forcibly add the UnservableInFutureVersions condition. For testing purposes only.")
+	flag.BoolVar(&o.UpgradeValidationForceRemoveCondition, "debug-upgrade-validation-force-remove-condition", isTrue(env("DEBUG_UPGRADE_VALIDATION_FORCE_REMOVE_CONDITION", "")), "If set, then the upgrade validation plugin will forcibly remove the UnservableInFutureVersions condition. For testing purposes only.")
 	flag.Bool("enable-ingress", false, "Enable configuration via ingress resources.")
 	flag.MarkDeprecated("enable-ingress", "Ingress resources are now synchronized to routes automatically.")
 	flag.StringVar(&o.ListenAddr, "listen-addr", env("ROUTER_LISTEN_ADDR", ""), "The name of an interface to listen on to expose metrics and health checking. If not specified, will not listen. Overrides stats port.")

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -799,7 +799,7 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 		plugin = status
 	}
 	if o.UpgradeValidation {
-		plugin = controller.NewUpgradeValidation(plugin, recorder)
+		plugin = controller.NewUpgradeValidation(plugin, recorder, o.UpgradeValidationForceAddCondition, o.UpgradeValidationForceRemoveCondition)
 	}
 	if o.ExtendedValidation {
 		plugin = controller.NewExtendedValidator(plugin, recorder)

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -785,7 +785,7 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 	factory.RouteModifierFn = o.RouteUpdate
 
 	var plugin router.Plugin = templatePlugin
-	var recorder controller.RejectionRecorder = controller.LogRejections
+	var recorder controller.RouteStatusRecorder = controller.LogRejections
 	if o.UpdateStatus {
 		lease := writerlease.New(time.Minute, 3*time.Second)
 		go lease.Run(stopCh)
@@ -797,6 +797,9 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 		status := controller.NewStatusAdmitter(plugin, routeclient.RouteV1(), routeLister, o.RouterName, o.RouterCanonicalHostname, lease, tracker)
 		recorder = status
 		plugin = status
+	}
+	if o.UpgradeValidation {
+		plugin = controller.NewUpgradeValidation(plugin, recorder)
 	}
 	if o.ExtendedValidation {
 		plugin = controller.NewExtendedValidator(plugin, recorder)

--- a/pkg/router/controller/contention.go
+++ b/pkg/router/controller/contention.go
@@ -7,9 +7,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-
 	routev1 "github.com/openshift/api/route/v1"
 )
 
@@ -258,15 +255,36 @@ func ingressEqual(a, b *routev1.RouteIngress) bool {
 }
 
 // ingressConditionsEqual determines if the route ingress conditions are equal,
-// while ignoring LastTransitionTime
+// while ignoring LastTransitionTime.
 func ingressConditionsEqual(a, b []routev1.RouteIngressCondition) bool {
-	conditionCmpOpts := []cmp.Option{
-		cmpopts.EquateEmpty(),
-		cmpopts.IgnoreFields(routev1.RouteIngressCondition{}, "LastTransitionTime"),
-		cmpopts.SortSlices(func(a, b routev1.RouteIngressCondition) bool { return a.Type < b.Type }),
+	if len(a) != len(b) {
+		return false
 	}
 
-	return cmp.Equal(a, b, conditionCmpOpts...)
+	// Compare each condition in a with every condition in b.
+	// Given the current max of only two conditions, nested loops are more efficient than sorting.
+	for i := 0; i < len(a); i++ {
+		matchFound := false
+		for j := 0; j < len(b); j++ {
+			if conditionsEqual(&a[i], &b[j]) {
+				matchFound = true
+				break
+			}
+		}
+		if !matchFound {
+			return false
+		}
+	}
+
+	return true
+}
+
+// conditionsEqual compares two RouteIngressConditions, ignoring LastTransitionTime.
+func conditionsEqual(a, b *routev1.RouteIngressCondition) bool {
+	return a.Type == b.Type &&
+		a.Status == b.Status &&
+		a.Reason == b.Reason &&
+		a.Message == b.Message
 }
 
 func ingressConditionTouched(ingress *routev1.RouteIngress) *metav1.Time {

--- a/pkg/router/controller/extended_validator.go
+++ b/pkg/router/controller/extended_validator.go
@@ -19,14 +19,14 @@ type ExtendedValidator struct {
 	// plugin is the next plugin in the chain.
 	plugin router.Plugin
 
-	// recorder is an interface for indicating route rejections.
-	recorder RejectionRecorder
+	// recorder is an interface for indicating route status.
+	recorder RouteStatusRecorder
 }
 
 // NewExtendedValidator creates a plugin wrapper that ensures only routes that
 // pass extended validation are relayed to the next plugin in the chain.
-// Recorder is an interface for indicating why a route was rejected.
-func NewExtendedValidator(plugin router.Plugin, recorder RejectionRecorder) *ExtendedValidator {
+// Recorder is an interface for indicating route status updates.
+func NewExtendedValidator(plugin router.Plugin, recorder RouteStatusRecorder) *ExtendedValidator {
 	return &ExtendedValidator{
 		plugin:   plugin,
 		recorder: recorder,

--- a/pkg/router/controller/extended_validator.go
+++ b/pkg/router/controller/extended_validator.go
@@ -45,6 +45,7 @@ func (p *ExtendedValidator) HandleEndpoints(eventType watch.EventType, endpoints
 
 // HandleRoute processes watch events on the Route resource.
 func (p *ExtendedValidator) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: ExtendedValidator")
 	// Check if previously seen route and its Spec is unchanged.
 	routeName := routeNameKey(route)
 	if err := routeapihelpers.ExtendedValidateRoute(route).ToAggregate(); err != nil {

--- a/pkg/router/controller/host_admitter.go
+++ b/pkg/router/controller/host_admitter.go
@@ -126,6 +126,7 @@ func (p *HostAdmitter) HandleEndpoints(eventType watch.EventType, endpoints *kap
 
 // HandleRoute processes watch events on the Route resource.
 func (p *HostAdmitter) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: HostAdmitter")
 	if p.allowedNamespaces != nil && !p.allowedNamespaces.Has(route.Namespace) {
 		// Ignore routes we don't need to "service" due to namespace
 		// restrictions (ala for sharding).

--- a/pkg/router/controller/host_admitter.go
+++ b/pkg/router/controller/host_admitter.go
@@ -78,7 +78,7 @@ type HostAdmitter struct {
 	admitter RouteAdmissionFunc
 
 	// recorder is an interface for indicating route rejections.
-	recorder RejectionRecorder
+	recorder RouteStatusRecorder
 
 	// allowWildcardRoutes enables wildcard route support.
 	allowWildcardRoutes bool
@@ -98,8 +98,8 @@ type HostAdmitter struct {
 
 // NewHostAdmitter creates a plugin wrapper that checks whether or not to
 // admit routes and relay them to the next plugin in the chain.
-// Recorder is an interface for indicating why a route was rejected.
-func NewHostAdmitter(plugin router.Plugin, fn RouteAdmissionFunc, allowWildcards, disableNamespaceCheck bool, recorder RejectionRecorder) *HostAdmitter {
+// Recorder is an interface for indicating route status updates..
+func NewHostAdmitter(plugin router.Plugin, fn RouteAdmissionFunc, allowWildcards, disableNamespaceCheck bool, recorder RouteStatusRecorder) *HostAdmitter {
 	return &HostAdmitter{
 		plugin:   plugin,
 		admitter: fn,

--- a/pkg/router/controller/host_admitter_test.go
+++ b/pkg/router/controller/host_admitter_test.go
@@ -22,19 +22,28 @@ const (
 	BlockedTestDomain = "domain.blocked.test"
 )
 
-type rejectionRecorder struct {
-	rejections map[string]string
+type routeStatusRecorder struct {
+	rejections                 map[string]string
+	unservableInFutureVersions map[string]string
 }
 
-func (_ rejectionRecorder) rejectionKey(route *routev1.Route) string {
+func (_ routeStatusRecorder) rejectionKey(route *routev1.Route) string {
 	return route.Namespace + "-" + route.Name
 }
 
-func (r rejectionRecorder) RecordRouteRejection(route *routev1.Route, reason, message string) {
+func (r routeStatusRecorder) RecordRouteRejection(route *routev1.Route, reason, message string) {
 	r.rejections[r.rejectionKey(route)] = reason
 }
 
-func (r rejectionRecorder) Clear() {
+func (r routeStatusRecorder) RecordRouteUnservableInFutureVersionsClear(route *routev1.Route) {
+	delete(r.unservableInFutureVersions, r.rejectionKey(route))
+}
+
+func (r routeStatusRecorder) RecordRouteUnservableInFutureVersions(route *routev1.Route, reason, message string) {
+	r.unservableInFutureVersions[r.rejectionKey(route)] = reason
+}
+
+func (r routeStatusRecorder) Clear() {
 	r.rejections = make(map[string]string)
 }
 
@@ -248,7 +257,7 @@ func TestWildcardHostDeny(t *testing.T) {
 func TestWildcardSubDomainOwnership(t *testing.T) {
 	p := &fakePlugin{}
 
-	recorder := rejectionRecorder{rejections: make(map[string]string)}
+	recorder := routeStatusRecorder{rejections: make(map[string]string)}
 	admitter := NewHostAdmitter(p, wildcardAdmitter, true, false, recorder)
 
 	oldest := metav1.Time{Time: time.Now()}
@@ -505,7 +514,7 @@ func TestValidRouteAdmissionFuzzing(t *testing.T) {
 	p := &fakePlugin{}
 
 	admitAll := func(route *routev1.Route) error { return nil }
-	recorder := rejectionRecorder{rejections: make(map[string]string)}
+	recorder := routeStatusRecorder{rejections: make(map[string]string)}
 	admitter := NewHostAdmitter(p, RouteAdmissionFunc(admitAll), true, false, recorder)
 
 	oldest := metav1.Time{Time: time.Now()}
@@ -602,7 +611,7 @@ func TestInvalidRouteAdmissionFuzzing(t *testing.T) {
 	p := &fakePlugin{}
 
 	admitAll := func(route *routev1.Route) error { return nil }
-	recorder := rejectionRecorder{rejections: make(map[string]string)}
+	recorder := routeStatusRecorder{rejections: make(map[string]string)}
 	admitter := NewHostAdmitter(p, RouteAdmissionFunc(admitAll), true, false, recorder)
 
 	oldest := metav1.Time{Time: time.Now()}
@@ -787,7 +796,7 @@ func TestStatusWildcardPolicyNoOp(t *testing.T) {
 	touched := metav1.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
 	c := fake.NewSimpleClientset()
-	recorder := rejectionRecorder{rejections: make(map[string]string)}
+	recorder := routeStatusRecorder{rejections: make(map[string]string)}
 	admitter := NewHostAdmitter(p, wildcardAdmitter, true, false, recorder)
 	err := admitter.HandleRoute(watch.Added, &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "wild", Namespace: "thing", UID: types.UID("uid8")},
@@ -825,7 +834,7 @@ func TestStatusWildcardPolicyNotAllowedNoOp(t *testing.T) {
 	touched := metav1.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
 	c := fake.NewSimpleClientset()
-	recorder := rejectionRecorder{rejections: make(map[string]string)}
+	recorder := routeStatusRecorder{rejections: make(map[string]string)}
 	admitter := NewHostAdmitter(p, wildcardAdmitter, false, false, recorder)
 	err := admitter.HandleRoute(watch.Added, &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "wild", Namespace: "thing", UID: types.UID("uid8")},
@@ -862,7 +871,7 @@ func TestDisableOwnershipChecksFuzzing(t *testing.T) {
 	p := &fakePlugin{}
 
 	admitAll := func(route *routev1.Route) error { return nil }
-	recorder := rejectionRecorder{rejections: make(map[string]string)}
+	recorder := routeStatusRecorder{rejections: make(map[string]string)}
 	uniqueHostPlugin := NewUniqueHost(p, true, recorder)
 	admitter := NewHostAdmitter(uniqueHostPlugin, RouteAdmissionFunc(admitAll), true, true, recorder)
 
@@ -1026,7 +1035,7 @@ func TestDisableOwnershipChecksFuzzing(t *testing.T) {
 
 func TestHandleNamespaceProcessing(t *testing.T) {
 	p := &fakePlugin{}
-	recorder := rejectionRecorder{rejections: make(map[string]string)}
+	recorder := routeStatusRecorder{rejections: make(map[string]string)}
 	admitter := NewHostAdmitter(p, wildcardAdmitter, true, false, recorder)
 
 	// Set namespaces handled in the host admitter plugin, the fakePlugin in
@@ -1148,7 +1157,7 @@ func TestHandleNamespaceProcessing(t *testing.T) {
 func TestWildcardPathRoutesWithoutNSCheckResyncs(t *testing.T) {
 	p := &fakePlugin{}
 
-	recorder := rejectionRecorder{rejections: make(map[string]string)}
+	recorder := routeStatusRecorder{rejections: make(map[string]string)}
 	admitter := NewHostAdmitter(p, wildcardAdmitter, true, true, recorder)
 
 	oldest := metav1.Time{Time: time.Now()}

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -233,6 +233,8 @@ func performIngressConditionRemoval(action string, lease writerlease.Lease, trac
 // attempts to update the route status and, depending on the outcome, clears the tracker if necessary. It returns the
 // writerlease's WorkResult and a boolean flag indicating whether the writerlease should retry.
 func handleRouteStatusUpdate(ctx context.Context, action string, oc client.RoutesGetter, route *routev1.Route, latest *routev1.RouteIngress, tracker ContentionTracker) (workResult writerlease.WorkResult, retry bool) {
+	log.V(4).Info("attempting to update route status")
+
 	switch _, err := oc.Routes(route.Namespace).UpdateStatus(ctx, route, metav1.UpdateOptions{}); {
 	case err == nil:
 		log.V(4).Info("updated route status", "action", action, "namespace", route.Namespace, "name", route.Name)

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -93,6 +93,7 @@ var nowFn = getRfc3339Timestamp
 
 // HandleRoute attempts to admit the provided route on watch add / modifications.
 func (a *StatusAdmitter) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: StatusAdmitter")
 	switch eventType {
 	case watch.Added, watch.Modified:
 		performIngressConditionUpdate("admit", a.lease, a.tracker, a.client, a.lister, route, a.routerName, a.routerCanonicalHostname, routev1.RouteIngressCondition{

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -168,8 +168,9 @@ func performIngressConditionUpdate(action string, lease writerlease.Lease, track
 }
 
 // recordIngressCondition updates the matching ingress on the route (or adds a new one) with the specified
-// condition, returning whether the route was updated or created, the time assigned to the condition, and
-// a pointer to the current ingress record.
+// condition. It returns whether the ingress record was updated or created, the time assigned to the
+// condition, a pointer to the latest ingress record, and a pointer to a shallow copy of the original ingress
+// record.
 func recordIngressCondition(route *routev1.Route, name, hostName string, condition routev1.RouteIngressCondition) (changed, created bool, at time.Time, latest, original *routev1.RouteIngress) {
 	for i := range route.Status.Ingress {
 		existing := &route.Status.Ingress[i]
@@ -188,6 +189,9 @@ func recordIngressCondition(route *routev1.Route, name, hostName string, conditi
 			if *existingCondition != condition {
 				changed = true
 			}
+		} else {
+			// If the condition we want doesn't exist, then consider it changed.
+			changed = true
 		}
 		if !changed {
 			return false, false, time.Time{}, existing, existing

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -197,14 +197,15 @@ func recordIngressCondition(route *routev1.Route, name, hostName string, conditi
 			return false, false, time.Time{}, existing, existing
 		}
 
-		// preserve a copy of the original ingress without conditions
+		// preserve a shallow copy of the original ingress
 		original := *existing
-		original.Conditions = nil
 
 		// generate the correct ingress
 		existing.Host = route.Spec.Host
 		existing.WildcardPolicy = route.Spec.WildcardPolicy
 		existing.RouterCanonicalHostname = hostName
+
+		// Add or update the condition
 		if existingCondition == nil {
 			existing.Conditions = append(existing.Conditions, condition)
 			existingCondition = &existing.Conditions[len(existing.Conditions)-1]

--- a/pkg/router/controller/status_test.go
+++ b/pkg/router/controller/status_test.go
@@ -1298,6 +1298,55 @@ func TestStatusUnservableInFutureVersions(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                       "update incorrect unservableInFutureVersions condition",
+			routerName:                 "test",
+			unservableInFutureVersions: true,
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
+				Spec:       routev1.RouteSpec{Host: "route1.test.local"},
+				Status: routev1.RouteStatus{Ingress: []routev1.RouteIngress{{
+					Host:       "route1.test.local",
+					RouterName: "test",
+					Conditions: []routev1.RouteIngressCondition{{
+						Type:    routev1.RouteUnservableInFutureVersions,
+						Status:  corev1.ConditionTrue,
+						Reason:  "wrong reason",
+						Message: "wrong message",
+					}},
+				}},
+				},
+			},
+			expectedRoute: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
+				Spec:       routev1.RouteSpec{Host: "route1.test.local"},
+				Status: routev1.RouteStatus{Ingress: []routev1.RouteIngress{{
+					Host:       "route1.test.local",
+					RouterName: "test",
+					Conditions: []routev1.RouteIngressCondition{
+						unservableInFutureVersionsTrueCondition,
+					},
+				}},
+				},
+			},
+		},
+		{
+			name:                       "no update for incorrect host name with unservableInFutureVersions condition",
+			routerName:                 "test",
+			unservableInFutureVersions: true,
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
+				Spec:       routev1.RouteSpec{Host: "route1.test.local"},
+				Status: routev1.RouteStatus{Ingress: []routev1.RouteIngress{{
+					Host:       "foo.test.local",
+					RouterName: "test",
+					Conditions: []routev1.RouteIngressCondition{
+						unservableInFutureVersionsTrueCondition,
+					},
+				}},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/router/controller/status_test.go
+++ b/pkg/router/controller/status_test.go
@@ -1081,7 +1081,9 @@ func Test_recordIngressCondition(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			changed, created, _, latest, _ := recordIngressCondition(tc.route, tc.routerName, tc.routerCanonicalHostname, tc.condition)
+			baselineIngressState := findIngressForRoute(tc.route, tc.routerName).DeepCopy()
+
+			changed, created, _, latest, original := recordIngressCondition(tc.route, tc.routerName, tc.routerCanonicalHostname, tc.condition)
 
 			// Compare expected route, but ignore LastTransitionTime since that is generated
 			cmpOpts := []cmp.Option{
@@ -1099,6 +1101,9 @@ func Test_recordIngressCondition(t *testing.T) {
 			}
 			if tc.expectChanged != changed {
 				t.Errorf("expected changed=%t, but got changed=%t", tc.expectChanged, changed)
+			}
+			if diff := cmp.Diff(baselineIngressState, original, cmpOpts...); len(diff) > 0 {
+				t.Errorf("expected original to match baseline ingress from route.Status (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -32,7 +32,7 @@ func HostForRoute(route *routev1.Route) string {
 type UniqueHost struct {
 	plugin router.Plugin
 
-	recorder RejectionRecorder
+	recorder RouteStatusRecorder
 
 	// nil means different than empty
 	allowedNamespaces sets.String
@@ -45,7 +45,7 @@ type UniqueHost struct {
 // NewUniqueHost creates a plugin wrapper that ensures only unique routes are passed into
 // the underlying plugin. Recorder is an interface for indicating why a route was
 // rejected.
-func NewUniqueHost(plugin router.Plugin, disableOwnershipCheck bool, recorder RejectionRecorder) *UniqueHost {
+func NewUniqueHost(plugin router.Plugin, disableOwnershipCheck bool, recorder RouteStatusRecorder) *UniqueHost {
 	routeActivationFn := hostindex.SameNamespace
 	if disableOwnershipCheck {
 		routeActivationFn = hostindex.OldestFirst

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -88,6 +88,7 @@ func (p *UniqueHost) HandleNode(eventType watch.EventType, node *kapi.Node) erro
 // determines which component needs to be recalculated (which template) and then does so
 // on demand.
 func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: UniqueHost")
 	if p.allowedNamespaces != nil && !p.allowedNamespaces.Has(route.Namespace) {
 		return nil
 	}

--- a/pkg/router/controller/upgrade_validation.go
+++ b/pkg/router/controller/upgrade_validation.go
@@ -53,6 +53,7 @@ func (p *UpgradeValidation) HandleEndpoints(eventType watch.EventType, endpoints
 // It checks if the route is upgradeable to a future version of OpenShift
 // and sets UnservableInFutureVersions condition if needed.
 func (p *UpgradeValidation) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: UpgradeValidation")
 	routeName := routeNameKey(route)
 
 	// Force add and force removal logic for debugging and testing.

--- a/pkg/router/controller/upgrade_validation.go
+++ b/pkg/router/controller/upgrade_validation.go
@@ -1,0 +1,67 @@
+package controller
+
+import (
+	kapi "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/openshift/router/pkg/router"
+	"github.com/openshift/router/pkg/router/routeapihelpers"
+)
+
+// UpgradeValidation implements the router.Plugin interface to provide
+// upgrade route validation.
+type UpgradeValidation struct {
+	// plugin is the next plugin in the chain.
+	plugin router.Plugin
+
+	// recorder is an interface for indicating route status.
+	recorder RouteStatusRecorder
+}
+
+// NewUpgradeValidation creates a plugin wrapper that validates for upgrades
+// and adds an UnservableInFutureVersions status if needed. It does not stop
+// the plugin chain if the route is unservable in future versions.
+// Recorder is an interface for indicating routes status update.
+func NewUpgradeValidation(plugin router.Plugin, recorder RouteStatusRecorder) *UpgradeValidation {
+	return &UpgradeValidation{
+		plugin:   plugin,
+		recorder: recorder,
+	}
+}
+
+// HandleNode processes watch events on the node resource
+func (p *UpgradeValidation) HandleNode(eventType watch.EventType, node *kapi.Node) error {
+	return p.plugin.HandleNode(eventType, node)
+}
+
+// HandleEndpoints processes watch events on the Endpoints resource.
+func (p *UpgradeValidation) HandleEndpoints(eventType watch.EventType, endpoints *kapi.Endpoints) error {
+	return p.plugin.HandleEndpoints(eventType, endpoints)
+}
+
+// HandleRoute processes watch events on the Route resource.
+// It checks if the route is upgradeable to a future version of OpenShift
+// and sets UnservableInFutureVersions condition if needed.
+func (p *UpgradeValidation) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	routeName := routeNameKey(route)
+	if err := routeapihelpers.UpgradeRouteValidation(route).ToAggregate(); err != nil {
+		log.Error(err, "route failed upgrade validation", "route", routeName)
+		p.recorder.RecordRouteUnservableInFutureVersions(route, "UpgradeRouteValidationFailed", err.Error())
+	} else {
+		p.recorder.RecordRouteUnservableInFutureVersionsClear(route)
+	}
+
+	return p.plugin.HandleRoute(eventType, route)
+}
+
+// HandleNamespaces processes watch events on namespaces.
+func (p *UpgradeValidation) HandleNamespaces(namespaces sets.String) error {
+	return p.plugin.HandleNamespaces(namespaces)
+}
+
+func (p *UpgradeValidation) Commit() error {
+	return p.plugin.Commit()
+}

--- a/pkg/router/routeapihelpers/validation.go
+++ b/pkg/router/routeapihelpers/validation.go
@@ -375,3 +375,41 @@ func validateCertificatePEM(certPEM string, options *x509.VerifyOptions) ([]*x50
 
 	return certs, nil
 }
+
+// UpgradeRouteValidation performs an upgrade validation for
+// a route. This checks for issues that will cause failures in the next
+// OpenShift version.
+func UpgradeRouteValidation(route *routev1.Route) field.ErrorList {
+	tlsConfig := route.Spec.TLS
+	result := field.ErrorList{}
+
+	if tlsConfig == nil {
+		return result
+	}
+
+	// Verify the route for incompatible SHA1 certificates within Spec.TLS.Certificate
+	// as it will prevent HaProxy from starting.
+	// There's no need to verify SHA1 certificates within Spec.TLS.CACertificate
+	// as they will be rejected by the ExtendedValidator plugin.
+	// Similarly, verifying SHA1 certificates within Spec.TLS.DestinationCACertificate
+	// is unnecessary as it will NOT prevent HaProxy from starting.
+	if len(tlsConfig.Certificate) > 0 {
+		certs, err := cert.ParseCertsPEM([]byte(tlsConfig.Certificate))
+		if err != nil {
+			// Handling cert parsing errors, like malformed or invalid certs, isn't necessary here,
+			// as the ExtendedValidator plugin is responsible for handling these errors.
+			return result
+		}
+
+		if len(certs) < 1 {
+			return result
+		}
+
+		if certs[0].SignatureAlgorithm == x509.SHA1WithRSA || certs[0].SignatureAlgorithm == x509.ECDSAWithSHA1 {
+			tlsCertFieldPath := field.NewPath("spec").Child("tls").Child("certificate")
+			message := "OpenShift 4.16 does not support certificates using SHA1 signature algorithms. This route will be rejected in OpenShift 4.16. To maintain functionality in OpenShift 4.16, generate a new certificate using a supported signature algorithm such as SHA256, SHA384, or SHA512, and update this route accordingly."
+			result = append(result, field.Invalid(tlsCertFieldPath, "redacted certificate data", message))
+		}
+	}
+	return result
+}

--- a/pkg/router/routeapihelpers/validation_test.go
+++ b/pkg/router/routeapihelpers/validation_test.go
@@ -10,27 +10,32 @@ import (
 )
 
 const (
-	testExpiredCAUnknownCertificate = `-----BEGIN CERTIFICATE-----
-MIIDIjCCAgqgAwIBAgIBBjANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx
-CzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl
-ZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3
-dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu
-Y29tMB4XDTE2MDExMzE5NDA1N1oXDTI2MDExMDE5NDA1N1owfDEYMBYGA1UEAxMP
-d3d3LmV4YW1wbGUuY29tMQswCQYDVQQIEwJTQzELMAkGA1UEBhMCVVMxIjAgBgkq
-hkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoTB0V4YW1wbGUx
-EDAOBgNVBAsTB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAM0B
-u++oHV1wcphWRbMLUft8fD7nPG95xs7UeLPphFZuShIhhdAQMpvcsFeg+Bg9PWCu
-v3jZljmk06MLvuWLfwjYfo9q/V+qOZVfTVHHbaIO5RTXJMC2Nn+ACF0kHBmNcbth
-OOgF8L854a/P8tjm1iPR++vHnkex0NH7lyosVc/vAgMBAAGjDTALMAkGA1UdEwQC
-MAAwDQYJKoZIhvcNAQEFBQADggEBADjFm5AlNH3DNT1Uzx3m66fFjqqrHEs25geT
-yA3rvBuynflEHQO95M/8wCxYVyuAx4Z1i4YDC7tx0vmOn/2GXZHY9MAj1I8KCnwt
-Jik7E2r1/yY0MrkawljOAxisXs821kJ+Z/51Ud2t5uhGxS6hJypbGspMS7OtBbw7
-8oThK7cWtCXOldNF6ruqY1agWnhRdAq5qSMnuBXuicOP0Kbtx51a1ugE3SnvQenJ
-nZxdtYUXvEsHZC/6bAtTfNh+/SwgxQJuL2ZM+VG3X2JIKY8xTDui+il7uTh422lq
-wED8uwKl+bOj6xFDyw4gWoBxRobsbFaME8pkykP1+GnKDberyAM=
+	// openssl req -x509 -sha256 -newkey rsa:1024 -days 3650 -keyout exampleca.key -out exampleca.crt -addext "keyUsage=cRLSign, digitalSignature, keyCertSign" -addext "extendedKeyUsage=serverAuth, clientAuth" -nodes -subj '/C=US/ST=SC/L=Default City/O=Default Company Ltd/OU=Test CA/CN=www.exampleca.com/emailAddress=example@example.com'
+	// openssl req -newkey rsa:1024 -nodes -keyout testUnrelatedCACertificate.key -out testUnrelatedCACertificate.csr -subj '/CN=www.example.com/ST=SC/C=US/emailAddress=example@example.com/O=Example/OU=Example'
+	// openssl x509 -req -days 3650 -sha256 -in testUnrelatedCACertificate.csr -CA exampleca.crt -CAcreateserial -CAkey exampleca.key -extensions ext -extfile <(echo $'[ext]\nbasicConstraints = CA:FALSE') -out testUnrelatedCACertificate.crt
+	//
+	// Key = testUnrelatedCACertificateKey
+	// CA = Unknown
+	testUnrelatedCACertificate = `-----BEGIN CERTIFICATE-----
+MIIC9DCCAl2gAwIBAgIUTWv/Z/7lOkdCELulnNZOP4azjG4wDQYJKoZIhvcNAQEL
+BQAwgaExCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJTQzEVMBMGA1UEBwwMRGVmYXVs
+dCBDaXR5MRwwGgYDVQQKDBNEZWZhdWx0IENvbXBhbnkgTHRkMRAwDgYDVQQLDAdU
+ZXN0IENBMRowGAYDVQQDDBF3d3cuZXhhbXBsZWNhLmNvbTEiMCAGCSqGSIb3DQEJ
+ARYTZXhhbXBsZUBleGFtcGxlLmNvbTAeFw0yNDAxMTAxOTAwMDRaFw0zNDAxMDcx
+OTAwMDRaMHwxGDAWBgNVBAMMD3d3dy5leGFtcGxlLmNvbTELMAkGA1UECAwCU0Mx
+CzAJBgNVBAYTAlVTMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUuY29t
+MRAwDgYDVQQKDAdFeGFtcGxlMRAwDgYDVQQLDAdFeGFtcGxlMIGfMA0GCSqGSIb3
+DQEBAQUAA4GNADCBiQKBgQDNAbvvqB1dcHKYVkWzC1H7fHw+5zxvecbO1Hiz6YRW
+bkoSIYXQEDKb3LBXoPgYPT1grr942ZY5pNOjC77li38I2H6Pav1fqjmVX01Rx22i
+DuUU1yTAtjZ/gAhdJBwZjXG7YTjoBfC/OeGvz/LY5tYj0fvrx55HsdDR+5cqLFXP
+7wIDAQABo00wSzAJBgNVHRMEAjAAMB0GA1UdDgQWBBSYTeaq+a2V/7QWJh/gH2tE
+GXln7jAfBgNVHSMEGDAWgBRQlTo+l7rGlVRX5myTzXIHBN587jANBgkqhkiG9w0B
+AQsFAAOBgQCvvO7Gp9zfrKa5LRrfPQuz82Q47UDSeZTmn1Hi6RJxpbgmSggsXV5W
+ibm7ToWdUrcOsmj0gwZO08jP5G5gy52kShogSy8Je7Qj7Jf4OOdG2pCMe1BEYdyS
+8W1kEoEBL8JhHt1ftjW2U3rPhxbtOLZ0gnzLf30T9GfgAB1nwadcwA==
 -----END CERTIFICATE-----`
 
-	testExpiredCertPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+	testUnrelatedCACertificateKey = `-----BEGIN RSA PRIVATE KEY-----
 MIICWwIBAAKBgQDNAbvvqB1dcHKYVkWzC1H7fHw+5zxvecbO1Hiz6YRWbkoSIYXQ
 EDKb3LBXoPgYPT1grr942ZY5pNOjC77li38I2H6Pav1fqjmVX01Rx22iDuUU1yTA
 tjZ/gAhdJBwZjXG7YTjoBfC/OeGvz/LY5tYj0fvrx55HsdDR+5cqLFXP7wIDAQAB
@@ -46,6 +51,8 @@ pgfj+yGLmkUw8JwgGH6xCUbHO+WBUFSlPf+Y50fJeO+OrjqPXAVKeSV3ZCwWjKT4
 u3YLAbyW/lHhOCiZu2iAI8AbmXem9lW6Tr7p/97s0w==
 -----END RSA PRIVATE KEY-----`
 
+	// Key = testPrivateKey
+	// CA = testCACertificate
 	testCertificate = `-----BEGIN CERTIFICATE-----
 MIICwjCCAiugAwIBAgIBATANBgkqhkiG9w0BAQsFADBjMQswCQYDVQQGEwJVUzEL
 MAkGA1UECAwCQ0ExETAPBgNVBAoMCFNlY3VyaXR5MRswGQYDVQQLDBJPcGVuU2hp
@@ -92,6 +99,8 @@ HP8gHJSZnaGrLKmjwNeQNsARYajKmDKO5HJ9g5H5Hae8enOb2yie541dneDT8rID
 4054dMQJnijd8620yf8wiNy05ZPOQQ0JvA/rW3WWZc5PGm8c2PsVjg==
 -----END RSA PRIVATE KEY-----`
 
+	// Key = Unknown
+	// CA = self-signed
 	testCACertificate = `-----BEGIN CERTIFICATE-----
 MIIClDCCAf2gAwIBAgIJAPU57OGhuqJtMA0GCSqGSIb3DQEBCwUAMGMxCzAJBgNV
 BAYTAlVTMQswCQYDVQQIDAJDQTERMA8GA1UECgwIU2VjdXJpdHkxGzAZBgNVBAsM
@@ -111,6 +120,8 @@ bGvtpjWA4r9WASIDPFsxk/cDEEEO6iPxgMOf5MdpQC2y2MU0rzF/Gg==
 
 	testDestinationCACertificate = testCACertificate
 
+	// Key = testValidInFutureKey
+	// CA = self-signed
 	testValidInFutureCert = `-----BEGIN CERTIFICATE-----
 MIIDjzCCAnegAwIBAgIJAJcdKWMFNUEGMA0GCSqGSIb3DQEBCwUAMF0xCzAJBgNV
 BAYTAlVTMQswCQYDVQQIDAJDQTERMA8GA1UECgwIU2VjdXJpdHkxEzARBgNVBAsM
@@ -134,6 +145,8 @@ fKSS26HocZpiN0e7vO0XoJfh4VkOIn7BGNwxiDr9cIRL4ZHhZ0/kRQuXCHHYbTdq
 9mKv
 -----END CERTIFICATE-----`
 
+	// Key = testValidInFutureKey / testValidInFutureKeyWithWhitespace
+	// CA = self-signed
 	testValidInFutureCertWithWhitespace = `
 	
 	
@@ -227,6 +240,8 @@ DOGy/dMN+k0W2RgJ5JKR3g==
 
 `
 
+	// Key = testSelfSignedKey
+	// CA = self-signed
 	testSelfSignedCert = `-----BEGIN CERTIFICATE-----
 MIIDjTCCAnWgAwIBAgIJAKM4rr3VRQARMA0GCSqGSIb3DQEBCwUAMF0xCzAJBgNV
 BAYTAlVTMQswCQYDVQQIDAJDQTERMA8GA1UECgwIU2VjdXJpdHkxEzARBgNVBAsM
@@ -279,26 +294,100 @@ H6e+rtFlOu/BZSBUUgcOJ4xSDUilztVSMGHK7AxhBGlBHzPRwY8bjQfMaODs9pD8
 qOFcy/8ogwZdP9nTV73O2wG56g==
 -----END PRIVATE KEY-----`
 
-	testExpiredCertNoKey = `-----BEGIN CERTIFICATE-----
-MIIDIjCCAgqgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx
-CzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl
-ZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3
-dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu
-Y29tMB4XDTE1MDExMjE0MTk0MVoXDTE2MDExMjE0MTk0MVowfDEYMBYGA1UEAwwP
-d3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkGA1UEBhMCVVMxIjAgBgkq
-hkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoMB0V4YW1wbGUx
-EDAOBgNVBAsMB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMrv
-gu6ZTTefNN7jjiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm
-47VRx5Qrf/YLXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1M
-mNrQUgZyQC6XIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAGjDTALMAkGA1UdEwQC
-MAAwDQYJKoZIhvcNAQEFBQADggEBAFCi7ZlkMnESvzlZCvv82Pq6S46AAOTPXdFd
-TMvrh12E1sdVALF1P1oYFJzG1EiZ5ezOx88fEDTW+Lxb9anw5/KJzwtWcfsupf1m
-V7J0D3qKzw5C1wjzYHh9/Pz7B1D0KthQRATQCfNf8s6bbFLaw/dmiIUhHLtIH5Qc
-yfrejTZbOSP77z8NOWir+BWWgIDDB2//3AkDIQvT20vmkZRhkqSdT7et4NmXOX/j
-jhPti4b2Fie0LeuvgaOdKjCpQQNrYthZHXeVlOLRhMTSk3qUczenkKTOhvP7IS9q
-+Dzv5hqgSfvMG392KWh5f8xXfJNs4W5KLbZyl901MeReiLrPH3w=
+	// openssl req -newkey rsa:1024 -nodes -keyout testExpiredCert.key -out testExpiredCert.csr -subj '/CN=www.example.com/ST=SC/C=US/emailAddress=example@example.com/O=Example/OU=Example'
+	// faketime 'last year 5pm' /bin/bash -c 'openssl x509 -req -days 1 -sha256 -in testExpiredCert.csr -CA testExpiredCertCA.crt -CAcreateserial -CAkey testExpiredCertCA.key -extensions ext -extfile <(echo $"[ext]\nbasicConstraints = CA:FALSE") -out testExpiredCert.crt'
+	//
+	// Key = testExpiredCertKey
+	// CA = testExpiredCertCA
+	testExpiredCert = `-----BEGIN CERTIFICATE-----
+MIICoDCCAgkCFAaeel1AtQzHHpRUjVZSaSEbuzcvMA0GCSqGSIb3DQEBCwUAMIGh
+MQswCQYDVQQGEwJVUzELMAkGA1UECAwCU0MxFTATBgNVBAcMDERlZmF1bHQgQ2l0
+eTEcMBoGA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UECwwHVGVzdCBD
+QTEaMBgGA1UEAwwRd3d3LmV4YW1wbGVjYS5jb20xIjAgBgkqhkiG9w0BCQEWE2V4
+YW1wbGVAZXhhbXBsZS5jb20wHhcNMjMwMTI2MjIwMDAwWhcNMjMwMTI3MjIwMDAw
+WjB8MRgwFgYDVQQDDA93d3cuZXhhbXBsZS5jb20xCzAJBgNVBAgMAlNDMQswCQYD
+VQQGEwJVUzEiMCAGCSqGSIb3DQEJARYTZXhhbXBsZUBleGFtcGxlLmNvbTEQMA4G
+A1UECgwHRXhhbXBsZTEQMA4GA1UECwwHRXhhbXBsZTCBnzANBgkqhkiG9w0BAQEF
+AAOBjQAwgYkCgYEAv2GAaJvd0aWxiw7jBTM+VDATQ2vTPbrRc5r8+2yNTwP1Dhr1
+VlLmX5o3yv/LeHhK6g8xw1xHcDdvIAdW+J6Uu99BwDK9R5dxwVoEeTYr82vOUoFQ
+1sdXqm4226bdAJXf3kdFo+zBr2aefpygpxvMGghz6oW7Nxz78SD8yHNaAzUCAwEA
+ATANBgkqhkiG9w0BAQsFAAOBgQABr3mFRjl60RAGL8s1pB6lqBRqy5pG2WoujQlT
+N65bDpFJP7vDiFe35qYVVGLAutPxTAaAtGkNhuiyoOqfP6BIlwkM68gD5plmdRBR
+hQi35A/6YMFAsBDOnhJccOCO2i19yhyAg2R0tMSder8b51IpmLABLt3UkujwVRJ+
+a3zkug==
 -----END CERTIFICATE-----`
 
+	testExpiredCertKey = `-----BEGIN PRIVATE KEY-----
+MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAL9hgGib3dGlsYsO
+4wUzPlQwE0Nr0z260XOa/PtsjU8D9Q4a9VZS5l+aN8r/y3h4SuoPMcNcR3A3byAH
+VvielLvfQcAyvUeXccFaBHk2K/NrzlKBUNbHV6puNtum3QCV395HRaPswa9mnn6c
+oKcbzBoIc+qFuzcc+/Eg/MhzWgM1AgMBAAECgYEAqC4Ood8XNzzcoM8cQV2e0GzP
+ANiocf7SQT1aQ7hJFb7sgtC9+HYxbKIhlYrkS6Gqc7WWjY9yV/Le/M52Z1U0bb5r
+/guvTx686AYoTZzCjptwpAuVE1sS9r+WCa/VgflPZYtaql960TtO72ntjcWHoIl/
+2AsE0/1wLHLquYHaDaECQQDxdDL9ecvEWD6yTom9GlfQq/6CwzA6Nhs1oncgDT/4
+1OXGD/GgXUvlJZszdkTrYh4az8YeobDsJsfMjIkFfQpDAkEAyukOORSRIk9/KBUm
+Ufyu7JtFibtr8mozkf43Dd+2BYyO6dPqS/E9m0nUZoMSoGfS0LqS8pT1hUU0RMun
+dXURJwJBALBC5V5I5UmmKc68qqxTaLu6cwc+OhykluRmf5P0WDjsIfiedwNcWCUl
+eNDui41RiSyFdNmzq5YZEU3vYa+SAkUCQQCx99EyvVhCWKl1dX9jv5WJDvLhx9H5
+D67lqKuO7p0OpuaeLfE85H0dW5cAxouqxwU/b7T9MSta1YTvphPdUG1XAkBwH06h
+STCeJCluaFZp/Aaok8fTAbodEu5gdfo/W8dspflTFM6RcR9+WJb91elObh3QiJET
+T1ZXsR6eRuHdx4oh
+-----END PRIVATE KEY-----`
+
+	// openssl req -x509 -sha256 -newkey rsa:1024 -days 3650 -keyout testExpiredCertCA.key -out testExpiredCertCA.crt -addext "keyUsage=cRLSign, digitalSignature, keyCertSign" -addext "extendedKeyUsage=serverAuth, clientAuth" -nodes -subj '/C=US/ST=SC/L=Default City/O=Default Company Ltd/OU=Test CA/CN=www.exampleca.com/emailAddress=example@example.com'
+	//
+	// Key = Unknown
+	// CA = self-signed
+	testExpiredCertCA = `-----BEGIN CERTIFICATE-----
+MIIDTDCCArWgAwIBAgIURqF5FgSa/bgzk50k/IkGmViVVsQwDQYJKoZIhvcNAQEL
+BQAwgaExCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJTQzEVMBMGA1UEBwwMRGVmYXVs
+dCBDaXR5MRwwGgYDVQQKDBNEZWZhdWx0IENvbXBhbnkgTHRkMRAwDgYDVQQLDAdU
+ZXN0IENBMRowGAYDVQQDDBF3d3cuZXhhbXBsZWNhLmNvbTEiMCAGCSqGSIb3DQEJ
+ARYTZXhhbXBsZUBleGFtcGxlLmNvbTAeFw0yNDAxMjYxODQ5MzZaFw0zNDAxMjMx
+ODQ5MzZaMIGhMQswCQYDVQQGEwJVUzELMAkGA1UECAwCU0MxFTATBgNVBAcMDERl
+ZmF1bHQgQ2l0eTEcMBoGA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UE
+CwwHVGVzdCBDQTEaMBgGA1UEAwwRd3d3LmV4YW1wbGVjYS5jb20xIjAgBgkqhkiG
+9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0A
+MIGJAoGBAMsGGCMEIyGolBZ0waJjvbOGg9It5RsGk7T8VUR1lIOe27FZk43vusYj
+ZM7toeI0ZoVeiS3MO/UwGoB87ytri6p+hkWmyfoKGBU9QMGSN5FP+98hq42WzTqz
+91ppWC0LnE1+FhpVTtahoW1oh/02I+DcbnIICsJEhDht47c7XRCxAgMBAAGjfzB9
+MB0GA1UdDgQWBBRaPZXE3tjBGhxMx050osl+A7xaMDAfBgNVHSMEGDAWgBRaPZXE
+3tjBGhxMx050osl+A7xaMDAPBgNVHRMBAf8EBTADAQH/MAsGA1UdDwQEAwIBhjAd
+BgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADgYEA
+WhPCLIhM9+0umzLFH7xpUa9KRsmcKTHNAzdwMUaMqWupUQH+lWaH8P0rIfz6KpIb
+ZiUiFJTlS7+mH55irYMHderxNmdCh6Zk/3Nm8AXz6vDP8/cjkR6SiX0bWirRsmMS
+4xFV4AJyDenc4zyqc8QHQhwxcaW83mLmGUcBR+u7FyE=
+-----END CERTIFICATE-----`
+
+	// openssl req -x509 -sha256 -newkey rsa:1024 -days 3650 -keyout exampleca.key -out exampleca.crt -addext "keyUsage=cRLSign, digitalSignature, keyCertSign" -addext "extendedKeyUsage=serverAuth, clientAuth" -nodes -subj '/C=US/ST=SC/L=Default City/O=Default Company Ltd/OU=Test CA/CN=www.exampleca.com/emailAddress=example@example.com'
+	// openssl req -newkey rsa:1024 -nodes -keyout testExpiredCertNoKey.key -out testExpiredCertNoKey.csr -subj '/CN=www.example.com/ST=SC/C=US/emailAddress=example@example.com/O=Example/OU=Example'
+	// faketime 'last year 5pm' /bin/bash -c 'openssl x509 -req -days 1 -sha256 -in testExpiredCertNoKey.csr -CA exampleca.crt -CAcreateserial -CAkey exampleca.key -extensions ext -extfile <(echo $"[ext]\nbasicConstraints = CA:FALSE") -out testExpiredCertNoKey.crt'
+	//
+	// Key = Unknown
+	// CA = Unknown
+	testExpiredCertNoKey = `-----BEGIN CERTIFICATE-----
+MIICoDCCAgkCFE1r/2f+5TpHQhC7pZzWTj+Gs4x0MA0GCSqGSIb3DQEBCwUAMIGh
+MQswCQYDVQQGEwJVUzELMAkGA1UECAwCU0MxFTATBgNVBAcMDERlZmF1bHQgQ2l0
+eTEcMBoGA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UECwwHVGVzdCBD
+QTEaMBgGA1UEAwwRd3d3LmV4YW1wbGVjYS5jb20xIjAgBgkqhkiG9w0BCQEWE2V4
+YW1wbGVAZXhhbXBsZS5jb20wHhcNMjMwMTEwMjIwMDAwWhcNMjMwMTExMjIwMDAw
+WjB8MRgwFgYDVQQDDA93d3cuZXhhbXBsZS5jb20xCzAJBgNVBAgMAlNDMQswCQYD
+VQQGEwJVUzEiMCAGCSqGSIb3DQEJARYTZXhhbXBsZUBleGFtcGxlLmNvbTEQMA4G
+A1UECgwHRXhhbXBsZTEQMA4GA1UECwwHRXhhbXBsZTCBnzANBgkqhkiG9w0BAQEF
+AAOBjQAwgYkCgYEAzQG776gdXXBymFZFswtR+3x8Puc8b3nGztR4s+mEVm5KEiGF
+0BAym9ywV6D4GD09YK6/eNmWOaTTowu+5Yt/CNh+j2r9X6o5lV9NUcdtog7lFNck
+wLY2f4AIXSQcGY1xu2E46AXwvznhr8/y2ObWI9H768eeR7HQ0fuXKixVz+8CAwEA
+ATANBgkqhkiG9w0BAQsFAAOBgQBYlpkSYiy/NABcjR9Y8F2gqvvYFOtFPc7qcqTl
+f7b8rn4jEA2Sq6QaNxY/GutuVT8nmLrjF7aZ1R9NdIGN6lWjsVsUpZXezyCkIWfD
+nkw+5PHjKOgRh24io7DjLC2txHDmHm21wgNWJv9q/CF0bQ+XF5EqXWkW8QD0bQto
+PJrhbw==
+-----END CERTIFICATE-----`
+
+	// Key = Unknown
+	// CA = 2nd cert in testIntCACertificateChain
+	//
+	// Key = Unknown
+	// CA = self-signed
 	testIntCACertificateChain = `-----BEGIN CERTIFICATE-----
 MIIFqjCCA5KgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwYDELMAkGA1UEBhMCVVMx
 CzAJBgNVBAgMAkNBMREwDwYDVQQKDAhTZWN1cml0eTEbMBkGA1UECwwST3BlblNo
@@ -368,6 +457,7 @@ qA0au8ygoLaCLhYK+HnzGRVAYqc4hb4LKNhIbAveHLOTUKNeAFADxq8REsPkpeM7
 G0k/6pTJTZwfsA==
 -----END CERTIFICATE-----`
 
+	// Same certs as testIntCACertificateChain
 	testIntCACertificateChainCanonical = `-----BEGIN CERTIFICATE-----
 MIIFqjCCA5KgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwYDELMAkGA1UEBhMCVVMx
 CzAJBgNVBAgMAkNBMREwDwYDVQQKDAhTZWN1cml0eTEbMBkGA1UECwwST3BlblNo
@@ -436,6 +526,8 @@ G0k/6pTJTZwfsA==
 -----END CERTIFICATE-----
 `
 
+	// Key = testPrivateKeyWithIntCA
+	// CA = 1st cert in testIntCACertificateChain
 	testCertificateWithIntCA = `-----BEGIN CERTIFICATE-----
 MIIGbzCCBFegAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwaDELMAkGA1UEBhMCVVMx
 CzAJBgNVBAgMAkNBMREwDwYDVQQKDAhTZWN1cml0eTEbMBkGA1UECwwST3BlblNo
@@ -526,6 +618,8 @@ TGqICdrZWiXt3a0Z9Vmj3p9lmf37Yn7vcK82D/LAW3gXuj3JI9UT+qCx/mb4xRMM
 psdbOzUfDqYCDPPviJvBYr4R+XdJfdF048NUtMO0w+dEiMPf5dPpi3fOvWGE
 -----END RSA PRIVATE KEY-----`
 
+	// Key = testExpiredCertificateKey
+	// CA = 1st cert in testIntCACertificateChain
 	testExpiredCertificateWithIntCA = `-----BEGIN CERTIFICATE-----
 MIIGdzCCBF+gAwIBAgICEAEwDQYJKoZIhvcNAQELBQAwaDELMAkGA1UEBhMCVVMx
 CzAJBgNVBAgMAkNBMREwDwYDVQQKDAhTZWN1cml0eTEbMBkGA1UECwwST3BlblNo
@@ -616,6 +710,8 @@ BLZdb77lbMNcPJb9KRWYwdq+bxZqO8MP2mWEWy8+WXrLk6P9x03bJhE1JPZzwRYf
 giVrDnYEggz1sg9RYApGlEp99hMFM15W14f+T+5vLD7W4anyfP+beWAnp+A0Nw==
 -----END RSA PRIVATE KEY-----`
 
+	// Key = testFutureValidCertificateKey
+	// CA = 1st cert in testIntCACertificateChain
 	testFutureValidCertificateWithIntCA = `-----BEGIN CERTIFICATE-----
 MIIGgTCCBGmgAwIBAgICEAIwDQYJKoZIhvcNAQELBQAwaDELMAkGA1UEBhMCVVMx
 CzAJBgNVBAgMAkNBMREwDwYDVQQKDAhTZWN1cml0eTEbMBkGA1UECwwST3BlblNo
@@ -706,6 +802,7 @@ E3aQMYHn+86jpSIh8ewXcxIxDj1PxfQ354kIW9+tPNY8akYL2WwJefCAmc46SHJs
 DHEcIfSs5RcvB768lQkSZ8KHmIcHzw745UFquKYnAdJZbpHBpVAC+Xx/gZs=
 -----END RSA PRIVATE KEY-----`
 
+	// Invalid
 	testInvalidCANoCert1 = `-----BEGIN CERTIFICATE REQUEST-----
 MIICnTCCAYUCAQAwWDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMREwDwYDVQQK
 DAhTZWN1cml0eTETMBEGA1UECwwKT3BlblNoaWZ0MzEUMBIGA1UEAwwLcm91dGVy
@@ -724,14 +821,18 @@ xhfvmedJE9ck2tEbxQk8BcdCXCN4HFePO8gpCYeC7r309E/QwFjU9+xw6qrpW5uP
 GA==
 -----END CERTIFICATE REQUEST-----`
 
+	// Invalid
 	testInvalidCANoCert2 = testSelfSignedKey
 
+	// Invalid/Malformed
 	testInvalidCAMalformedCert = `-----BEGIN CERTIFICATE-----
 MIIDjTCCAnWgAwIBAgIJAKM4rr3VRQARMA0GCSqGSIb3DQEBCwUAMF0xCzAJBgNV
 The+rest+of+the+certificate+info+is+invalid+and+badly+malformed/
 0A==
 -----END CERTIFICATE-----`
 
+	// Key = bz1723400key1
+	// CA = self-signed
 	bz1723400cert = `-----BEGIN CERTIFICATE-----
 MIICazCCAfKgAwIBAgIJANp+3iOVYFyDMAoGCCqGSM49BAMCMHQxCzAJBgNVBAYT
 AlVTMRcwFQYDVQQIDA5Ob3J0aCBDYXJvbGluYTEQMA4GA1UEBwwHUmFsZWlnaDEQ
@@ -826,6 +927,83 @@ g89A85Z2evF4bSHKPJCcd2ucphoc02WB5lh7bJM5iVc+vVxedMV/gQJBAKjHZb9j
 IrRGZJwgzmWX+NzqK9H3AyFk5p9oBuzmulVoJyKFzs1eN4ZIn25ifP8hP+uJHOTE
 jZrtwVw4rGVb/qM=
 -----END PRIVATE KEY-----`
+
+	// openssl req -x509 -sha1 -newkey rsa:1024 -days 3650 -keyout exampleca.key -out exampleca.crt -addext "keyUsage=cRLSign, digitalSignature, keyCertSign" -addext "extendedKeyUsage=serverAuth, clientAuth" -nodes -subj '/C=US/ST=SC/L=Default City/O=Default Company Ltd/OU=Test CA/CN=www.exampleca.com/emailAddress=example@example.com'
+	// openssl req -newkey rsa:1024 -nodes -keyout testCertificateRsaSha1.key -out testCertificateRsaSha1.csr -subj '/CN=www.example.com/ST=SC/C=US/emailAddress=example@example.com/O=Example/OU=Example'
+	// openssl x509 -req -days 3650 -sha1 -in testCertificateRsaSha1.csr -CA exampleca.crt -CAcreateserial -CAkey exampleca.key -extensions ext -extfile <(echo $'[ext]\nbasicConstraints = CA:FALSE') -out testCertificateRsaSha1.crt
+	//
+	// Key = testCertificateRsaSha1Key
+	// CA = Unknown
+	testCertificateRsaSha1 = `-----BEGIN CERTIFICATE-----
+MIIC9DCCAl2gAwIBAgIUTWv/Z/7lOkdCELulnNZOP4azjHowDQYJKoZIhvcNAQEF
+BQAwgaExCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJTQzEVMBMGA1UEBwwMRGVmYXVs
+dCBDaXR5MRwwGgYDVQQKDBNEZWZhdWx0IENvbXBhbnkgTHRkMRAwDgYDVQQLDAdU
+ZXN0IENBMRowGAYDVQQDDBF3d3cuZXhhbXBsZWNhLmNvbTEiMCAGCSqGSIb3DQEJ
+ARYTZXhhbXBsZUBleGFtcGxlLmNvbTAeFw0yNDAxMTAxOTU2MDhaFw0zNDAxMDcx
+OTU2MDhaMHwxGDAWBgNVBAMMD3d3dy5leGFtcGxlLmNvbTELMAkGA1UECAwCU0Mx
+CzAJBgNVBAYTAlVTMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUuY29t
+MRAwDgYDVQQKDAdFeGFtcGxlMRAwDgYDVQQLDAdFeGFtcGxlMIGfMA0GCSqGSIb3
+DQEBAQUAA4GNADCBiQKBgQC4hsxewdQOk5goI9bdkR1urJnbu7TeZdDtPz0Mi976
+1guAxNPQO98t0X/Bhs7toZz/zIG4vQZfXaV2IU1ry7pQ64I8bTPXQ/Kpt8zW3zng
+dPeIJqVujKPybIL/teHJ1Bw4c4x1ZMpAGoZ6s750tQy1zP7WRqStJv2G9l3OQLFu
+AQIDAQABo00wSzAJBgNVHRMEAjAAMB0GA1UdDgQWBBS6uwvwYLV5u4TX9ZFMBpQe
+hW4YKjAfBgNVHSMEGDAWgBRQlTo+l7rGlVRX5myTzXIHBN587jANBgkqhkiG9w0B
+AQUFAAOBgQB+1bS0s6SpuCuMFFMpeBcE7WX//AGU/ZcRfO60ithV6NQ9OnN3djfS
+H+ZeW3QEaQVMM0PIOuMO22/9AN6UVs8IxSuSkrfBOQ+PY/3169b6rpGl44/ZTx6B
+O+c5wkkhnmy4+T6KnjQE5aO1VKBp3Ocl8PyIBqLLV52pZWUuytGlqA==
+-----END CERTIFICATE-----
+`
+	testCertificateRsaSha1Key = `
+-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBALiGzF7B1A6TmCgj
+1t2RHW6smdu7tN5l0O0/PQyL3vrWC4DE09A73y3Rf8GGzu2hnP/Mgbi9Bl9dpXYh
+TWvLulDrgjxtM9dD8qm3zNbfOeB094gmpW6Mo/Jsgv+14cnUHDhzjHVkykAahnqz
+vnS1DLXM/tZGpK0m/Yb2Xc5AsW4BAgMBAAECgYAWaNBzBYkSSBxna4rRl6kCYtXA
+mLgrdiP8W/y3BFmNDueQuNacaFj/QH0KbKu+sizV5+ktHU+jz0Sj5wF3AOPccRtJ
+QcGxr66f1uVPeBQfO27ac8b5UYwIFCu4gJ9IQp86INARuO4U5UR2o7sJ8rUpmf2M
+p2JUQwKXjO0qDyDcQQJBAODWqTkdr0Av2vAOZe6SOfmr+u/2shAWPTg8uc1Y08Ng
+1Fh0o7vqkOQ6Amtw4o5lE0RE0LlPSnxhpl28sT0gwUkCQQDSGdtIk77rh+WqNjYZ
+GWhKBA2H8w0jo37Wz1aGyv/Yt6LC/LgOdOcadu4xSIgG+Al9JHdzLx7iWvNdIjD6
+l/75AkEA1szdwL5WVnkhrmPjCAhVMO0YALbrqKjGdfq1+7OYJDlWxOcyIe5X3GJ7
+O1AOccGopXkk+1UAMVJNUZJata6cWQJBAIEvhubsecNHL09mwALU3YxNS6ihKR4V
+xML+gBynq4Ms/vZYADBbb1KVeEZza7ilQOhiyNPZUGssM2G7yVP8q7kCQHFCAgmO
+redbrtiWNunEy1hVHOJD6ALriPz2i1W51NMbrPV2kOy9GpV/p3oby3GmXHs+Zlo6
+bBbOLhI7o+VlGaM=
+-----END PRIVATE KEY-----`
+
+	// openssl ecparam -out exampleca.key -name secp224r1 -genkey
+	// openssl req -x509 -sha1 -key exampleca.key -days 3650 -out exampleca.crt -addext "keyUsage=cRLSign, digitalSignature, keyCertSign" -addext "extendedKeyUsage=serverAuth, clientAuth" -nodes -subj '/C=US/ST=SC/L=Default City/O=Default Company Ltd/OU=Test CA/CN=www.exampleca.com/emailAddress=example@example.com'
+	// openssl ecparam -out testCertificateEcdsaSha1.key -name secp224r1 -genkey
+	// openssl req -new -nodes -key testCertificateEcdsaSha1.key -out testCertificateEcdsaSha1.csr -subj '/CN=www.example.com/ST=SC/C=US/emailAddress=example@example.com/O=Example/OU=Example'
+	// openssl x509 -req -days 3650 -sha1 -in testCertificateEcdsaSha1.csr -CA exampleca.crt -CAcreateserial -CAkey exampleca.key -extensions ext -extfile <(echo $'[ext]\nbasicConstraints = CA:FALSE') -out testCertificateEcdsaSha1.crt
+	//
+	// Key = testCertificateEcdsaSha1Key
+	// CA = Unknown
+	testCertificateEcdsaSha1 = `-----BEGIN CERTIFICATE-----
+MIICWTCCAgegAwIBAgIUTWv/Z/7lOkdCELulnNZOP4azjIIwCQYHKoZIzj0EATCB
+oTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENp
+dHkxHDAaBgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3Qg
+Q0ExGjAYBgNVBAMMEXd3dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNl
+eGFtcGxlQGV4YW1wbGUuY29tMB4XDTI0MDExMDIwMjMzNVoXDTM0MDEwNzIwMjMz
+NVowfDEYMBYGA1UEAwwPd3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkG
+A1UEBhMCVVMxIjAgBgkqhkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAO
+BgNVBAoMB0V4YW1wbGUxEDAOBgNVBAsMB0V4YW1wbGUwTjAQBgcqhkjOPQIBBgUr
+gQQAIQM6AATOmu6DIvMYCHfyKfX3jiFKwmsai2r6hJI67MWvjcEq3mztN9hg/WNw
+D15CgvKqNpZboP+JaUtgLaNNMEswCQYDVR0TBAIwADAdBgNVHQ4EFgQUX5KvVN+P
+hOBQfF+oksHEHN9SMEowHwYDVR0jBBgwFoAU7dd64Bp/HI/JIqHUUknXX5jz068w
+CQYHKoZIzj0EAQNBADA+Ah0AxlT5Ri6/suTGv8pnL6QYp3Czpz3h3G5KOtzkbwId
+ANQzMWFQDZ+sjIEMr+UJsiD5mB1jUPysXUFT6Xg=
+-----END CERTIFICATE-----
+`
+	testCertificateEcdsaSha1Key = `-----BEGIN EC PARAMETERS-----
+BgUrgQQAIQ==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MGgCAQEEHMp+7YQt1rH4YHPyOyLtjiUeDzZezVY5zYT9YJWgBwYFK4EEACGhPAM6
+AATOmu6DIvMYCHfyKfX3jiFKwmsai2r6hJI67MWvjcEq3mztN9hg/WNwD15CgvKq
+NpZboP+JaUtgLQ==
+-----END EC PRIVATE KEY-----
+`
 )
 
 // TestExtendedValidateRoute ensures that a route's certificate and keys
@@ -982,7 +1160,7 @@ func TestExtendedValidateRoute(t *testing.T) {
 					TLS: &routev1.TLSConfig{
 						Termination:   routev1.TLSTerminationEdge,
 						Certificate:   testCertificate,
-						Key:           testExpiredCertPrivateKey,
+						Key:           testUnrelatedCACertificateKey,
 						CACertificate: testCACertificate,
 					},
 				},
@@ -990,28 +1168,42 @@ func TestExtendedValidateRoute(t *testing.T) {
 			expectedErrors: 1,
 		},
 		{
-			name: "Edge termination expired cert unknown CA",
+			name: "Edge termination cert with unknown CA",
 			route: &routev1.Route{
 				Spec: routev1.RouteSpec{
 					Host: "www.example.com",
 					TLS: &routev1.TLSConfig{
 						Termination: routev1.TLSTerminationEdge,
-						Certificate: testExpiredCAUnknownCertificate,
-						Key:         testExpiredCertPrivateKey,
+						Certificate: testCertificate,
+						Key:         testPrivateKey,
 					},
 				},
 			},
 			expectedErrors: 0,
 		},
 		{
-			name: "Edge termination expired cert mismatched CA",
+			name: "Edge termination expired cert with unknown CA and diff host",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					Host: "think.different.test",
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationEdge,
+						Certificate: testExpiredCert,
+						Key:         testExpiredCertKey,
+					},
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Edge termination cert mismatched CA",
 			route: &routev1.Route{
 				Spec: routev1.RouteSpec{
 					Host: "www.example.com",
 					TLS: &routev1.TLSConfig{
 						Termination:   routev1.TLSTerminationEdge,
-						Certificate:   testExpiredCAUnknownCertificate,
-						Key:           testExpiredCertPrivateKey,
+						Certificate:   testUnrelatedCACertificate,
+						Key:           testUnrelatedCACertificateKey,
 						CACertificate: testCACertificate,
 					},
 				},
@@ -1019,13 +1211,34 @@ func TestExtendedValidateRoute(t *testing.T) {
 			expectedErrors: 1,
 		},
 		{
-			name: "Edge termination expired cert key mismatch",
+			// Note: This test case passes because the crypto/x509 package's Certificate.Verify
+			//       function returns an Expired error BEFORE checking for a mismatch error, and
+			//       the extended validation's validateCertificatePEM function logic ignores the
+			//       Expired error.  Therefore, expectedErrors is 0 with an expired certificate
+			//       even if the CA doesn't match.  The extended validation logic has had this
+			//       issue since OpenShift 3.3, and it is preserved for backwards-compatibility.
+			name: "Edge termination with expired cert, ignoring CA mismatch",
 			route: &routev1.Route{
 				Spec: routev1.RouteSpec{
 					Host: "www.example.com",
 					TLS: &routev1.TLSConfig{
 						Termination:   routev1.TLSTerminationEdge,
-						Certificate:   testExpiredCAUnknownCertificate,
+						Certificate:   testExpiredCert,
+						Key:           testExpiredCertKey,
+						CACertificate: testCACertificate,
+					},
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Edge termination mismatched key and cert with unrelated CA",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					Host: "www.example.com",
+					TLS: &routev1.TLSConfig{
+						Termination:   routev1.TLSTerminationEdge,
+						Certificate:   testUnrelatedCACertificate,
 						Key:           testPrivateKey,
 						CACertificate: testCACertificate,
 					},
@@ -1119,45 +1332,30 @@ func TestExtendedValidateRoute(t *testing.T) {
 			expectedErrors: 4,
 		},
 		{
-			name: "example cert",
+			name: "expired cert edge",
 			route: &routev1.Route{
 				Spec: routev1.RouteSpec{
 					Host: "www.example.com",
 					TLS: &routev1.TLSConfig{
 						Termination:   routev1.TLSTerminationEdge,
-						Certificate:   testCertificate,
-						Key:           testPrivateKey,
-						CACertificate: testCACertificate,
+						Certificate:   testExpiredCert,
+						Key:           testExpiredCertKey,
+						CACertificate: testExpiredCertCA,
 					},
 				},
 			},
 			expectedErrors: 0,
 		},
 		{
-			name: "Expired cert",
-			route: &routev1.Route{
-				Spec: routev1.RouteSpec{
-					Host: "www.example.com",
-					TLS: &routev1.TLSConfig{
-						Termination:   routev1.TLSTerminationEdge,
-						Certificate:   testCertificate,
-						Key:           testPrivateKey,
-						CACertificate: testCACertificate,
-					},
-				},
-			},
-			expectedErrors: 0,
-		},
-		{
-			name: "Expired cert reencrypt",
+			name: "expired cert reencrypt",
 			route: &routev1.Route{
 				Spec: routev1.RouteSpec{
 					Host: "www.example.com",
 					TLS: &routev1.TLSConfig{
 						Termination:              routev1.TLSTerminationReencrypt,
-						Certificate:              testCertificate,
-						Key:                      testPrivateKey,
-						CACertificate:            testCACertificate,
+						Certificate:              testExpiredCert,
+						Key:                      testExpiredCertKey,
+						CACertificate:            testExpiredCertCA,
 						DestinationCACertificate: testCACertificate,
 					},
 				},
@@ -1212,9 +1410,9 @@ func TestExtendedValidateRoute(t *testing.T) {
 					Host: "think.different.test",
 					TLS: &routev1.TLSConfig{
 						Termination:   routev1.TLSTerminationEdge,
-						Certificate:   testCertificate,
-						Key:           testPrivateKey,
-						CACertificate: testCACertificate,
+						Certificate:   testExpiredCert,
+						Key:           testExpiredCertKey,
+						CACertificate: testExpiredCertCA,
 					},
 				},
 			},
@@ -1719,51 +1917,79 @@ func TestExtendedValidateRoute(t *testing.T) {
 			},
 			expectedErrors: 1,
 		},
+		{
+			name: "Edge termination with cert using SHA1 with RSA key",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationEdge,
+						Certificate: testCertificateRsaSha1,
+						Key:         testCertificateRsaSha1Key,
+					},
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Edge termination with cert using SHA1 with ECDSA key",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationEdge,
+						Certificate: testCertificateEcdsaSha1,
+						Key:         testCertificateEcdsaSha1Key,
+					},
+				},
+			},
+			expectedErrors: 0,
+		},
 	}
 
 	for _, tc := range tests {
-		errs := ExtendedValidateRoute(tc.route)
-		if len(errs) != tc.expectedErrors {
-			t.Errorf("Test case %s expected %d error(s), got %d. %v", tc.name, tc.expectedErrors, len(errs), errs)
-		}
-
-		if len(errs) == 0 {
-			if tc.expectRoute != nil {
-				if e, a := tc.expectRoute, tc.route; !reflect.DeepEqual(e, a) {
-					t.Errorf("Test case %s got unexpected route differences: %s", tc.name, diff.ObjectReflectDiff(e, a))
-				}
+		t.Run(tc.name, func(t *testing.T) {
+			errs := ExtendedValidateRoute(tc.route)
+			if len(errs) != tc.expectedErrors {
+				t.Errorf("expected %d error(s), got %d. %v", tc.expectedErrors, len(errs), errs)
 			}
 
-			if tls := tc.route.Spec.TLS; tls != nil {
-				data, err := sanitizePEM([]byte(tls.CACertificate))
-				if err != nil {
-					t.Errorf("Test case %s should have sanitized CA, got %v", tc.name, err)
+			if len(errs) == 0 {
+				if tc.expectRoute != nil {
+					if e, a := tc.expectRoute, tc.route; !reflect.DeepEqual(e, a) {
+						t.Errorf("got unexpected route differences: %s", diff.ObjectReflectDiff(e, a))
+					}
 				}
-				if e, a := data, []byte(tls.CACertificate); !bytes.Equal(e, a) {
-					t.Errorf("Test case %s should have sanitized CA, got\n%s\n%s", tc.name, e, a)
-				}
-				data, err = sanitizePEM([]byte(tls.Certificate))
-				if err != nil {
-					t.Errorf("Test case %s should have sanitized certificate, got %v", tc.name, err)
-				}
-				if e, a := data, []byte(tls.Certificate); !bytes.Equal(e, a) {
-					t.Errorf("Test case %s should have sanitized certificate, got\n%s\n%s", tc.name, e, a)
-				}
-				data, err = sanitizePEM([]byte(tls.DestinationCACertificate))
-				if err != nil {
-					t.Errorf("Test case %s should have sanitized destination CA, got %v", tc.name, err)
-				}
-				if e, a := data, []byte(tls.DestinationCACertificate); !bytes.Equal(e, a) {
-					t.Errorf("Test case %s should have sanitized destination CA, got\n%s\n%s", tc.name, e, a)
-				}
-				data, err = sanitizePEM([]byte(tls.Key))
-				if err != nil {
-					t.Errorf("Test case %s should have sanitized key, got %v", tc.name, err)
-				}
-				if e, a := data, []byte(tls.Key); !bytes.Equal(e, a) {
-					t.Errorf("Test case %s should have sanitized key, got\n%s\n%s", tc.name, e, a)
+
+				if tls := tc.route.Spec.TLS; tls != nil {
+					data, err := sanitizePEM([]byte(tls.CACertificate))
+					if err != nil {
+						t.Errorf("should have sanitized CA, got %v", err)
+					}
+					if e, a := data, []byte(tls.CACertificate); !bytes.Equal(e, a) {
+						t.Errorf("should have sanitized CA, got\n%s\n%s", e, a)
+					}
+					data, err = sanitizePEM([]byte(tls.Certificate))
+					if err != nil {
+						t.Errorf("should have sanitized certificate, got %v", err)
+					}
+					if e, a := data, []byte(tls.Certificate); !bytes.Equal(e, a) {
+						t.Errorf("should have sanitized certificate, got\n%s\n%s", e, a)
+					}
+					data, err = sanitizePEM([]byte(tls.DestinationCACertificate))
+					if err != nil {
+						t.Errorf("should have sanitized destination CA, got %v", err)
+					}
+					if e, a := data, []byte(tls.DestinationCACertificate); !bytes.Equal(e, a) {
+						t.Errorf("should have sanitized destination CA, got\n%s\n%s", e, a)
+					}
+					data, err = sanitizePEM([]byte(tls.Key))
+					if err != nil {
+						t.Errorf("should have sanitized key, got %v", err)
+					}
+					if e, a := data, []byte(tls.Key); !bytes.Equal(e, a) {
+						t.Errorf("should have sanitized key, got\n%s\n%s", e, a)
+					}
 				}
 			}
-		}
+		})
 	}
 }

--- a/pkg/router/template/configmanager/haproxy/blueprint_plugin.go
+++ b/pkg/router/template/configmanager/haproxy/blueprint_plugin.go
@@ -22,6 +22,7 @@ func NewBlueprintPlugin(cm templaterouter.ConfigManager) *BlueprintPlugin {
 
 // HandleRoute processes watch events on blueprint routes.
 func (p *BlueprintPlugin) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: BlueprintPlugin")
 	switch eventType {
 	case watch.Added, watch.Modified:
 		return p.manager.AddBlueprint(route)

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -217,6 +217,7 @@ func (p *TemplatePlugin) HandleNode(eventType watch.EventType, node *kapi.Node) 
 // determines which component needs to be recalculated (which template) and then does so
 // on demand.
 func (p *TemplatePlugin) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: TemplatePlugin")
 	switch eventType {
 	case watch.Added, watch.Modified:
 		p.Router.AddRoute(route)

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -17,42 +17,48 @@ import (
 )
 
 const (
-	testExpiredCAUnknownCertificate = `-----BEGIN CERTIFICATE-----
-MIIDIjCCAgqgAwIBAgIBBjANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx
-CzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl
-ZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3
-dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu
-Y29tMB4XDTE2MDExMzE5NDA1N1oXDTI2MDExMDE5NDA1N1owfDEYMBYGA1UEAxMP
-d3d3LmV4YW1wbGUuY29tMQswCQYDVQQIEwJTQzELMAkGA1UEBhMCVVMxIjAgBgkq
-hkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoTB0V4YW1wbGUx
-EDAOBgNVBAsTB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAM0B
-u++oHV1wcphWRbMLUft8fD7nPG95xs7UeLPphFZuShIhhdAQMpvcsFeg+Bg9PWCu
-v3jZljmk06MLvuWLfwjYfo9q/V+qOZVfTVHHbaIO5RTXJMC2Nn+ACF0kHBmNcbth
-OOgF8L854a/P8tjm1iPR++vHnkex0NH7lyosVc/vAgMBAAGjDTALMAkGA1UdEwQC
-MAAwDQYJKoZIhvcNAQEFBQADggEBADjFm5AlNH3DNT1Uzx3m66fFjqqrHEs25geT
-yA3rvBuynflEHQO95M/8wCxYVyuAx4Z1i4YDC7tx0vmOn/2GXZHY9MAj1I8KCnwt
-Jik7E2r1/yY0MrkawljOAxisXs821kJ+Z/51Ud2t5uhGxS6hJypbGspMS7OtBbw7
-8oThK7cWtCXOldNF6ruqY1agWnhRdAq5qSMnuBXuicOP0Kbtx51a1ugE3SnvQenJ
-nZxdtYUXvEsHZC/6bAtTfNh+/SwgxQJuL2ZM+VG3X2JIKY8xTDui+il7uTh422lq
-wED8uwKl+bOj6xFDyw4gWoBxRobsbFaME8pkykP1+GnKDberyAM=
+	// openssl req -newkey rsa:1024 -nodes -keyout testExpiredCert.key -out testExpiredCert.csr -subj '/CN=www.example.com/ST=SC/C=US/emailAddress=example@example.com/O=Example/OU=Example'
+	// faketime 'last year 5pm' /bin/bash -c 'openssl x509 -req -days 1 -sha256 -in testExpiredCert.csr -CA testExpiredCertCA.crt -CAcreateserial -CAkey testExpiredCertCA.key -extensions ext -extfile <(echo $"[ext]\nbasicConstraints = CA:FALSE") -out testExpiredCert.crt'
+	//
+	// Key = testExpiredCertKey
+	// CA = testExpiredCertCA
+	testExpiredCert = `-----BEGIN CERTIFICATE-----
+MIICoDCCAgkCFAaeel1AtQzHHpRUjVZSaSEbuzcvMA0GCSqGSIb3DQEBCwUAMIGh
+MQswCQYDVQQGEwJVUzELMAkGA1UECAwCU0MxFTATBgNVBAcMDERlZmF1bHQgQ2l0
+eTEcMBoGA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UECwwHVGVzdCBD
+QTEaMBgGA1UEAwwRd3d3LmV4YW1wbGVjYS5jb20xIjAgBgkqhkiG9w0BCQEWE2V4
+YW1wbGVAZXhhbXBsZS5jb20wHhcNMjMwMTI2MjIwMDAwWhcNMjMwMTI3MjIwMDAw
+WjB8MRgwFgYDVQQDDA93d3cuZXhhbXBsZS5jb20xCzAJBgNVBAgMAlNDMQswCQYD
+VQQGEwJVUzEiMCAGCSqGSIb3DQEJARYTZXhhbXBsZUBleGFtcGxlLmNvbTEQMA4G
+A1UECgwHRXhhbXBsZTEQMA4GA1UECwwHRXhhbXBsZTCBnzANBgkqhkiG9w0BAQEF
+AAOBjQAwgYkCgYEAv2GAaJvd0aWxiw7jBTM+VDATQ2vTPbrRc5r8+2yNTwP1Dhr1
+VlLmX5o3yv/LeHhK6g8xw1xHcDdvIAdW+J6Uu99BwDK9R5dxwVoEeTYr82vOUoFQ
+1sdXqm4226bdAJXf3kdFo+zBr2aefpygpxvMGghz6oW7Nxz78SD8yHNaAzUCAwEA
+ATANBgkqhkiG9w0BAQsFAAOBgQABr3mFRjl60RAGL8s1pB6lqBRqy5pG2WoujQlT
+N65bDpFJP7vDiFe35qYVVGLAutPxTAaAtGkNhuiyoOqfP6BIlwkM68gD5plmdRBR
+hQi35A/6YMFAsBDOnhJccOCO2i19yhyAg2R0tMSder8b51IpmLABLt3UkujwVRJ+
+a3zkug==
 -----END CERTIFICATE-----`
 
-	testExpiredCertPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
-MIICWwIBAAKBgQDNAbvvqB1dcHKYVkWzC1H7fHw+5zxvecbO1Hiz6YRWbkoSIYXQ
-EDKb3LBXoPgYPT1grr942ZY5pNOjC77li38I2H6Pav1fqjmVX01Rx22iDuUU1yTA
-tjZ/gAhdJBwZjXG7YTjoBfC/OeGvz/LY5tYj0fvrx55HsdDR+5cqLFXP7wIDAQAB
-AoGAfE7P4Zsj6zOzGPI/Izj7Bi5OvGnEeKfzyBiH9Dflue74VRQkqqwXs/DWsNv3
-c+M2Y3iyu5ncgKmUduo5X8D9To2ymPRLGuCdfZTxnBMpIDKSJ0FTwVPkr6cYyyBk
-5VCbc470pQPxTAAtl2eaO1sIrzR4PcgwqrSOjwBQQocsGAECQQD8QOra/mZmxPbt
-bRh8U5lhgZmirImk5RY3QMPI/1/f4k+fyjkU5FRq/yqSyin75aSAXg8IupAFRgyZ
-W7BT6zwBAkEA0A0ugAGorpCbuTa25SsIOMxkEzCiKYvh0O+GfGkzWG4lkSeJqGME
-keuJGlXrZNKNoCYLluAKLPmnd72X2yTL7wJARM0kAXUP0wn324w8+HQIyqqBj/gF
-Vt9Q7uMQQ3s72CGu3ANZDFS2nbRZFU5koxrggk6lRRk1fOq9NvrmHg10AQJABOea
-pgfj+yGLmkUw8JwgGH6xCUbHO+WBUFSlPf+Y50fJeO+OrjqPXAVKeSV3ZCwWjKT4
-9viXJNJJ4WfF0bO/XwJAOMB1wQnEOSZ4v+laMwNtMq6hre5K8woqteXICoGcIWe8
-u3YLAbyW/lHhOCiZu2iAI8AbmXem9lW6Tr7p/97s0w==
------END RSA PRIVATE KEY-----`
+	testExpiredCertKey = `-----BEGIN PRIVATE KEY-----
+MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAL9hgGib3dGlsYsO
+4wUzPlQwE0Nr0z260XOa/PtsjU8D9Q4a9VZS5l+aN8r/y3h4SuoPMcNcR3A3byAH
+VvielLvfQcAyvUeXccFaBHk2K/NrzlKBUNbHV6puNtum3QCV395HRaPswa9mnn6c
+oKcbzBoIc+qFuzcc+/Eg/MhzWgM1AgMBAAECgYEAqC4Ood8XNzzcoM8cQV2e0GzP
+ANiocf7SQT1aQ7hJFb7sgtC9+HYxbKIhlYrkS6Gqc7WWjY9yV/Le/M52Z1U0bb5r
+/guvTx686AYoTZzCjptwpAuVE1sS9r+WCa/VgflPZYtaql960TtO72ntjcWHoIl/
+2AsE0/1wLHLquYHaDaECQQDxdDL9ecvEWD6yTom9GlfQq/6CwzA6Nhs1oncgDT/4
+1OXGD/GgXUvlJZszdkTrYh4az8YeobDsJsfMjIkFfQpDAkEAyukOORSRIk9/KBUm
+Ufyu7JtFibtr8mozkf43Dd+2BYyO6dPqS/E9m0nUZoMSoGfS0LqS8pT1hUU0RMun
+dXURJwJBALBC5V5I5UmmKc68qqxTaLu6cwc+OhykluRmf5P0WDjsIfiedwNcWCUl
+eNDui41RiSyFdNmzq5YZEU3vYa+SAkUCQQCx99EyvVhCWKl1dX9jv5WJDvLhx9H5
+D67lqKuO7p0OpuaeLfE85H0dW5cAxouqxwU/b7T9MSta1YTvphPdUG1XAkBwH06h
+STCeJCluaFZp/Aaok8fTAbodEu5gdfo/W8dspflTFM6RcR9+WJb91elObh3QiJET
+T1ZXsR6eRuHdx4oh
+-----END PRIVATE KEY-----`
 
+	// Key = testPrivateKey
+	// CA = testCACertificate
 	testCertificate = `-----BEGIN CERTIFICATE-----
 MIICwjCCAiugAwIBAgIBATANBgkqhkiG9w0BAQsFADBjMQswCQYDVQQGEwJVUzEL
 MAkGA1UECAwCQ0ExETAPBgNVBAoMCFNlY3VyaXR5MRswGQYDVQQLDBJPcGVuU2hp
@@ -99,6 +105,8 @@ HP8gHJSZnaGrLKmjwNeQNsARYajKmDKO5HJ9g5H5Hae8enOb2yie541dneDT8rID
 4054dMQJnijd8620yf8wiNy05ZPOQQ0JvA/rW3WWZc5PGm8c2PsVjg==
 -----END RSA PRIVATE KEY-----`
 
+	// Key = N/A
+	// CA = self-signed
 	testCACertificate = `-----BEGIN CERTIFICATE-----
 MIIClDCCAf2gAwIBAgIJAPU57OGhuqJtMA0GCSqGSIb3DQEBCwUAMGMxCzAJBgNV
 BAYTAlVTMQswCQYDVQQIDAJDQTERMA8GA1UECgwIU2VjdXJpdHkxGzAZBgNVBAsM
@@ -776,7 +784,7 @@ func TestHandleRouteExtendedValidation(t *testing.T) {
 			name: "Reencrypt termination OK with bad config",
 			route: &routev1.Route{
 				Spec: routev1.RouteSpec{
-					Host: "www.reencypt.badconfig.test",
+					Host: "www.reencrypt.badconfig.test",
 					TLS: &routev1.TLSConfig{
 						Termination:              routev1.TLSTerminationReencrypt,
 						Certificate:              "def",
@@ -792,7 +800,7 @@ func TestHandleRouteExtendedValidation(t *testing.T) {
 			name: "Reencrypt termination OK without certs",
 			route: &routev1.Route{
 				Spec: routev1.RouteSpec{
-					Host: "www.reencypt.nocerts.test",
+					Host: "www.reencrypt.nocerts.test",
 					TLS: &routev1.TLSConfig{
 						Termination:              routev1.TLSTerminationReencrypt,
 						DestinationCACertificate: testDestinationCACertificate,
@@ -805,7 +813,7 @@ func TestHandleRouteExtendedValidation(t *testing.T) {
 			name: "Reencrypt termination bad config without certs",
 			route: &routev1.Route{
 				Spec: routev1.RouteSpec{
-					Host: "www.reencypt.badconfignocerts.test",
+					Host: "www.reencrypt.badconfignocerts.test",
 					TLS: &routev1.TLSConfig{
 						Termination:              routev1.TLSTerminationReencrypt,
 						DestinationCACertificate: "abc",
@@ -818,7 +826,7 @@ func TestHandleRouteExtendedValidation(t *testing.T) {
 			name: "Reencrypt termination no dest cert",
 			route: &routev1.Route{
 				Spec: routev1.RouteSpec{
-					Host: "www.reencypt.nodestcert.test",
+					Host: "www.reencrypt.nodestcert.test",
 					TLS: &routev1.TLSConfig{
 						Termination:   routev1.TLSTerminationReencrypt,
 						Certificate:   testCertificate,
@@ -881,7 +889,7 @@ func TestHandleRouteExtendedValidation(t *testing.T) {
 					TLS: &routev1.TLSConfig{
 						Termination:   routev1.TLSTerminationEdge,
 						Certificate:   testCertificate,
-						Key:           testExpiredCertPrivateKey,
+						Key:           testExpiredCertKey,
 						CACertificate: testCACertificate,
 					},
 				},
@@ -895,13 +903,12 @@ func TestHandleRouteExtendedValidation(t *testing.T) {
 					Host: "www.edge.expiredcert.test",
 					TLS: &routev1.TLSConfig{
 						Termination:   routev1.TLSTerminationEdge,
-						Certificate:   testExpiredCAUnknownCertificate,
-						Key:           testExpiredCertPrivateKey,
+						Certificate:   testExpiredCert,
+						Key:           testExpiredCertKey,
 						CACertificate: testCACertificate,
 					},
 				},
 			},
-			errorExpected: true,
 		},
 		{
 			name: "Edge termination expired cert key mismatch",
@@ -910,7 +917,7 @@ func TestHandleRouteExtendedValidation(t *testing.T) {
 					Host: "www.edge.expiredcertkeymismatch.test",
 					TLS: &routev1.TLSConfig{
 						Termination:   routev1.TLSTerminationEdge,
-						Certificate:   testExpiredCAUnknownCertificate,
+						Certificate:   testExpiredCert,
 						Key:           testPrivateKey,
 						CACertificate: testCACertificate,
 					},
@@ -1015,14 +1022,10 @@ func TestHandleRouteExtendedValidation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := plugin.HandleRoute(watch.Added, tc.route)
-			if tc.errorExpected {
-				if err == nil {
-					t.Fatalf("test case %s: expected an error, got none", tc.name)
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("test case %s: expected no errors, got %v", tc.name, err)
-				}
+			if tc.errorExpected && err == nil {
+				t.Fatal("expected an error, got none")
+			} else if !tc.errorExpected && err != nil {
+				t.Fatalf("expected no errors, got %v", err)
 			}
 		})
 	}

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -1099,7 +1099,7 @@ func TestHandleRouteExtendedValidation(t *testing.T) {
 func TestHandleRouteUpgradeValidation(t *testing.T) {
 	rejections := &fakeStatusRecorder{}
 	fake := &fakePlugin{}
-	plugin := controller.NewUpgradeValidation(fake, rejections)
+	plugin := controller.NewUpgradeValidation(fake, rejections, false, false)
 
 	tests := []struct {
 		name                               string

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -125,6 +125,48 @@ bGvtpjWA4r9WASIDPFsxk/cDEEEO6iPxgMOf5MdpQC2y2MU0rzF/Gg==
 -----END CERTIFICATE-----`
 
 	testDestinationCACertificate = testCACertificate
+
+	// openssl req -x509 -sha1 -newkey rsa:1024 -days 3650 -keyout exampleca.key -out exampleca.crt -addext "keyUsage=cRLSign, digitalSignature, keyCertSign" -addext "extendedKeyUsage=serverAuth, clientAuth" -nodes -subj '/C=US/ST=SC/L=Default City/O=Default Company Ltd/OU=Test CA/CN=www.exampleca.com/emailAddress=example@example.com'
+	// openssl req -newkey rsa:1024 -nodes -keyout testCertificateRsaSha1.key -out testCertificateRsaSha1.csr -subj '/CN=www.example.com/ST=SC/C=US/emailAddress=example@example.com/O=Example/OU=Example'
+	// openssl x509 -req -days 3650 -sha1 -in testCertificateRsaSha1.csr -CA exampleca.crt -CAcreateserial -CAkey exampleca.key -extensions ext -extfile <(echo $'[ext]\nbasicConstraints = CA:FALSE') -out testCertificateRsaSha1.crt
+	//
+	// Key = testCertificateRsaSha1Key
+	testCertificateRsaSha1 = `-----BEGIN CERTIFICATE-----
+MIIC9DCCAl2gAwIBAgIUTWv/Z/7lOkdCELulnNZOP4azjHowDQYJKoZIhvcNAQEF
+BQAwgaExCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJTQzEVMBMGA1UEBwwMRGVmYXVs
+dCBDaXR5MRwwGgYDVQQKDBNEZWZhdWx0IENvbXBhbnkgTHRkMRAwDgYDVQQLDAdU
+ZXN0IENBMRowGAYDVQQDDBF3d3cuZXhhbXBsZWNhLmNvbTEiMCAGCSqGSIb3DQEJ
+ARYTZXhhbXBsZUBleGFtcGxlLmNvbTAeFw0yNDAxMTAxOTU2MDhaFw0zNDAxMDcx
+OTU2MDhaMHwxGDAWBgNVBAMMD3d3dy5leGFtcGxlLmNvbTELMAkGA1UECAwCU0Mx
+CzAJBgNVBAYTAlVTMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUuY29t
+MRAwDgYDVQQKDAdFeGFtcGxlMRAwDgYDVQQLDAdFeGFtcGxlMIGfMA0GCSqGSIb3
+DQEBAQUAA4GNADCBiQKBgQC4hsxewdQOk5goI9bdkR1urJnbu7TeZdDtPz0Mi976
+1guAxNPQO98t0X/Bhs7toZz/zIG4vQZfXaV2IU1ry7pQ64I8bTPXQ/Kpt8zW3zng
+dPeIJqVujKPybIL/teHJ1Bw4c4x1ZMpAGoZ6s750tQy1zP7WRqStJv2G9l3OQLFu
+AQIDAQABo00wSzAJBgNVHRMEAjAAMB0GA1UdDgQWBBS6uwvwYLV5u4TX9ZFMBpQe
+hW4YKjAfBgNVHSMEGDAWgBRQlTo+l7rGlVRX5myTzXIHBN587jANBgkqhkiG9w0B
+AQUFAAOBgQB+1bS0s6SpuCuMFFMpeBcE7WX//AGU/ZcRfO60ithV6NQ9OnN3djfS
+H+ZeW3QEaQVMM0PIOuMO22/9AN6UVs8IxSuSkrfBOQ+PY/3169b6rpGl44/ZTx6B
+O+c5wkkhnmy4+T6KnjQE5aO1VKBp3Ocl8PyIBqLLV52pZWUuytGlqA==
+-----END CERTIFICATE-----
+`
+	testCertificateRsaSha1Key = `
+-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBALiGzF7B1A6TmCgj
+1t2RHW6smdu7tN5l0O0/PQyL3vrWC4DE09A73y3Rf8GGzu2hnP/Mgbi9Bl9dpXYh
+TWvLulDrgjxtM9dD8qm3zNbfOeB094gmpW6Mo/Jsgv+14cnUHDhzjHVkykAahnqz
+vnS1DLXM/tZGpK0m/Yb2Xc5AsW4BAgMBAAECgYAWaNBzBYkSSBxna4rRl6kCYtXA
+mLgrdiP8W/y3BFmNDueQuNacaFj/QH0KbKu+sizV5+ktHU+jz0Sj5wF3AOPccRtJ
+QcGxr66f1uVPeBQfO27ac8b5UYwIFCu4gJ9IQp86INARuO4U5UR2o7sJ8rUpmf2M
+p2JUQwKXjO0qDyDcQQJBAODWqTkdr0Av2vAOZe6SOfmr+u/2shAWPTg8uc1Y08Ng
+1Fh0o7vqkOQ6Amtw4o5lE0RE0LlPSnxhpl28sT0gwUkCQQDSGdtIk77rh+WqNjYZ
+GWhKBA2H8w0jo37Wz1aGyv/Yt6LC/LgOdOcadu4xSIgG+Al9JHdzLx7iWvNdIjD6
+l/75AkEA1szdwL5WVnkhrmPjCAhVMO0YALbrqKjGdfq1+7OYJDlWxOcyIe5X3GJ7
+O1AOccGopXkk+1UAMVJNUZJata6cWQJBAIEvhubsecNHL09mwALU3YxNS6ihKR4V
+xML+gBynq4Ms/vZYADBbb1KVeEZza7ilQOhiyNPZUGssM2G7yVP8q7kCQHFCAgmO
+redbrtiWNunEy1hVHOJD6ALriPz2i1W51NMbrPV2kOy9GpV/p3oby3GmXHs+Zlo6
+bBbOLhI7o+VlGaM=
+-----END PRIVATE KEY-----`
 )
 
 // TestRouter provides an implementation of the plugin's router interface suitable for unit testing.
@@ -471,23 +513,45 @@ func TestHandleTCPEndpoints(t *testing.T) {
 	}
 }
 
-type rejection struct {
+type status struct {
 	route   *routev1.Route
 	reason  string
 	message string
 }
 
-type fakeRejections struct {
-	rejections []rejection
+type fakeStatusRecorder struct {
+	rejections                 []status
+	unservableInFutureVersions []status
 }
 
-func (r *fakeRejections) RecordRouteRejection(route *routev1.Route, reason, message string) {
-	r.rejections = append(r.rejections, rejection{route: route, reason: reason, message: message})
+func (r *fakeStatusRecorder) RecordRouteRejection(route *routev1.Route, reason, message string) {
+	r.rejections = append(r.rejections, status{route: route, reason: reason, message: message})
+}
+func (r *fakeStatusRecorder) RecordRouteUnservableInFutureVersions(route *routev1.Route, reason, message string) {
+	r.unservableInFutureVersions = append(r.unservableInFutureVersions, status{route: route, reason: reason, message: message})
+}
+func (r *fakeStatusRecorder) RecordRouteUnservableInFutureVersionsClear(route *routev1.Route) {
+	var unservableInFutureVersions []status
+	for _, entry := range r.unservableInFutureVersions {
+		if entry.route.UID != route.UID {
+			unservableInFutureVersions = append(unservableInFutureVersions, entry)
+		}
+	}
+	r.unservableInFutureVersions = unservableInFutureVersions
+}
+
+func (r *fakeStatusRecorder) isUnservableInFutureVersions(route *routev1.Route) bool {
+	for _, r := range r.unservableInFutureVersions {
+		if r.route.UID == route.UID {
+			return true
+		}
+	}
+	return false
 }
 
 // TestHandleRoute test route watch events
 func TestHandleRoute(t *testing.T) {
-	rejections := &fakeRejections{}
+	rejections := &fakeStatusRecorder{}
 	router := newTestRouter(make(map[ServiceAliasConfigKey]ServiceAliasConfig))
 	templatePlugin := newDefaultTemplatePlugin(router, true, nil)
 	// TODO: move tests that rely on unique hosts to pkg/router/controller and remove them from
@@ -538,7 +602,7 @@ func TestHandleRoute(t *testing.T) {
 	}
 
 	if len(rejections.rejections) > 0 {
-		t.Fatalf("did not expect a recorded rejection: %#v", rejections)
+		t.Fatalf("did not expect a recorded status: %#v", rejections)
 	}
 
 	// attempt to add a second route with a newer time, verify it is ignored
@@ -571,7 +635,7 @@ func TestHandleRoute(t *testing.T) {
 		rejections.rejections[0].route.Name != "dupe" ||
 		rejections.rejections[0].reason != "HostAlreadyClaimed" ||
 		rejections.rejections[0].message != "route test already exposes www.example.com and is older" {
-		t.Fatalf("did not record rejection: %#v", rejections)
+		t.Fatalf("did not record status: %#v", rejections)
 	}
 	rejections.rejections = nil
 
@@ -590,7 +654,7 @@ func TestHandleRoute(t *testing.T) {
 		t.Fatalf("unexpected claimed routes: %#v", r)
 	}
 	if len(rejections.rejections) != 0 {
-		t.Fatalf("did not record rejection: %#v", rejections)
+		t.Fatalf("did not record status: %#v", rejections)
 	}
 	rejections.rejections = nil
 
@@ -610,7 +674,7 @@ func TestHandleRoute(t *testing.T) {
 		rejections.rejections[0].route.Name != "test" ||
 		rejections.rejections[0].reason != "HostAlreadyClaimed" ||
 		rejections.rejections[0].message != "replaced by older route dupe" {
-		t.Fatalf("did not record rejection: %#v", rejections)
+		t.Fatalf("did not record status: %#v", rejections)
 	}
 	rejections.rejections = nil
 
@@ -640,7 +704,7 @@ func TestHandleRoute(t *testing.T) {
 		t.Fatalf("did not clear claimed route: %#v", plugin)
 	}
 	if len(rejections.rejections) != 0 {
-		t.Fatalf("unexpected rejection: %#v", rejections)
+		t.Fatalf("unexpected status: %#v", rejections)
 	}
 
 	plugin.HandleRoute(watch.Deleted, fooDupe3)
@@ -649,7 +713,7 @@ func TestHandleRoute(t *testing.T) {
 		t.Fatalf("did not clear claimed route: %#v", plugin)
 	}
 	if len(rejections.rejections) != 0 {
-		t.Fatalf("unexpected rejection: %#v", rejections)
+		t.Fatalf("unexpected status: %#v", rejections)
 	}
 
 	//delete
@@ -671,7 +735,7 @@ func TestHandleRoute(t *testing.T) {
 		t.Errorf("did not clear claimed route: %#v", plugin)
 	}
 	if len(rejections.rejections) != 0 {
-		t.Fatalf("unexpected rejection: %#v", rejections)
+		t.Fatalf("unexpected status: %#v", rejections)
 	}
 }
 
@@ -703,7 +767,7 @@ func (p *fakePlugin) Commit() error {
 
 // TestHandleRouteExtendedValidation test route watch events with extended route configuration validation.
 func TestHandleRouteExtendedValidation(t *testing.T) {
-	rejections := &fakeRejections{}
+	rejections := &fakeStatusRecorder{}
 	fake := &fakePlugin{}
 	plugin := controller.NewExtendedValidator(fake, rejections)
 
@@ -731,7 +795,7 @@ func TestHandleRouteExtendedValidation(t *testing.T) {
 	}
 
 	if len(rejections.rejections) > 0 {
-		t.Fatalf("did not expect a recorded rejection: %#v", rejections)
+		t.Fatalf("did not expect a recorded status: %#v", rejections)
 	}
 
 	tests := []struct {
@@ -1026,6 +1090,106 @@ func TestHandleRouteExtendedValidation(t *testing.T) {
 				t.Fatal("expected an error, got none")
 			} else if !tc.errorExpected && err != nil {
 				t.Fatalf("expected no errors, got %v", err)
+			}
+		})
+	}
+}
+
+// TestHandleRouteUpgradeValidation tests the upgrade route validation plugin.
+func TestHandleRouteUpgradeValidation(t *testing.T) {
+	rejections := &fakeStatusRecorder{}
+	fake := &fakePlugin{}
+	plugin := controller.NewUpgradeValidation(fake, rejections)
+
+	tests := []struct {
+		name                               string
+		route                              *routev1.Route
+		unservableInFutureVersionsExpected bool
+	}{
+		{
+			name: "route with no cert should not be unservable in future versions",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					Host: "www.normal.test",
+				},
+			},
+			unservableInFutureVersionsExpected: false,
+		},
+		{
+			name: "route with SHA256 cert should not be unservable in future versions",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					Host: "www.example.com",
+					TLS: &routev1.TLSConfig{
+						Termination:              routev1.TLSTerminationReencrypt,
+						Certificate:              testCertificate,
+						Key:                      testPrivateKey,
+						CACertificate:            testCACertificate,
+						DestinationCACertificate: testDestinationCACertificate,
+					},
+				},
+			},
+			unservableInFutureVersionsExpected: false,
+		},
+		{
+			name: "route with invalid certs should not be unservable in future versions",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					Host: "www.reencrypt.badconfig.test",
+					TLS: &routev1.TLSConfig{
+						Termination:              routev1.TLSTerminationReencrypt,
+						Certificate:              "def",
+						Key:                      "ghi",
+						CACertificate:            "jkl",
+						DestinationCACertificate: "abc",
+					},
+				},
+			},
+			unservableInFutureVersionsExpected: false,
+		},
+		{
+			name: "route with expired cert should not be unservable in future versions",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					Host: "www.edge.expiredcert.test",
+					TLS: &routev1.TLSConfig{
+						Termination:   routev1.TLSTerminationEdge,
+						Certificate:   testExpiredCert,
+						Key:           testExpiredCertKey,
+						CACertificate: testCACertificate,
+					},
+				},
+			},
+			unservableInFutureVersionsExpected: false,
+		},
+		{
+			name: "SHA1 certificate should be unservable in future versions",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					Host: "www.reencrypt.sha1.test",
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationReencrypt,
+						Certificate: testCertificateRsaSha1,
+						Key:         testCertificateRsaSha1Key,
+					},
+				},
+			},
+			unservableInFutureVersionsExpected: true,
+		},
+	}
+
+	uidCount := 0
+	nextUID := func() types.UID {
+		uidCount++
+		return types.UID(fmt.Sprintf("%03d", uidCount))
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.route.UID = nextUID()
+			plugin.HandleRoute(watch.Added, tc.route)
+			unservableInFutureVersions := rejections.isUnservableInFutureVersions(tc.route)
+			if tc.unservableInFutureVersionsExpected != unservableInFutureVersions {
+				t.Fatalf("expected to be unservableInFutureVersions=%t, got unservableInFutureVersions=%t", tc.unservableInFutureVersionsExpected, unservableInFutureVersions)
 			}
 		})
 	}

--- a/pkg/router/writerlease/writerlease.go
+++ b/pkg/router/writerlease/writerlease.go
@@ -250,7 +250,7 @@ func (l *WriterLease) work() bool {
 	if leaseState == Follower {
 		// if we are following, continue to defer work until the lease expires
 		if remaining := leaseExpires.Sub(l.nowFn()); remaining > 0 {
-			log.V(4).Info("follower awaiting lease expiration", "worker", l.name, "leaseTimeRemaining", remaining)
+			log.V(4).Info("follower awaiting lease expiration", "worker", l.name, "key", key, "leaseTimeRemaining", remaining)
 			time.Sleep(remaining)
 			l.queue.Add(key)
 			l.queue.Done(key)
@@ -303,6 +303,7 @@ func (l *WriterLease) nextState(result WorkResult) {
 		case Election, Follower:
 			l.tick = 0
 			l.state = Leader
+			log.V(4).Info("state change: elected to leader", "worker", l.name)
 		}
 		l.expires = l.nowFn().Add(l.maxBackoff)
 	case Release:
@@ -310,6 +311,7 @@ func (l *WriterLease) nextState(result WorkResult) {
 		case Election, Leader:
 			l.tick = 0
 			l.state = Follower
+			log.V(4).Info("state change: demoted to follower", "worker", l.name)
 		case Follower:
 			l.tick++
 		}

--- a/vendor/github.com/openshift/api/route/v1/generated.proto
+++ b/vendor/github.com/openshift/api/route/v1/generated.proto
@@ -213,7 +213,7 @@ message RouteIngress {
 // router.
 message RouteIngressCondition {
   // Type is the type of the condition.
-  // Currently only Admitted.
+  // Currently only Admitted or UnservableInFutureVersions.
   optional string type = 1;
 
   // Status is the status of the condition.

--- a/vendor/github.com/openshift/api/route/v1/route-CustomNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/route/v1/route-CustomNoUpgrade.crd.yaml
@@ -344,7 +344,7 @@ spec:
                               description: Status is the status of the condition. Can be True, False, Unknown.
                               type: string
                             type:
-                              description: Type is the type of the condition. Currently only Admitted.
+                              description: Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.
                               type: string
                       host:
                         description: Host is the host string under which the route is exposed; this value is required

--- a/vendor/github.com/openshift/api/route/v1/route-TechPreviewNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/route/v1/route-TechPreviewNoUpgrade.crd.yaml
@@ -344,7 +344,7 @@ spec:
                               description: Status is the status of the condition. Can be True, False, Unknown.
                               type: string
                             type:
-                              description: Type is the type of the condition. Currently only Admitted.
+                              description: Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.
                               type: string
                       host:
                         description: Host is the host string under which the route is exposed; this value is required

--- a/vendor/github.com/openshift/api/route/v1/route.crd.yaml
+++ b/vendor/github.com/openshift/api/route/v1/route.crd.yaml
@@ -376,7 +376,7 @@ spec:
                               description: Status is the status of the condition. Can be True, False, Unknown.
                               type: string
                             type:
-                              description: Type is the type of the condition. Currently only Admitted.
+                              description: Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.
                               type: string
                           required:
                             - status

--- a/vendor/github.com/openshift/api/route/v1/types.go
+++ b/vendor/github.com/openshift/api/route/v1/types.go
@@ -369,14 +369,16 @@ type RouteIngressConditionType string
 const (
 	// RouteAdmitted means the route is able to service requests for the provided Host
 	RouteAdmitted RouteIngressConditionType = "Admitted"
-	// TODO: add other route condition types
+	// RouteUnservableInFutureVersions indicates that the route is using an unsupported
+	// configuration that may be incompatible with a future version of OpenShift.
+	RouteUnservableInFutureVersions RouteIngressConditionType = "UnservableInFutureVersions"
 )
 
 // RouteIngressCondition contains details for the current condition of this route on a particular
 // router.
 type RouteIngressCondition struct {
 	// Type is the type of the condition.
-	// Currently only Admitted.
+	// Currently only Admitted or UnservableInFutureVersions.
 	Type RouteIngressConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=RouteIngressConditionType"`
 	// Status is the status of the condition.
 	// Can be True, False, Unknown.

--- a/vendor/github.com/openshift/api/route/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/route/v1/zz_generated.swagger_doc_generated.go
@@ -85,7 +85,7 @@ func (RouteIngress) SwaggerDoc() map[string]string {
 
 var map_RouteIngressCondition = map[string]string{
 	"":                   "RouteIngressCondition contains details for the current condition of this route on a particular router.",
-	"type":               "Type is the type of the condition. Currently only Admitted.",
+	"type":               "Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.",
 	"status":             "Status is the status of the condition. Can be True, False, Unknown.",
 	"reason":             "(brief) reason for the condition's last transition, and is usually a machine and human readable constant",
 	"message":            "Human readable message indicating details about last transition.",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -196,7 +196,7 @@ github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 ## explicit
 github.com/munnerz/goautoneg
-# github.com/openshift/api v0.0.0-20230807132801-600991d550ac
+# github.com/openshift/api v0.0.0-20240522145529-93d6bda14341
 ## explicit; go 1.20
 github.com/openshift/api/project/v1
 github.com/openshift/api/route


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/router/pull/555, https://github.com/openshift/router/pull/575, https://github.com/openshift/router/pull/588, https://github.com/openshift/router/pull/587 (in that order). All required to support new Upgrade Validation plugin.

This PR adds support for setting a new status condition type, UnservableInFutureVersions, when a SHA1 cert is detected on a route. It accomplishes this by adding a new plugin, the upgrade validation plugin. This plugin is simple: when a route configuration that is unsupported in the future is detected, it adds a UnservableInFutureVersions status condition to the route. When the problematic configuration is no longer detected, it clears/removes the UnservableInFutureVersions condition.

In order to support updating a new route status condition, the routeRejectionRecorder and associated methods were refactored to be more generic. The writerlease logic used to update route status had to be refactored because the old code made assumptions that only one type of status condition would ever be updated.

It also updates certificates for existing unit tests, as some certificates were SHA1 and incorrectly labeled as expired.

Depends on https://github.com/openshift/api/pull/1751
Related Ingress Operator PR https://github.com/openshift/cluster-ingress-operator/pull/1014

**DELTA FROM https://github.com/openshift/router/pull/555**:
- Dropped [Bump golang 1.21](https://github.com/openshift/router/pull/555/commits/6bec8018ae25d992fcd2ca0e4a9bb77a31651d34) commit as bumping API in 4.15 doesn't require bumping GO to 1.21
- Recreated API commit [Bump openshift/api](https://github.com/openshift/router/pull/555/commits/79d80c4eed809c3603d51981e3c14896d55c2f97) to vendor 4.15 API

**HOW I CREATED THIS PR**:
1. Cherry-Pick the commits in https://github.com/openshift/router/pull/555. https://github.com/openshift/router/commit/7ad7ec1d2390aeeb851874ec1ab7ba0dadbf1158 is the merge commit for this PR:
   ```
   # Get all commits in this merge commit:
   $ git log --oneline  
   7ad7ec1d2390aeeb851874ec1ab7ba0dadbf1158^..7ad7ec1d2390aeeb851874ec1ab7ba0dadbf1158
   7ad7ec1d Merge pull request #555 from gcs278/OCPBUGS-26498-upgradeable-status
   c22b003f Add Upgrade Validation router plugin
   e8b2579d Remove original condition clearing from recordIngressCondition
   e70ba933 Fix recordIngressCondition changed=false issue.
   79d80c4e Bump openshift/api
   6bec8018 Bump golang 1.21
   2c881701 Regenerate certs for unit tests
   ce709bc3 Add .gitleaks.toml

   # Cherry-Pick the first two before `6bec8018 Bump golang 1.21`
   $ git cherry-pick ce709bc3 2c881701
   [...no conflicts...]

   # Create the `Bump openshift/api` commit with the 4.15 API
   $ go get github.com/openshift/api@93d6bda14341f1d18319774367829c3278c171e7
   $ go mod tidy
   $ go mod vendor
   $ git add -A
   $ git commit
   [...message...]

   # Finish cherry-picking commits after `79d80c4e Bump openshift/api`
   $ git cherry-pick e70ba933 e8b2579d c22b003f
   [...no conflicts...]
   ```
2. Cherry-Pick the commit in https://github.com/openshift/router/pull/575. https://github.com/openshift/router/commit/d2d6892ca0bf71574a8f95579dfe7a848a5cf359 is the merge commit for this PR:
   ```
   # Get all commits in this merge commit:
   $ git log --oneline d2d6892ca0bf71574a8f95579dfe7a848a5cf359^..d2d6892ca0bf71574a8f95579dfe7a848a5cf359
   d2d6892c Merge pull request #575 from gcs278/OCPBUGS-26498-upgradeable-status-E2E-args
   0ff5da48  Add Upgrade Validation force arguments for running E2E tests

   # Cherry-Pick the non-merge commit
   $ git cherry-pick 0ff5da48
   [...no conflicts...]
   ```
3. Cherry-Pick the commits in https://github.com/openshift/router/pull/588. https://github.com/openshift/router/commit/b6f7c63c52e6b20fde2549a3c3e69a052ab453cc is the merge commit for this PR:
   ```
   # Get all commits in this merge commit:
   $ git log --oneline b6f7c63c52e6b20fde2549a3c3e69a052ab453cc^..b6f7c63c52e6b20fde2549a3c3e69a052ab453cc
   b6f7c63c Merge pull request #588 from gcs278/efficient-contention-comparison
   44f217fe Make ingressConditionsEqual more efficient
   3f171901 Add log for attempting to update route status
   66eb2237 Add verbose logging for plugin chain execution
   efcba1b6 Log election results in writerlease

   # Cherry-Pick the commits
   $ git cherry-pick efcba1b6 66eb2237 3f171901 44f217fe
   [...no conflicts...]
   ```
4. Cherry-Pick the commits in https://github.com/openshift/router/pull/587. https://github.com/openshift/router/commit/5610ac80b43350131694dddf42660e8cc844389d is the merge commit for this PR:
   ```
   # Get all commits in this merge commit:
   $ git log --oneline 5610ac80b43350131694dddf42660e8cc844389d^..5610ac80b43350131694dddf42660e8cc844389d
   5610ac80 Merge pull request #587 from gcs278/efficient-route-status-updates
   13ab1dd8 Optimize Upgrade Validation plugin by skipping unnecessary changes

   # Cherry-Pick the 13ab1dd8 commit
   $ git cherry-pick 13ab1dd8
   [...no conflicts...]
   ```