### PR TITLE
NE-1815: Activate dynamic cookies for dynamic server slots (DCM)

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -703,6 +703,8 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
               {{- "" }} secure attr SameSite={{ $samesite }}
             {{- end }}
           {{- end }}
+          {{- with $dynamicConfigManager }} dynamic
+          {{- end }}
         {{- end }}{{/* end disable cookies check */}}
 
         {{- if matchValues (print $cfg.TLSTermination) "edge" "reencrypt" }}
@@ -760,6 +762,7 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
 
         {{- with $dynamicConfigManager }}
           {{- if (eq $cfg.TLSTermination "reencrypt") }}
+  dynamic-cookie-key {{ $cfg.RoutingKeyName }}
             {{- range $idx, $serverName := $dynamicConfigManager.GenerateDynamicServerNames $cfgIdx }}
   server {{ $serverName }} 172.4.0.4:8765 weight 0 ssl disabled check inter {{ firstMatch $timeSpecPattern (index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval") (env "ROUTER_BACKEND_CHECK_INTERVAL") "5000ms" }}
               {{- if gt (len (index $cfg.Certificates (printf "%s_pod" $cfg.Host)).Contents) 0 }} verify required ca-file {{ $workingDir }}/router/cacerts/{{$cfgIdx }}.pem


### PR DESCRIPTION
- Introduced a "dynamic" option for ["cookie" directive](https://docs.haproxy.org/2.8/configuration.html#4-cookie) used on plain HTTP, edge and re-encrypt routes. This option activates the dynamic cookie creation per server, applicable only for dynamic server slots (static server slots set cookie values explicitly). Without this option, dynamic servers will not set a cookie value.

- Added the ["dynamic-cookie-key" directive](https://docs.haproxy.org/2.8/configuration.html#dynamic-cookie-key) to re-ecrypt routes to align the dynamic cookie handling across all route types (plain HTTP and edge already have "dynamic-cookie-key").This directive is used to generate a unique cookie value for a each route.

`Set-Cookie` header sent from dynamic servers before this change:
```
set-cookie: a84fef2b01006bb7036c768d4a819999=; Expires=Thu, 01-Jan-1970 00:00:01 GMT; path=/; HttpOnly
```

and after:
```
set-cookie: a84fef2b01006bb7036c768d4a819999=424f3944a7ac32ec; path=/; HttpOnly
```

**Note**: the dynamic cookie value is a 16 chars long hash which is different from the cookie set on the static servers (32 chars).

Previous PR on the same topic (dynamic cookies for DCM slots): https://github.com/openshift/origin/pull/20557. This PR introduced "dynamic-cookie-key" directive for plain http/edge and passthrough backends in order to be able to disable the dynamic cookies for blueprint routes buy default and re-enable after a reload.