### PR TITLE
OCPBUGS-55506: Prevent startup failures due to name resolution

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -184,6 +184,22 @@ defaults
   option contstats
   {{- end }}
 
+  # Prevent failures at startup due to name resolution
+  default-server init-addr last,none resolvers ingress_dns
+
+# Define a resolver to be used when servers are specified by name and
+# therefore requires name resolution. Server name resolution typically
+# occurs only at startup. With this configuration, name resolution
+# will occur once every 10s. Successful name resolution results in the
+# server being marked UP while failure results in the server being
+# marked DOWN. Note this only occurs when servers are specified by
+# name.
+resolvers ingress_dns
+  parse-resolv-conf
+  resolve_retries 1
+  timeout retry 5s
+  timeout resolve 10s
+  
   {{ if (gt .StatsPort -1) }}
 listen stats
     {{ if eq "v4v6" $router_ip_v4_v6_mode }}


### PR DESCRIPTION
When servers are listed using FQDN names rather than IP addresses, HAProxy will attempt to resolve these names at startup. In the event that a name cannot be resolve, HAProxy will fail. To overcome this, use the 'init-addr' such that even if name resolution fails, HAProxy will still start normally. Any server that fails name resolution will be set in the DOWN state. Note that the key here is the 'none' keyword used with 'init-addr'

Also note that this option is being set via the 'default-server' option in the 'defaults' section and therefore applied to all servers listed in the configuration.