### PR TITLE
NE-1815: Enable ALPN for reencrypt routes when DCM is enabled

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -757,6 +757,8 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
   server {{ $serverName }} 172.4.0.4:8765 weight 0 ssl disabled check inter {{ firstMatch $timeSpecPattern (index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval") (env "ROUTER_BACKEND_CHECK_INTERVAL") "5000ms" }}
               {{- if gt (len (index $cfg.Certificates (printf "%s_pod" $cfg.Host)).Contents) 0 }} verify required ca-file {{ $workingDir }}/router/cacerts/{{$cfgIdx }}.pem
               {{- else }}
+                {{- if not (isTrue $router_disable_http2) }} alpn h2,http/1.1
+                {{- end }}
                 {{- if gt (len $defaultDestinationCA) 0 }} verify required ca-file {{ $defaultDestinationCA }}
                 {{- else }} verify none
                 {{- end }}


### PR DESCRIPTION
This PR ensures that ALPN protocol negotiation is enabled for reencrypt routes when the Dynamic Configuration Manager (DCM) is active, aligning the behavior with [non-DCM configurations](https://github.com/openshift/router/blob/d095bdbb4777677f5317e49fb353f41b9c1a22e7/images/router/haproxy/conf/haproxy-config.template#L728-L729).

The gap to support HTTP2 workloads for reencrypt routes was found during [the smoke testing](https://github.com/openshift/cluster-ingress-operator/pull/1113#issuecomment-2315530761).