### PR TITLE
OCPBUGS-26498: Make ingressConditionsEqual more efficient

### DIFF
--- a/pkg/router/controller/contention.go
+++ b/pkg/router/controller/contention.go
@@ -7,9 +7,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-
 	routev1 "github.com/openshift/api/route/v1"
 )
 
@@ -258,15 +255,36 @@ func ingressEqual(a, b *routev1.RouteIngress) bool {
 }
 
 // ingressConditionsEqual determines if the route ingress conditions are equal,
-// while ignoring LastTransitionTime
+// while ignoring LastTransitionTime.
 func ingressConditionsEqual(a, b []routev1.RouteIngressCondition) bool {
-	conditionCmpOpts := []cmp.Option{
-		cmpopts.EquateEmpty(),
-		cmpopts.IgnoreFields(routev1.RouteIngressCondition{}, "LastTransitionTime"),
-		cmpopts.SortSlices(func(a, b routev1.RouteIngressCondition) bool { return a.Type < b.Type }),
+	if len(a) != len(b) {
+		return false
 	}
 
-	return cmp.Equal(a, b, conditionCmpOpts...)
+	// Compare each condition in a with every condition in b.
+	// Given the current max of only two conditions, nested loops are more efficient than sorting.
+	for i := 0; i < len(a); i++ {
+		matchFound := false
+		for j := 0; j < len(b); j++ {
+			if conditionsEqual(&a[i], &b[j]) {
+				matchFound = true
+				break
+			}
+		}
+		if !matchFound {
+			return false
+		}
+	}
+
+	return true
+}
+
+// conditionsEqual compares two RouteIngressConditions, ignoring LastTransitionTime.
+func conditionsEqual(a, b *routev1.RouteIngressCondition) bool {
+	return a.Type == b.Type &&
+		a.Status == b.Status &&
+		a.Reason == b.Reason &&
+		a.Message == b.Message
 }
 
 func ingressConditionTouched(ingress *routev1.RouteIngress) *metav1.Time {

--- a/pkg/router/controller/extended_validator.go
+++ b/pkg/router/controller/extended_validator.go
@@ -45,6 +45,7 @@ func (p *ExtendedValidator) HandleEndpoints(eventType watch.EventType, endpoints
 
 // HandleRoute processes watch events on the Route resource.
 func (p *ExtendedValidator) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: ExtendedValidator")
 	// Check if previously seen route and its Spec is unchanged.
 	routeName := routeNameKey(route)
 	if err := routeapihelpers.ExtendedValidateRoute(route).ToAggregate(); err != nil {

--- a/pkg/router/controller/host_admitter.go
+++ b/pkg/router/controller/host_admitter.go
@@ -126,6 +126,7 @@ func (p *HostAdmitter) HandleEndpoints(eventType watch.EventType, endpoints *kap
 
 // HandleRoute processes watch events on the Route resource.
 func (p *HostAdmitter) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: HostAdmitter")
 	if p.allowedNamespaces != nil && !p.allowedNamespaces.Has(route.Namespace) {
 		// Ignore routes we don't need to "service" due to namespace
 		// restrictions (ala for sharding).

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -233,6 +233,8 @@ func performIngressConditionRemoval(action string, lease writerlease.Lease, trac
 // attempts to update the route status and, depending on the outcome, clears the tracker if necessary. It returns the
 // writerlease's WorkResult and a boolean flag indicating whether the writerlease should retry.
 func handleRouteStatusUpdate(ctx context.Context, action string, oc client.RoutesGetter, route *routev1.Route, latest *routev1.RouteIngress, tracker ContentionTracker) (workResult writerlease.WorkResult, retry bool) {
+	log.V(4).Info("attempting to update route status")
+
 	switch _, err := oc.Routes(route.Namespace).UpdateStatus(ctx, route, metav1.UpdateOptions{}); {
 	case err == nil:
 		log.V(4).Info("updated route status", "action", action, "namespace", route.Namespace, "name", route.Name)

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -93,6 +93,7 @@ var nowFn = getRfc3339Timestamp
 
 // HandleRoute attempts to admit the provided route on watch add / modifications.
 func (a *StatusAdmitter) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: StatusAdmitter")
 	switch eventType {
 	case watch.Added, watch.Modified:
 		performIngressConditionUpdate("admit", a.lease, a.tracker, a.client, a.lister, route, a.routerName, a.routerCanonicalHostname, routev1.RouteIngressCondition{

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -88,6 +88,7 @@ func (p *UniqueHost) HandleNode(eventType watch.EventType, node *kapi.Node) erro
 // determines which component needs to be recalculated (which template) and then does so
 // on demand.
 func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: UniqueHost")
 	if p.allowedNamespaces != nil && !p.allowedNamespaces.Has(route.Namespace) {
 		return nil
 	}

--- a/pkg/router/controller/upgrade_validation.go
+++ b/pkg/router/controller/upgrade_validation.go
@@ -53,6 +53,7 @@ func (p *UpgradeValidation) HandleEndpoints(eventType watch.EventType, endpoints
 // It checks if the route is upgradeable to a future version of OpenShift
 // and sets UnservableInFutureVersions condition if needed.
 func (p *UpgradeValidation) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: UpgradeValidation")
 	routeName := routeNameKey(route)
 
 	// Force add and force removal logic for debugging and testing.

--- a/pkg/router/template/configmanager/haproxy/blueprint_plugin.go
+++ b/pkg/router/template/configmanager/haproxy/blueprint_plugin.go
@@ -22,6 +22,7 @@ func NewBlueprintPlugin(cm templaterouter.ConfigManager) *BlueprintPlugin {
 
 // HandleRoute processes watch events on blueprint routes.
 func (p *BlueprintPlugin) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: BlueprintPlugin")
 	switch eventType {
 	case watch.Added, watch.Modified:
 		return p.manager.AddBlueprint(route)

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -217,6 +217,7 @@ func (p *TemplatePlugin) HandleNode(eventType watch.EventType, node *kapi.Node) 
 // determines which component needs to be recalculated (which template) and then does so
 // on demand.
 func (p *TemplatePlugin) HandleRoute(eventType watch.EventType, route *routev1.Route) error {
+	log.V(10).Info("HandleRoute: TemplatePlugin")
 	switch eventType {
 	case watch.Added, watch.Modified:
 		p.Router.AddRoute(route)

--- a/pkg/router/writerlease/writerlease.go
+++ b/pkg/router/writerlease/writerlease.go
@@ -250,7 +250,7 @@ func (l *WriterLease) work() bool {
 	if leaseState == Follower {
 		// if we are following, continue to defer work until the lease expires
 		if remaining := leaseExpires.Sub(l.nowFn()); remaining > 0 {
-			log.V(4).Info("follower awaiting lease expiration", "worker", l.name, "leaseTimeRemaining", remaining)
+			log.V(4).Info("follower awaiting lease expiration", "worker", l.name, "key", key, "leaseTimeRemaining", remaining)
 			time.Sleep(remaining)
 			l.queue.Add(key)
 			l.queue.Done(key)
@@ -303,6 +303,7 @@ func (l *WriterLease) nextState(result WorkResult) {
 		case Election, Follower:
 			l.tick = 0
 			l.state = Leader
+			log.V(4).Info("state change: elected to leader", "worker", l.name)
 		}
 		l.expires = l.nowFn().Add(l.maxBackoff)
 	case Release:
@@ -310,6 +311,7 @@ func (l *WriterLease) nextState(result WorkResult) {
 		case Election, Leader:
 			l.tick = 0
 			l.state = Follower
+			log.V(4).Info("state change: demoted to follower", "worker", l.name)
 		case Follower:
 			l.tick++
 		}


### PR DESCRIPTION
We found that the router's contention tracker was slower after updates were made to support the UnservableInFutureVersions condition. This lag sometimes causes routers to update the route status before the contention tracker detected an update, leading to the per-route contention logic not activating.
    
In such scenarios, the maxContentions logic eventually activates, temporarily preventing the router from making any updates to the routes. This commit improves the efficiency of the ingressConditionsEqual function to help mitigate this type of issues.

Related [slack thread](https://redhat-internal.slack.com/archives/CBWMXQJKD/p1714425622177519).

### Current PR Benchmark Results (Nested Loops):
```
$ go test -bench=. -run=Benchmark_ingressConditionsEqual ./... -benchtime=10s -benchmem
[...] 
goos: linux
goarch: amd64
pkg: github.com/openshift/router/pkg/router/controller
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
Benchmark_ingressConditionsEqual/single-12         		1000000000	         4.936 ns/op	       0 B/op	       0 allocs/op
Benchmark_ingressConditionsEqual/mismatch_length-12         	1000000000	         2.449 ns/op	       0 B/op	       0 allocs/op
Benchmark_ingressConditionsEqual/double-12                  	433452776	        27.60 ns/op	       0 B/op	       0 allocs/op
PASS
```

### Using `sort.Slice` Benchmark Results (Previous PR Revision https://github.com/openshift/router/pull/588/commits/b1bea4d90af236e6ede0934ba6c41598f8e9827f):
```
$ go test -bench=. -run=Benchmark_ingressConditionsEqual ./... -benchtime=10s -benchmem
[...]
goos: linux
goarch: amd64
pkg: github.com/openshift/router/pkg/router/controller
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
Benchmark_ingressConditionsEqual/single-12         		88920192	       121.0 ns/op	      48 B/op	       2 allocs/op
Benchmark_ingressConditionsEqual/mismatch_length-12         	1000000000	         2.352 ns/op	       0 B/op	       0 allocs/op
Benchmark_ingressConditionsEqual/double-12                  	30747393	       379.5 ns/op	     304 B/op	       6 allocs/op
PASS
```

### Post-https://github.com/openshift/router/pull/555 Benchmark Results (Not this PR):
```
$ go test -bench=. -run=Benchmark_ingressConditionsEqual ./... -benchtime=10s -benchmem
[...]
goos: linux
goarch: amd64
pkg: github.com/openshift/router/pkg/router/controller
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
Benchmark_ingressConditionsEqual/single-12         	  	  226267	     52844 ns/op	    7878 B/op	     251 allocs/op
Benchmark_ingressConditionsEqual/mismatch_length-12         	   84859	    140895 ns/op	   18302 B/op	     674 allocs/op
Benchmark_ingressConditionsEqual/double-12                  	   68632	    174946 ns/op	   23050 B/op	     863 allocs/op
PASS
````


### Pre-https://github.com/openshift/router/pull/555 Benchmark Results:
```
$ go test -bench=. -run=Benchmark_ingressConditionsEqual ./... -benchtime=10s -benchmem
[...]
goos: linux
goarch: amd64
pkg: github.com/openshift/router/pkg/router/controller
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
Benchmark_ingressConditionsEqual/single-12         	 	 7699280	      1549 ns/op	    1008 B/op	      19 allocs/op
Benchmark_ingressConditionsEqual/mismatch_length-12         	 2992860	      3983 ns/op	    2336 B/op	      35 allocs/op
Benchmark_ingressConditionsEqual/double-12                  	 2984841	      4028 ns/op	    2336 B/op	      35 allocs/op
PASS
```

Also, I have included some trivial logging improvements that will help debugging racy conditions.