### PR TITLE
OCPBUGS-29894: Check if CRLs are downloaded when determining ready status

### DIFF
--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -635,6 +635,7 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 		if err != nil {
 			return err
 		}
+		checkCRLs := metrics.CRLsUpdated()
 		checkController := metrics.ControllerLive()
 		liveChecks := []healthz.HealthChecker{checkController}
 		if !(isTrue(env("ROUTER_BIND_PORTS_BEFORE_SYNC", ""))) {
@@ -691,7 +692,7 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 				Name:            o.RouterName,
 			},
 			LiveChecks:  liveChecks,
-			ReadyChecks: []healthz.HealthChecker{checkBackend, checkSync, metrics.ProcessRunning(stopCh)},
+			ReadyChecks: []healthz.HealthChecker{checkBackend, checkSync, metrics.ProcessRunning(stopCh), checkCRLs},
 		}
 
 		if tlsConfig, err := makeTLSConfig(30 * time.Second); err != nil {

--- a/pkg/router/crl/crl.go
+++ b/pkg/router/crl/crl.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	logf "github.com/openshift/router/log"
@@ -66,6 +67,11 @@ var (
 	CRLFilename = filepath.Join(mtlsLatestSymlink, crlBasename)
 	// CABundleFilename is the fully qualified path to the currently in use CA bundle.
 	CABundleFilename = filepath.Join(mtlsLatestSymlink, caBundleBasename)
+	// crlsUpdated is true when all CRLs have been successfully updated, and false when there are missing CRLs.
+	// You must take crlsMutex before using crlsUpdated.
+	crlsUpdated = false
+	// crlsMutex protects crlsUpdated.
+	crlsMutex = sync.Mutex{}
 )
 
 // authorityKeyIdentifier is a certificate's authority key identifier.
@@ -143,6 +149,9 @@ func ManageCRLs(caBundleFilename string, caUpdateChannel <-chan struct{}, update
 			log.Error(err, "failed to parse CA bundle", "CA bundle filename", caBundleFilename)
 			nextUpdate = time.Now().Add(errorBackoffTime)
 		}
+		if !shouldHaveCRLs {
+			SetCRLsUpdated(true)
+		}
 		for {
 			updated := false
 			if nextUpdate.IsZero() {
@@ -175,8 +184,9 @@ func ManageCRLs(caBundleFilename string, caUpdateChannel <-chan struct{}, update
 				nextUpdate = time.Now().Add(errorBackoffTime)
 				continue
 			}
-			// After successfully updating the CRL file, reset caUpdated
+			// After successfully updating the CRL file, reset caUpdated and mark CRLs as updated
 			caUpdated = false
+			SetCRLsUpdated(true)
 			if updated {
 				updateCallback(shouldHaveCRLs)
 			}
@@ -505,4 +515,18 @@ func makeStagingDirectory() (string, error) {
 		return "", err
 	}
 	return stagingDirName, nil
+}
+
+// GetCRLsUpdated returns true if all necessary CRLs have been downloaded.
+func GetCRLsUpdated() bool {
+	crlsMutex.Lock()
+	defer crlsMutex.Unlock()
+	return crlsUpdated
+}
+
+// SetCRLsUpdated sets crlsUpdated to the specified value, indicating whether all necessary CRLs have been downloaded.
+func SetCRLsUpdated(value bool) {
+	crlsMutex.Lock()
+	defer crlsMutex.Unlock()
+	crlsUpdated = value
 }

--- a/pkg/router/crl/crl.go
+++ b/pkg/router/crl/crl.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	logf "github.com/openshift/router/log"
@@ -66,6 +67,11 @@ var (
 	CRLFilename = filepath.Join(mtlsLatestSymlink, crlBasename)
 	// CABundleFilename is the fully qualified path to the currently in use CA bundle.
 	CABundleFilename = filepath.Join(mtlsLatestSymlink, caBundleBasename)
+	// crlsUpdated is true when all CRLs have been successfully updated, and false when there are missing CRLs.
+	// You must take crlsMutex before using crlsUpdated.
+	crlsUpdated = false
+	// crlsMutex protects crlsUpdated.
+	crlsMutex = sync.Mutex{}
 )
 
 // authorityKeyIdentifier is a certificate's authority key identifier.
@@ -142,6 +148,8 @@ func ManageCRLs(caBundleFilename string, caUpdateChannel <-chan struct{}, update
 		if err != nil {
 			log.Error(err, "failed to parse CA bundle", "CA bundle filename", caBundleFilename)
 			nextUpdate = time.Now().Add(errorBackoffTime)
+		} else if !shouldHaveCRLs {
+			SetCRLsUpdated(true)
 		}
 		for {
 			updated := false
@@ -175,8 +183,9 @@ func ManageCRLs(caBundleFilename string, caUpdateChannel <-chan struct{}, update
 				nextUpdate = time.Now().Add(errorBackoffTime)
 				continue
 			}
-			// After successfully updating the CRL file, reset caUpdated
+			// After successfully updating the CRL file, reset caUpdated and mark CRLs as updated
 			caUpdated = false
+			SetCRLsUpdated(true)
 			if updated {
 				updateCallback(shouldHaveCRLs)
 			}
@@ -505,4 +514,18 @@ func makeStagingDirectory() (string, error) {
 		return "", err
 	}
 	return stagingDirName, nil
+}
+
+// GetCRLsUpdated returns true if all necessary CRLs have been downloaded.
+func GetCRLsUpdated() bool {
+	crlsMutex.Lock()
+	defer crlsMutex.Unlock()
+	return crlsUpdated
+}
+
+// SetCRLsUpdated sets crlsUpdated to the specified value, indicating whether all necessary CRLs have been downloaded.
+func SetCRLsUpdated(value bool) {
+	crlsMutex.Lock()
+	defer crlsMutex.Unlock()
+	crlsUpdated = value
 }

--- a/pkg/router/metrics/health.go
+++ b/pkg/router/metrics/health.go
@@ -12,6 +12,7 @@ import (
 
 	"k8s.io/apiserver/pkg/server/healthz"
 
+	"github.com/openshift/router/pkg/router/crl"
 	"github.com/openshift/router/pkg/router/metrics/probehttp"
 	templateplugin "github.com/openshift/router/pkg/router/template"
 )
@@ -73,6 +74,15 @@ func ControllerLive() healthz.HealthChecker {
 		return nil
 	})
 
+}
+
+func CRLsUpdated() healthz.HealthChecker {
+	return healthz.NamedCheck("crls-updated", func(r *http.Request) error {
+		if !crl.GetCRLsUpdated() {
+			return fmt.Errorf("missing CRLs")
+		}
+		return nil
+	})
 }
 
 // ProxyProtocolHTTPBackendAvailable returns a healthz check that verifies a backend supporting

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -480,6 +480,8 @@ func (r *templateRouter) watchMutualTLSCert() error {
 			log.V(0).Error(err, "failed to establish watch on mTLS certificate directory")
 			return nil
 		}
+	} else {
+		crl.SetCRLsUpdated(true)
 	}
 	return nil
 }

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -454,32 +454,36 @@ func (r *templateRouter) writeDefaultCert() error {
 // mutual TLS and reloads the router if the directory contents change.
 func (r *templateRouter) watchMutualTLSCert() error {
 	caPath := os.Getenv("ROUTER_MUTUAL_TLS_AUTH_CA")
-	if len(caPath) != 0 {
-		r.haveClientCA = true
-		if err := crl.InitMTLSDirectory(caPath); err != nil {
-			return err
-		}
-		haveCRLs, err := crl.CABundleHasCRLs(caPath)
-		if err != nil {
-			log.V(0).Error(err, "failed to parse CA Bundle", "path", caPath)
-			return err
-		}
+	// If there are no CAs provided, there are no CRLs to download.
+	if len(caPath) == 0 {
+		crl.SetCRLsUpdated(true)
+		return nil
+	}
+
+	r.haveClientCA = true
+	if err := crl.InitMTLSDirectory(caPath); err != nil {
+		return err
+	}
+	haveCRLs, err := crl.CABundleHasCRLs(caPath)
+	if err != nil {
+		log.V(0).Error(err, "failed to parse CA Bundle", "path", caPath)
+		return err
+	}
+	r.haveCRLs = haveCRLs
+	caUpdateChannel := make(chan struct{})
+	crlReloadFn := func(haveCRLs bool) {
 		r.haveCRLs = haveCRLs
-		caUpdateChannel := make(chan struct{})
-		crlReloadFn := func(haveCRLs bool) {
-			r.haveCRLs = haveCRLs
-			log.V(0).Info("reloading to get updated client CA CRL", "name", crl.CRLFilename, "have CRLs", haveCRLs)
-			r.rateLimitedCommitFunction.RegisterChange()
-		}
-		crl.ManageCRLs(caPath, caUpdateChannel, crlReloadFn)
-		caReloadFn := func() {
-			// Send signal to CRL management goroutine that client CA has been changed
-			caUpdateChannel <- struct{}{}
-		}
-		if err := r.watchVolumeMountDir(filepath.Dir(caPath), caReloadFn); err != nil {
-			log.V(0).Error(err, "failed to establish watch on mTLS certificate directory")
-			return nil
-		}
+		log.V(0).Info("reloading to get updated client CA CRL", "name", crl.CRLFilename, "have CRLs", haveCRLs)
+		r.rateLimitedCommitFunction.RegisterChange()
+	}
+	crl.ManageCRLs(caPath, caUpdateChannel, crlReloadFn)
+	caReloadFn := func() {
+		// Send signal to CRL management goroutine that client CA has been changed
+		caUpdateChannel <- struct{}{}
+	}
+	if err := r.watchVolumeMountDir(filepath.Dir(caPath), caReloadFn); err != nil {
+		log.V(0).Error(err, "failed to establish watch on mTLS certificate directory")
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Require all CRLs to be downloaded before the router can report that it's ready. This prevents forwarding requests to a router until it's ready to handle mTLS.

This fixes OCPBUGS-29894