### PR TITLE
[WIP] OCPBUGS-27741: Properly handle route path while rewriting

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -683,9 +683,9 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
         {{- with $pathRewriteTarget := firstMatch $pathRewriteTargetPattern (index $cfg.Annotations "haproxy.router.openshift.io/rewrite-target") }}
   # Path rewrite target
           {{- if eq $pathRewriteTarget "/" }}
-  http-request replace-path ^{{ $cfg.Path }}/?(.*)$ '{{ processRewriteTarget $pathRewriteTarget }}'
+  http-request replace-path '^{{ processRewritePath $cfg.Path }}/?(.*)$' '{{ processRewriteTarget $pathRewriteTarget }}'
           {{- else }}
-  http-request replace-path ^{{ $cfg.Path }}(.*)$ '{{ processRewriteTarget $pathRewriteTarget }}'
+  http-request replace-path '^{{ processRewritePath $cfg.Path }}(.*)$' '{{ processRewriteTarget $pathRewriteTarget }}'
           {{- end }}
         {{- end }}{{/* rewrite target */}}
   

--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -415,5 +415,6 @@ var helperFunctions = template.FuncMap{
 	"clipHAProxyTimeoutValue": clipHAProxyTimeoutValue, //clips extrodinarily high timeout values to be below the maximum allowed timeout value
 	"parseIPList":             parseIPList,             //parses the list of IPs/CIDRs (IPv4/IPv6)
 
-	"processRewriteTarget": rewritetarget.SanitizeInput, //sanitizes `haproxy.router.openshift.io/rewrite-target` annotation
+	"processRewriteTarget": rewritetarget.SanitizeRewriteTargetInput, //sanitizes `haproxy.router.openshift.io/rewrite-target` annotation
+	"processRewritePath":   rewritetarget.SanitizeRewritePathInput,   //sanitizes route path for rewrite-target functionality
 }

--- a/pkg/router/template/util/rewritetarget/rewritetarget_test.go
+++ b/pkg/router/template/util/rewritetarget/rewritetarget_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func Test_SanitizeInput(t *testing.T) {
+func Test_SanitizeRewriteTargetInput(t *testing.T) {
 	testCases := []struct {
 		name   string
 		input  string
@@ -85,7 +85,55 @@ func Test_SanitizeInput(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := rewritetarget.SanitizeInput(tc.input)
+			got := rewritetarget.SanitizeRewriteTargetInput(tc.input)
+			if got != tc.output {
+				t.Errorf("Failure: expected %s, got %s", tc.output, got)
+			}
+		})
+	}
+}
+
+func Test_SanitizeRewritePathInput(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+			name:   "normal path",
+			input:  `/foo/bar`,
+			output: `/foo/bar`,
+		},
+		{
+			name:   "single quotes should be escaped",
+			input:  `'foo'foo\'`,
+			output: `'\''foo'\''foo\\'\''`,
+		},
+		{
+			name:   "number sign should NOT be escaped",
+			input:  `/foo/bar#`,
+			output: `/foo/bar#`,
+		},
+		{
+			name:   "backslashes should be escaped",
+			input:  `\foo\\foo\\\foo`,
+			output: `\\foo\\\\foo\\\\\\foo`,
+		},
+		{
+			name:   "special characters should be escaped",
+			input:  `/foo\.+*?()|[]{}^$`,
+			output: `/foo\\\.\+\*\?\(\)\|\[\]\{\}\^\$`,
+		},
+		{
+			name:   "new line characters should be escaped",
+			input:  "/foo\r\n",
+			output: `/foo\r\n`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rewritetarget.SanitizeRewritePathInput(tc.input)
 			if got != tc.output {
 				t.Errorf("Failure: expected %s, got %s", tc.output, got)
 			}


### PR DESCRIPTION
Process the route's spec.path while using the
`haproxy.router.openshift.io/rewrite-target` annotation to prevent HAProxy configuration issues.

Previously, values in the route's path would be interpreted as regex meta characters. Now, this fix forces literal interpretation of the characters in spec.path when matching for rewriting. This change introduces some unavoidable incompatibilities if users were previously using regex meta characters in a spec.path.

Use cases have been documented here: https://docs.google.com/document/d/1wA6ZdRYaiN70TY5UbTOn1wl5qAn_NPb2ty_G85XhnYM/edit#heading=h.pca9p2i57r2u