### PR TITLE
OCPBUGS-26603: Listen for stats connections on v6 addresses when relevant.

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -186,7 +186,14 @@ defaults
 
   {{ if (gt .StatsPort -1) }}
 listen stats
+    {{ if eq "v4v6" $router_ip_v4_v6_mode }}
   bind :{{ if (gt .StatsPort 0) }}{{ .StatsPort }}{{ else }}1936{{ end }}
+  bind :::{{ if (gt .StatsPort 0) }}{{ .StatsPort }}{{ else }}1936{{ end }} v6only
+    {{- else if eq "v6" $router_ip_v4_v6_mode }}
+  bind :::{{ if (gt .StatsPort 0) }}{{ .StatsPort }}{{ else }}1936{{ end }} v6only
+    {{- else }}
+  bind :{{ if (gt .StatsPort 0) }}{{ .StatsPort }}{{ else }}1936{{ end }}
+    {{- end }}
   mode http
   # Health check monitoring uri.
   monitor-uri /healthz


### PR DESCRIPTION
When the router is configured for ipv6 or dual stack modes, it already listens on ipv6 ports for normal traffic. This change makes the router listen on ipv6 ports for stats traffic as well.

This is part of the fix for OCPBUGS-26603.