### PR TITLE
WIP: NE-906: test dynamic config manager

### DIFF
--- a/hack/Dockerfile.debug
+++ b/hack/Dockerfile.debug
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 RUN yum install -y https://github.com/frobware/haproxy-builds/raw/master/rhaos-4.16-rhel-9/haproxy28-2.8.5-1.rhaos4.16.el9.x86_64.rpm
 RUN haproxy -vv
-RUN INSTALL_PKGS="rsyslog procps-ng util-linux socat" && \
+RUN INSTALL_PKGS="rsyslog procps-ng util-linux socat diffutils" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/hack/Dockerfile.debug
+++ b/hack/Dockerfile.debug
@@ -19,4 +19,4 @@ WORKDIR /var/lib/haproxy/conf
 ENV XDG_CONFIG_HOME=/tmp \
     TEMPLATE_FILE=/var/lib/haproxy/conf/haproxy-config.template \
     RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy
-ENTRYPOINT ["/usr/bin/openshift-router", "--v=4"]
+ENTRYPOINT ["/usr/bin/openshift-router", "--v=2"]

--- a/hack/Makefile.debug
+++ b/hack/Makefile.debug
@@ -3,7 +3,7 @@
 export GOOS=linux
 
 REGISTRY ?= quay.io
-IMAGE ?= openshift/openshift-router
+IMAGE ?= amcdermo/openshift-router-ne906-release-416
 TAG ?= latest
 IMAGEBUILDER ?= podman
 

--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -73,6 +73,55 @@ if [ -n "${ROUTER_SHUTDOWN-}" ]; then
   exit 1
 fi
 
+# Base directory for reloads
+track_reloads_dir="/tmp/reloads"
+
+# Directories for storing snapshots, unified diffs, and traditional diffs
+snapshot_dir="${track_reloads_dir}/snapshots"
+unified_diff_dir="${track_reloads_dir}/changes/unified"
+traditional_diff_dir="${track_reloads_dir}/changes/traditional"
+
+# Generate a timestamp
+current_date=$(date "+%Y-%m-%d_%H%M%S")
+
+mkdir -p "$snapshot_dir"
+mkdir -p "$unified_diff_dir"
+mkdir -p "$traditional_diff_dir"
+
+# Snapshot directory for this change
+current_snapshot_dir="${snapshot_dir}/${current_date}"
+mkdir -p "$current_snapshot_dir"
+
+# Save snapshots if the previous configuration exists
+if [ -f "${track_reloads_dir}/haproxy.config.last" ]; then
+    cp "${track_reloads_dir}/haproxy.config.last" "${current_snapshot_dir}/haproxy.config.prev"
+    cp "$config_file" "${current_snapshot_dir}/haproxy.config.curr"
+    diff -u "${track_reloads_dir}/haproxy.config.last" "$config_file" > "${unified_diff_dir}/${current_date}.diff"
+    diff "${track_reloads_dir}/haproxy.config.last" "$config_file" > "${traditional_diff_dir}/${current_date}.diff"
+fi
+
+# Back up the current configuration file
+cp "$config_file" "${track_reloads_dir}/haproxy.config.last"
+
+prune_dir() {
+    local dir=$1
+    pushd "$dir" > /dev/null 2>&1 || { echo "Failed to enter directory $dir"; return; }
+    num_files=$(ls -1 | wc -l)
+    num_delete=$((num_files - 250))
+
+    if [ "$num_delete" -gt 0 ]; then
+        # Delete the oldest files if there are more files than the target
+        ls -1tr | head -n "$num_delete" | xargs -I {} rm -rf "{}"
+    fi
+
+    popd > /dev/null 2>&1
+}
+
+# Prune snapshots, unified diffs, and traditional diffs directories
+prune_dir "$snapshot_dir"
+prune_dir "$unified_diff_dir"
+prune_dir "$traditional_diff_dir"
+
 reload_status=0
 if [ -n "$old_pids" ]; then
   /usr/sbin/haproxy -f $config_file -p $pid_file -x /var/lib/haproxy/run/haproxy.sock -sf $old_pids

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -838,19 +838,14 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 
 	select {
 	case <-stopCh:
-		// 45s is the default interval that almost all cloud load balancers require to take an unhealthy
-		// endpoint out of rotation.
-		delay := getIntervalFromEnv("ROUTER_GRACEFUL_SHUTDOWN_DELAY", 45)
+		delay := getIntervalFromEnv("ROUTER_GRACEFUL_SHUTDOWN_DELAY", 0)
 		log.Info(fmt.Sprintf("Shutdown requested, waiting %s for new connections to cease", delay))
-		time.Sleep(delay)
 		log.Info("Instructing the template router to terminate")
 		if err := templatePlugin.Stop(); err != nil {
 			log.Error(err, "Router did not shut down cleanly")
 		} else {
 			log.Info("Shutdown complete, exiting")
 		}
-		// wait one second to let any remaining actions settle
-		time.Sleep(time.Second)
 	}
 	return nil
 }

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -742,7 +742,7 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 		}
 		cfgManager = haproxyconfigmanager.NewHAProxyConfigManager(cmopts)
 		if len(o.BlueprintRouteNamespace) > 0 {
-			blueprintPlugin = haproxyconfigmanager.NewBlueprintPlugin(cfgManager)
+			//blueprintPlugin = haproxyconfigmanager.NewBlueprintPlugin(cfgManager)
 		}
 	}
 

--- a/pkg/router/metrics/health.go
+++ b/pkg/router/metrics/health.go
@@ -111,7 +111,7 @@ func ProxyProtocolHTTPBackendAvailable(u *url.URL) healthz.HealthChecker {
 			log.V(4).Info("probe failed", "url", u.String(), "response", res)
 			return errBackend
 		}
-		log.V(4).Info("probe succeeded", "url", u.String(), "response", res)
+		log.V(5).Info("probe succeeded", "url", u.String(), "StatusCode", res.StatusCode, "Status", res.Status)
 		return nil
 	})
 }

--- a/pkg/router/template/configmanager/haproxy/backend.go
+++ b/pkg/router/template/configmanager/haproxy/backend.go
@@ -170,7 +170,7 @@ func (b *Backend) Refresh() error {
 
 // SetRoutingKey sets the cookie routing key for the haproxy backend.
 func (b *Backend) SetRoutingKey(k string) error {
-	log.V(4).Info("setting routing key", "backend", b.name)
+	log.V(2).Info("setting routing key", "backend", b.name)
 
 	cmd := fmt.Sprintf("set dynamic-cookie-key backend %s %s", b.name, k)
 	if err := b.executeCommand(cmd); err != nil {
@@ -217,13 +217,13 @@ func (b *Backend) Disable() error {
 
 // EnableServer enables serving traffic with a haproxy backend server.
 func (b *Backend) EnableServer(name string) error {
-	log.V(4).Info("enabling server with ready state", "server", name)
+	log.V(2).Info("enabling server with ready state", "server", name)
 	return b.UpdateServerState(name, BackendServerStateReady)
 }
 
 // DisableServer stops serving traffic for a haproxy backend server.
 func (b *Backend) DisableServer(name string) error {
-	log.V(4).Info("disabling server with maint state", "server", name)
+	log.V(2).Info("disabling server with maint state", "server", name)
 	return b.UpdateServerState(name, BackendServerStateMaint)
 }
 

--- a/pkg/router/template/configmanager/haproxy/client.go
+++ b/pkg/router/template/configmanager/haproxy/client.go
@@ -51,7 +51,7 @@ func NewClient(socketName string, timeout int) *Client {
 // RunCommand executes a haproxy dynamic config API command and if present
 // converts the response as desired.
 func (c *Client) RunCommand(cmd string, converter Converter) ([]byte, error) {
-	log.V(4).Info("running haproxy command", "command", cmd)
+	log.V(2).Info("running haproxy command", "command", cmd)
 	buffer, err := c.runCommandWithRetries(cmd, maxRetries)
 	if err != nil {
 		log.V(0).Info("haproxy dynamic config API command failed", "command", cmd, "error", err)
@@ -59,7 +59,7 @@ func (c *Client) RunCommand(cmd string, converter Converter) ([]byte, error) {
 	}
 
 	response := buffer.Bytes()
-	log.V(4).Info("haproxy command returned", "response", string(response))
+	log.V(2).Info("haproxy command returned", "response", string(response))
 	if converter == nil {
 		return response, nil
 	}
@@ -191,7 +191,7 @@ func (c *Client) runCommandWithRetries(cmd string, limit int) (*bytes.Buffer, er
 	})
 
 	if cmdErr != nil {
-		log.V(4).Info("failed attempt to run haproxy command", "command", cmd, "attempts", n, "error", cmdErr)
+		log.V(2).Info("failed attempt to run haproxy command", "command", cmd, "attempts", n, "error", cmdErr)
 	}
 
 	return buffer, cmdErr

--- a/pkg/router/template/configmanager/haproxy/client.go
+++ b/pkg/router/template/configmanager/haproxy/client.go
@@ -59,6 +59,7 @@ func (c *Client) RunCommand(cmd string, converter Converter) ([]byte, error) {
 	}
 
 	response := buffer.Bytes()
+
 	log.V(2).Info("haproxy command returned", "response", string(response))
 	if converter == nil {
 		return response, nil

--- a/pkg/router/template/configmanager/haproxy/manager.go
+++ b/pkg/router/template/configmanager/haproxy/manager.go
@@ -162,7 +162,7 @@ func NewHAProxyConfigManager(options templaterouter.ConfigManagerOptions) *hapro
 	return &haproxyConfigManager{
 		connectionInfo:         options.ConnectionInfo,
 		commitInterval:         options.CommitInterval,
-		blueprintRoutes:        buildBlueprintRoutes(options.BlueprintRoutes, options.ExtendedValidation),
+		blueprintRoutes:        nil, //buildBlueprintRoutes(options.BlueprintRoutes, options.ExtendedValidation),
 		blueprintRoutePoolSize: options.BlueprintRoutePoolSize,
 		maxDynamicServers:      options.MaxDynamicServers,
 		wildcardRoutesAllowed:  options.WildcardRoutesAllowed,

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -558,6 +558,17 @@ func (r *templateRouter) commitAndReload() error {
 		r.dynamicConfigManager.Notify(RouterEventReloadEnd)
 	}
 
+	fmt.Printf(`
+ _________
+< RELOAD! >
+ ---------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+`)
+
 	return nil
 }
 


### PR DESCRIPTION
- reload-haproxy: Track changes with diff and snapshots
- pkg/router/metrics/health: log success at level 5
- Add obvious reload indicator in commitAndReload function
- hack/Makefile.debug: record the image ref for debugging [NE-906](https://issues.redhat.com//browse/NE-906)
- Modify router shutdown delay for debugging
- hack/Dockerfile.debug: set openshift-router log level to 2
- pkg/router/template/configmanager/haproxy/backend: log.V(4) => log.V(2)
- Disable blueprint routes
