### PR TITLE
OCPBUGS-36630: Add hack Makefile target to build CI version of router image

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -25,7 +25,7 @@ To test Router changes on an available cluster, utilize `Dockerfile.debug` and
 `Makefile.debug` in `hack/`.
 
 `Dockerfile.debug` is a multi-stage dockerifle for building the Router binary,
-as well as the Router image itself. The outputted image uses `centos:8` as it's base
+as well as the Router image itself. The outputted image uses `ubi9` as it's base
 since installing packages on an OpenShift RHEL base image requires RHEL entitlements.
 
 `Makefile.debug` contains simple commands for "hot-swapping" the Router image running

--- a/hack/Makefile.debug
+++ b/hack/Makefile.debug
@@ -4,12 +4,19 @@ export GOOS=linux
 
 REGISTRY ?= quay.io
 IMAGE ?= openshift/openshift-router
+IMAGE_BASE ?= openshift/openshift-router-base
 TAG ?= latest
 IMAGEBUILDER ?= podman
 
 new-openshift-router-image:
 	GO111MODULE=on CGO_ENABLED=0 GOFLAGS=-mod=vendor go build -o openshift-router -gcflags=all="-N -l" ./cmd/openshift-router
 	$(IMAGEBUILDER) build -t $(IMAGE):$(TAG) -f hack/Dockerfile.debug .
+
+new-ci-router-image:
+	$(IMAGEBUILDER) build -t $(IMAGE_BASE):$(TAG) -f images/router/base/Dockerfile.ocp .
+	cp -f images/router/haproxy/Dockerfile.ocp images/router/haproxy/Dockerfile.ocp.tmp
+	sed -i "s|FROM .*|FROM $(IMAGE_BASE):$(TAG)|" images/router/haproxy/Dockerfile.ocp.tmp
+	$(IMAGEBUILDER) build -t $(IMAGE):$(TAG) -f images/router/haproxy/Dockerfile.ocp.tmp .
 
 push:
 	$(IMAGEBUILDER) tag $(IMAGE):$(TAG) $(REGISTRY)/$(IMAGE):$(TAG)


### PR DESCRIPTION
This PR enables the build of the CI version router image on local. The same [base and router dockerfiles are used](https://github.com/openshift/release/blob/d27dd22029dc85e2d58327cc8ad88d6eaf33f44e/ci-operator/config/openshift/router/openshift-router-master.yaml#L16-L29) by the new target. Use case: I want the same image that the CI would build but with my fix.  