### PR TITLE
OCPBUGS-26498: Optimize Upgrade Validation plugin by skipping unnecessary changes

### DIFF
--- a/pkg/router/controller/status_test.go
+++ b/pkg/router/controller/status_test.go
@@ -1298,6 +1298,55 @@ func TestStatusUnservableInFutureVersions(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                       "update incorrect unservableInFutureVersions condition",
+			routerName:                 "test",
+			unservableInFutureVersions: true,
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
+				Spec:       routev1.RouteSpec{Host: "route1.test.local"},
+				Status: routev1.RouteStatus{Ingress: []routev1.RouteIngress{{
+					Host:       "route1.test.local",
+					RouterName: "test",
+					Conditions: []routev1.RouteIngressCondition{{
+						Type:    routev1.RouteUnservableInFutureVersions,
+						Status:  corev1.ConditionTrue,
+						Reason:  "wrong reason",
+						Message: "wrong message",
+					}},
+				}},
+				},
+			},
+			expectedRoute: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
+				Spec:       routev1.RouteSpec{Host: "route1.test.local"},
+				Status: routev1.RouteStatus{Ingress: []routev1.RouteIngress{{
+					Host:       "route1.test.local",
+					RouterName: "test",
+					Conditions: []routev1.RouteIngressCondition{
+						unservableInFutureVersionsTrueCondition,
+					},
+				}},
+				},
+			},
+		},
+		{
+			name:                       "no update for incorrect host name with unservableInFutureVersions condition",
+			routerName:                 "test",
+			unservableInFutureVersions: true,
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
+				Spec:       routev1.RouteSpec{Host: "route1.test.local"},
+				Status: routev1.RouteStatus{Ingress: []routev1.RouteIngress{{
+					Host:       "foo.test.local",
+					RouterName: "test",
+					Conditions: []routev1.RouteIngressCondition{
+						unservableInFutureVersionsTrueCondition,
+					},
+				}},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Both performIngressConditionUpdate and performIngressConditionRemoval functions add tasks to the writerlease queue even if no work needed to be done. This commit optimizes the Upgrade Validation plugin by ensuring that tasks for updating UnservableInFutureVersions are only added to the queue when changes are required.

This reduction in unnecessary work significantly lowers the frequency of lease extensions. Previously, excessive lease extensions could delay route status updates under certain conditions, such as during temporary contention periods
where a router pod gets demoted to a follower. After the contention is resolved, the pod’s subsequent retry will be delayed more than necessary.

Additionally, this update provides a clearer indication of when updates are actually required, but have been completed by another router pod. The prior logic did not clearly distinguish between unnecessary updates and updates that were completed by another pod.

The selective updates are only added to the interface used by Upgrade Validation plugin to avoid perturbing existing Admitted condition logic. This means nominal clusters without SHA1 routes should not be impacted by the Upgrade
Validation plugin, minimizing the risk associated with its introduction.

Fixes [TestRouteAdmissionPolicy Flake](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-ingress-operator/1049/pull-ci-openshift-cluster-ingress-operator-master-e2e-gcp-operator/1783251298133479424) by reducing the number of unnecessary lease extensions. 