### PR TITLE
[WIP] HAProxy config check

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -17,5 +17,6 @@ USER 1001
 EXPOSE 80 443
 WORKDIR /var/lib/haproxy/conf
 ENV TEMPLATE_FILE=/var/lib/haproxy/conf/haproxy-config.template \
-    RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy
+    RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy \
+    CONFIG_CHECK_SCRIPT=/var/lib/haproxy/check-haproxy
 ENTRYPOINT ["/usr/bin/openshift-router", "--v=2"]

--- a/images/router/haproxy/check-haproxy
+++ b/images/router/haproxy/check-haproxy
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+config_file=/var/lib/haproxy/conf/haproxy.config
+if [[ "$1" != "" ]]; then
+  config_file=$1
+fi
+/usr/sbin/haproxy -c -f $config_file

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -17,7 +17,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	routelisters "github.com/openshift/client-go/route/listers/route/v1"
-	"github.com/openshift/router/pkg/router"
 	"github.com/openshift/router/pkg/router/writerlease"
 )
 
@@ -59,7 +58,6 @@ func (logRecorder) RecordRouteUnservableInFutureVersionsClear(route *routev1.Rou
 
 // StatusAdmitter ensures routes added to the plugin have status set.
 type StatusAdmitter struct {
-	plugin router.Plugin
 	client client.RoutesGetter
 	lister routelisters.RouteLister
 
@@ -74,9 +72,8 @@ type StatusAdmitter struct {
 // route has a status field set that matches this router. The admitter manages
 // an LRU of recently seen conflicting updates to handle when two router processes
 // with differing configurations are writing updates at the same time.
-func NewStatusAdmitter(plugin router.Plugin, client client.RoutesGetter, lister routelisters.RouteLister, name, hostName string, lease writerlease.Lease, tracker ContentionTracker) *StatusAdmitter {
+func NewStatusAdmitter(client client.RoutesGetter, lister routelisters.RouteLister, name, hostName string, lease writerlease.Lease, tracker ContentionTracker) *StatusAdmitter {
 	return &StatusAdmitter{
-		plugin: plugin,
 		client: client,
 		lister: lister,
 
@@ -107,23 +104,23 @@ func (a *StatusAdmitter) HandleRoute(eventType watch.EventType, route *routev1.R
 			Status: corev1.ConditionTrue,
 		})
 	}
-	return a.plugin.HandleRoute(eventType, route)
+	return nil
 }
 
 func (a *StatusAdmitter) HandleNode(eventType watch.EventType, node *kapi.Node) error {
-	return a.plugin.HandleNode(eventType, node)
+	return nil
 }
 
 func (a *StatusAdmitter) HandleEndpoints(eventType watch.EventType, route *kapi.Endpoints) error {
-	return a.plugin.HandleEndpoints(eventType, route)
+	return nil
 }
 
 func (a *StatusAdmitter) HandleNamespaces(namespaces sets.String) error {
-	return a.plugin.HandleNamespaces(namespaces)
+	return nil
 }
 
 func (a *StatusAdmitter) Commit() error {
-	return a.plugin.Commit()
+	return nil
 }
 
 // RecordRouteRejection attempts to update the route status with a reason for a route being rejected.

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -113,9 +113,13 @@ func TestMain(m *testing.M) {
 
 	createRouterDirs()
 
+	statusPlugin := controller.NewStatusAdmitter(routeClient.RouteV1(), routeLister, "default", "example.com", lease, tracker)
+
 	// The template plugin which is wrapped
 	svcFetcher := templateplugin.NewListWatchServiceLookup(client.CoreV1(), 60*time.Second, namespace)
 	pluginCfg := templateplugin.TemplatePluginConfig{
+		Plugin:     statusPlugin,
+		Recorder:   statusPlugin,
 		WorkingDir: workdir,
 		DefaultCertificate: `-----BEGIN CERTIFICATE-----
 MIIDIjCCAgqgAwIBAgIBBjANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx
@@ -176,8 +180,6 @@ u3YLAbyW/lHhOCiZu2iAI8AbmXem9lW6Tr7p/97s0w==
 	}
 
 	// Wrap the template plugin with other stuff
-	statusPlugin := controller.NewStatusAdmitter(plugin, routeClient.RouteV1(), routeLister, "default", "example.com", lease, tracker)
-	plugin = statusPlugin
 	plugin = controller.NewUniqueHost(plugin, routerSelection.DisableNamespaceOwnershipCheck, statusPlugin)
 	plugin = controller.NewHostAdmitter(plugin, routerSelection.RouteAdmissionFunc(), false, false, statusPlugin)
 

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -230,7 +230,7 @@ func (r *TestRouter) calculateServiceWeights(serviceUnits map[ServiceUnitKey]int
 }
 
 // AddRoute adds a ServiceAliasConfig and associated ServiceUnits for the route
-func (r *TestRouter) AddRoute(route *routev1.Route) {
+func (r *TestRouter) AddRoute(route *routev1.Route) error {
 	routeKey := getKey(route)
 
 	config := ServiceAliasConfig{
@@ -245,6 +245,7 @@ func (r *TestRouter) AddRoute(route *routev1.Route) {
 	}
 
 	r.State[routeKey] = config
+	return nil
 }
 
 // RemoveRoute removes the service alias config for Route
@@ -299,6 +300,9 @@ func getKey(route *routev1.Route) ServiceAliasConfigKey {
 
 func (r *TestRouter) Commit() {
 	// No op
+}
+func (r *TestRouter) CheckConfig() error {
+	return nil
 }
 
 // TestHandleEndpoints test endpoint watch events
@@ -379,7 +383,7 @@ func TestHandleEndpoints(t *testing.T) {
 	}
 
 	router := newTestRouter(make(map[ServiceAliasConfigKey]ServiceAliasConfig))
-	templatePlugin := newDefaultTemplatePlugin(router, true, nil)
+	templatePlugin := newDefaultTemplatePlugin(&fakePlugin{}, router, true, nil, nil)
 	// TODO: move tests that rely on unique hosts to pkg/router/controller and remove them from
 	// here
 	plugin := controller.NewUniqueHost(templatePlugin, false, controller.LogRejections)
@@ -489,7 +493,7 @@ func TestHandleTCPEndpoints(t *testing.T) {
 	}
 
 	router := newTestRouter(make(map[ServiceAliasConfigKey]ServiceAliasConfig))
-	templatePlugin := newDefaultTemplatePlugin(router, false, nil)
+	templatePlugin := newDefaultTemplatePlugin(&fakePlugin{}, router, false, nil, nil)
 	// TODO: move tests that rely on unique hosts to pkg/router/controller and remove them from
 	// here
 	plugin := controller.NewUniqueHost(templatePlugin, false, controller.LogRejections)
@@ -553,7 +557,7 @@ func (r *fakeStatusRecorder) isUnservableInFutureVersions(route *routev1.Route) 
 func TestHandleRoute(t *testing.T) {
 	rejections := &fakeStatusRecorder{}
 	router := newTestRouter(make(map[ServiceAliasConfigKey]ServiceAliasConfig))
-	templatePlugin := newDefaultTemplatePlugin(router, true, nil)
+	templatePlugin := newDefaultTemplatePlugin(&fakePlugin{}, router, true, nil, rejections)
 	// TODO: move tests that rely on unique hosts to pkg/router/controller and remove them from
 	// here
 	plugin := controller.NewUniqueHost(templatePlugin, false, rejections)
@@ -1197,7 +1201,7 @@ func TestHandleRouteUpgradeValidation(t *testing.T) {
 
 func TestNamespaceScopingFromEmpty(t *testing.T) {
 	router := newTestRouter(make(map[ServiceAliasConfigKey]ServiceAliasConfig))
-	templatePlugin := newDefaultTemplatePlugin(router, true, nil)
+	templatePlugin := newDefaultTemplatePlugin(&fakePlugin{}, router, true, nil, nil)
 	// TODO: move tests that rely on unique hosts to pkg/router/controller and remove them from
 	// here
 	plugin := controller.NewUniqueHost(templatePlugin, false, controller.LogRejections)


### PR DESCRIPTION
Swap TemplatePlugin and StatusAdmitter ordering so that StatusAdmitter is the last plugin so that the TemplatePlugin can reject a route based on whether HAProxy rejects the configuration.

When TemplatePlugin adds a route, it also writes the config file without reloading, and runs the configuration check script. If the configuration check script fails with the new route, the route will be removed from the state and it will be rejected.

Example failure for https://issues.redhat.com//browse/OCPBUGS-27741 looks like:
```yaml
status:
  ingress:
  - conditions:
    - lastTransitionTime: "2024-11-27T16:40:59Z"
      message: Failed to validate HAProxy config with route. Review the openshift-router
        logs for more details on the validation failure.
      reason: HAProxyCheckConfigFailed
      status: "False"
      type: Admitted
    host: route-service1-default.apps.gspence-2024-11-27-0943.devcluster.openshift.com
    routerCanonicalHostname: router-default.apps.gspence-2024-11-27-0943.devcluster.openshift.com
    routerName: default
    wildcardPolicy: None
```

WIP:
- Additional unit testing coverage
- Test & confirm that writing the config before reloading is OKAY
- Research impact of swapping StatusAdmitter and TemplatePlugin ordering
- Understand performance impact of running `haproxy -c` on every route add or change.
