### PR TITLE
OCPBUGS-43745: Add support for IdleCloseTerminationPolicy

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -221,11 +221,10 @@ frontend public
     {{- end }}
   mode http
 
-  # Workaround for a known issue encountered with certain HTTP clients,
-  # particularly the Apache HTTP client (prior to version 5),
-  # where closed idle connections are erroneously reused.
-  # Bug reference: https://issues.redhat.com/browse/OCPBUGS-32044.
+  {{- if isTrue (env "ROUTER_IDLE_CLOSE_ON_RESPONSE") }}
   option idle-close-on-response
+  {{- end }}
+
   tcp-request inspect-delay {{ firstMatch $timeSpecPattern (env "ROUTER_INSPECT_DELAY") "5s" }}
   tcp-request content accept if HTTP
 
@@ -346,7 +345,9 @@ frontend fe_sni
   {{- "" }} no-alpn
   mode http
 
+  {{- if isTrue (env "ROUTER_IDLE_CLOSE_ON_RESPONSE") }}
   option idle-close-on-response
+  {{- end }}
 
     {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
   capture request header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}
@@ -459,7 +460,9 @@ frontend fe_no_sni
   {{- "" }} no-alpn
   mode http
 
+  {{- if isTrue (env "ROUTER_IDLE_CLOSE_ON_RESPONSE") }}
   option idle-close-on-response
+  {{- end }}
 
     {{- range $idx, $captureHeader := .CaptureHTTPRequestHeaders }}
   capture request header {{ $captureHeader.Name }} len {{ $captureHeader.MaxLength }}


### PR DESCRIPTION
Replace the hard-coded `idle-close-on-response` setting with a conditional based on the IngressController's `spec.idleConnectionTerminationPolicy` field, which controls whether HAProxy maintains idle frontend connections during reloads or closes them immediately.

The default behaviour for OCP 4.19 returns to closing idle connections immediately, reversing https://issues.redhat.com/browse/OCPBUGS-32044 which had made 'option idle-close-on-response' always present in the HAProxy configuration.

References:

- The field `idleConnectionTerminationPolicy` was added in https://github.com/openshift/api/pull/2102
- cluster-ingress-operator e2e test in openshift/cluster-ingress-operator#1166
