### PR TITLE
NE-1815: Add verifyhost to dynamic server slots for re-encrypt routes (DCM)

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -769,6 +769,15 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
               {{- else }}
                 {{- if not (isTrue $router_disable_http2) }} alpn h2,http/1.1
                 {{- end }}
+                {{- /*
+                    Add "verifyhost" for the primary service only. This server is not intended
+                    to be used for alternate backend endpoints. A reload will be triggered if
+                    an alternate backend endpoint is added dynamically.
+                */ -}}
+                {{- with $serviceUnit := index $.ServiceUnits $cfg.PrimaryServiceUnitKey -}}
+                    {{- if $cfg.VerifyServiceHostname }} verifyhost {{ $serviceUnit.Hostname }}
+                    {{- end }}
+                {{- end }}
                 {{- if gt (len $defaultDestinationCA) 0 }} verify required ca-file {{ $defaultDestinationCA }}
                 {{- else }} verify none
                 {{- end }}

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -234,10 +234,11 @@ func (r *TestRouter) AddRoute(route *routev1.Route) {
 	routeKey := getKey(route)
 
 	config := ServiceAliasConfig{
-		Host:         route.Spec.Host,
-		Path:         route.Spec.Path,
-		ServiceUnits: getServiceUnits(route),
+		Host: route.Spec.Host,
+		Path: route.Spec.Path,
 	}
+	serviceUnits, _ := getServiceUnits(route)
+	config.ServiceUnits = serviceUnits
 	config.ServiceUnitNames = r.calculateServiceWeights(config.ServiceUnits)
 
 	for key := range config.ServiceUnits {

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -80,6 +80,9 @@ type ServiceAliasConfig struct {
 
 	// HTTPResponseHeaders has route-specific custom HTTP request headers.
 	HTTPRequestHeaders []HTTPHeader
+
+	// PrimaryServiceUnitKey is the key of the primary service of the route.
+	PrimaryServiceUnitKey ServiceUnitKey
 }
 
 type ServiceAliasConfigStatus string


### PR DESCRIPTION
This PR introduces  [the "verifyhost" configuration setting](https://docs.haproxy.org/2.8/configuration.html#verifyhost) to dynamic server slots during template rendering. This ensures consistent behavior with static servers.

The "verifyhost" uses the FQDN of the primary service only, as it's not feasible to predict which service endpoint will be used when alternate backends are available.Consequently, dynamic servers for re-encrypt routes are not intended to handle alternate backend endpoints. A reload is forced when endpoint changes occur for alternate backend services in a re-encrypt route.

The commit which added the server certificate verification without `verifyhost`: https://github.com/openshift/router/commit/50a330de5a3da9636b36b5e9e62ddbc374b99524.