### PR TITLE
[RFE-5098] Support for customizing HAProxy error code response page for http error code 504

### DIFF
--- a/images/router/haproxy/conf/error-page-403.http
+++ b/images/router/haproxy/conf/error-page-403.http
@@ -1,0 +1,95 @@
+HTTP/1.0 403 Forbidden
+Pragma: no-cache
+Cache-Control: private, max-age=0, no-cache, no-store
+Connection: close
+Content-Type: text/html
+
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <style type="text/css">
+      body {
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        line-height: 1.66666667;
+        font-size: 16px;
+        color: #333;
+        background-color: #fff;
+        margin: 2em 1em;
+      }
+      h1 {
+        font-size: 28px;
+        font-weight: 400;
+      }
+      p {
+        margin: 0 0 10px;
+      }
+      .alert.alert-info {
+        background-color: #F0F0F0;
+        margin-top: 30px;
+        padding: 30px;
+      }
+      .alert p {
+        padding-left: 35px;
+      }
+      ul {
+        padding-left: 51px;
+        position: relative;
+      }
+      li {
+        font-size: 14px;
+        margin-bottom: 1em;
+      }
+      p.info {
+        position: relative;
+        font-size: 20px;
+      }
+      p.info:before, p.info:after {
+        content: "";
+        left: 0;
+        position: absolute;
+        top: 0;
+      }
+      p.info:before {
+        background: #0066CC;
+        border-radius: 16px;
+        color: #fff;
+        content: "i";
+        font: bold 16px/24px serif;
+        height: 24px;
+        left: 0px;
+        text-align: center;
+        top: 4px;
+        width: 24px;
+      }
+
+      @media (min-width: 768px) {
+        body {
+          margin: 6em;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>Forbidden</h1>
+      <p>Request forbidden by administrative rules. The server can be reached and understood the request, but refuses to take any further action</p>
+
+      <div class="alert alert-info">
+        <p class="info">
+          Possible reasons you are seeing this page:
+        </p>
+        <ul>
+          <li>
+            <strong>Authorization parameters are missing or set wrong.</strong>
+            Check your authorization parameters.
+          </li>
+          <li>
+            <strong>Internet protocol address whitelisting.</strong>
+            Your internet protocol address is not whitelisted, contact to service host.
+          </li>
+        </ul>
+      </div>
+    </div>
+  </body>
+</html>

--- a/images/router/haproxy/conf/error-page-504.http
+++ b/images/router/haproxy/conf/error-page-504.http
@@ -1,0 +1,91 @@
+HTTP/1.0 504 Gateway Timeout
+Pragma: no-cache
+Cache-Control: private, max-age=0, no-cache, no-store
+Connection: close
+Content-Type: text/html
+
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <style type="text/css">
+      body {
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        line-height: 1.66666667;
+        font-size: 16px;
+        color: #333;
+        background-color: #fff;
+        margin: 2em 1em;
+      }
+      h1 {
+        font-size: 28px;
+        font-weight: 400;
+      }
+      p {
+        margin: 0 0 10px;
+      }
+      .alert.alert-info {
+        background-color: #F0F0F0;
+        margin-top: 30px;
+        padding: 30px;
+      }
+      .alert p {
+        padding-left: 35px;
+      }
+      ul {
+        padding-left: 51px;
+        position: relative;
+      }
+      li {
+        font-size: 14px;
+        margin-bottom: 1em;
+      }
+      p.info {
+        position: relative;
+        font-size: 20px;
+      }
+      p.info:before, p.info:after {
+        content: "";
+        left: 0;
+        position: absolute;
+        top: 0;
+      }
+      p.info:before {
+        background: #0066CC;
+        border-radius: 16px;
+        color: #fff;
+        content: "i";
+        font: bold 16px/24px serif;
+        height: 24px;
+        left: 0px;
+        text-align: center;
+        top: 4px;
+        width: 24px;
+      }
+
+      @media (min-width: 768px) {
+        body {
+          margin: 6em;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>Gateway timeout</h1>
+      <p>The server did not respond in time. Please try again later.</p>
+
+      <div class="alert alert-info">
+        <p class="info">
+          Possible reasons you are seeing this page:
+        </p>
+        <ul>
+          <li>
+            <strong>Request processing is taking too long.</strong>
+            The request could not be completed within the given time.
+          </li>
+        </ul>
+      </div>
+    </div>
+  </body>
+</html>

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -152,8 +152,10 @@ defaults
   # backend service or alternatively, you can send a custom 503 or 404 error.
   #
   # server openshift_backend 127.0.0.1:8080
+  errorfile 504 {{ env "ROUTER_ERRORFILE_504" "/var/lib/haproxy/conf/error-page-504.http" }}
   errorfile 503 {{ env "ROUTER_ERRORFILE_503" "/var/lib/haproxy/conf/error-page-503.http" }}
   errorfile 404 {{ env "ROUTER_ERRORFILE_404" "/var/lib/haproxy/conf/error-page-404.http" }}
+  errorfile 403 {{ env "ROUTER_ERRORFILE_403" "/var/lib/haproxy/conf/error-page-403.http" }}
 
   timeout connect {{ firstMatch $timeSpecPattern (env "ROUTER_DEFAULT_CONNECT_TIMEOUT") "5s" }}
   timeout client {{ firstMatch $timeSpecPattern (env "ROUTER_DEFAULT_CLIENT_TIMEOUT") "30s" }}


### PR DESCRIPTION
**I'm not sure if this is enough to make this work. Or should this be against master or next release version?**

We have noticed problems regarding error response descriptions with HA-proxy. Problems have been encountered during timeouts and whitelisting as in these cases request produces blank response and this makes debugging work difficult. After finding out the reasons for the problems, we propose adding status codes 504 and 403 to the error responses to help identifying problems with timeouts and access rights in the future.