### PR TITLE
NO-JIRA: Add possibility to annotate router with HAProxy backend-config-snippet annotation

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -632,7 +632,6 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
           {{- end }}
         {{- end }}
 
-        {{- /* custom ACL snippet from route-annotation */ -}}
         {{- with $snippet := index $cfg.Annotations "haproxy.router.openshift.io/backend-config-snippet" }}
 {{ indent $snippet 2 }}
         {{- end }}
@@ -846,7 +845,6 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
           {{- end }}
         {{- end }}
 
-        {{- /* custom ACL snippet from route-annotation */ -}}
         {{- with $snippet := index $cfg.Annotations "haproxy.router.openshift.io/backend-config-snippet" }}
 {{ indent $snippet 2 }}
         {{- end }}

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -632,6 +632,11 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
           {{- end }}
         {{- end }}
 
+        {{- /* custom ACL snippet from route-annotation */ -}}
+        {{- with $snippet := index $cfg.Annotations "haproxy.router.openshift.io/backend-config-snippet" }}
+{{ indent $snippet 2 }}
+        {{- end }}
+
   timeout check 5000ms
         {{- with $setHeaders := firstMatch $setForwardedHeadersPattern (index $cfg.Annotations $setForwardedHeadersAnnotation) $setForwardedHeadersDefaultValue }}
           {{- if eq $setHeaders "append" }}
@@ -698,7 +703,7 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
   http-request replace-path ^{{ $cfg.Path }}(.*)$ '{{ processRewriteTarget $pathRewriteTarget }}'
           {{- end }}
         {{- end }}{{/* rewrite target */}}
-  
+
         {{- if not (isTrue (index $cfg.Annotations "haproxy.router.openshift.io/disable_cookies")) }}
   cookie {{ firstMatch $cookieNamePattern (index $cfg.Annotations "router.openshift.io/cookie_name") (env "ROUTER_COOKIE_NAME" "") $cfg.RoutingKeyName }} insert indirect nocache httponly
           {{- if and (matchValues (print $cfg.TLSTermination) "edge" "reencrypt") (ne $cfg.InsecureEdgeTerminationPolicy "Allow") }}
@@ -839,6 +844,11 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
           {{- else }}
   #TCP connection rate not restricted
           {{- end }}
+        {{- end }}
+
+        {{- /* custom ACL snippet from route-annotation */ -}}
+        {{- with $snippet := index $cfg.Annotations "haproxy.router.openshift.io/backend-config-snippet" }}
+{{ indent $snippet 2 }}
         {{- end }}
 
   hash-type consistent

--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -403,6 +403,31 @@ func parseIPList(list string) string {
 	return result
 }
 
+// indent adds a specified number of spaces to the beginning of each line in the input string.
+// If input is empty, it returns an empty string.
+// If indent is 0 or negative, it returns the input string as is.
+func indent(input string, spaces int) string {
+	if input == "" {
+		return ""
+	}
+
+	if spaces <= 0 {
+		return input
+	}
+
+	padding := strings.Repeat(" ", spaces)
+	lines := strings.Split(input, "\n")
+
+	// Process each line, adding the padding to the start of each one
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = padding + line
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
 var helperFunctions = template.FuncMap{
 	"endpointsForAlias":        endpointsForAlias,        //returns the list of valid endpoints
 	"processEndpointsForAlias": processEndpointsForAlias, //returns the list of valid endpoints after processing them
@@ -429,5 +454,7 @@ var helperFunctions = template.FuncMap{
 	"clipHAProxyTimeoutValue": clipHAProxyTimeoutValue, //clips extrodinarily high timeout values to be below the maximum allowed timeout value
 	"parseIPList":             parseIPList,             //parses the list of IPs/CIDRs (IPv4/IPv6)
 
-	"processRewriteTarget": rewritetarget.SanitizeInput, //sanitizes `haproxy.router.openshift.io/rewrite-target` annotation
+	"indent":                 indent,                 //indents a multiline string with specified number of spaces
+	"processRewriteTarget":   rewritetarget.SanitizeInput, //sanitizes `haproxy.router.openshift.io/rewrite-target` annotation
 }
+

--- a/pkg/router/template/template_helper_test.go
+++ b/pkg/router/template/template_helper_test.go
@@ -1104,3 +1104,64 @@ func TestParseIPList(t *testing.T) {
 		})
 	}
 }
+
+func TestIndent(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		spaces   int
+		expected string
+	}{
+		{
+			name:     "empty input",
+			input:    "",
+			spaces:   2,
+			expected: "",
+		},
+		{
+			name:     "zero spaces",
+			input:    "line1\nline2\nline3",
+			spaces:   0,
+			expected: "line1\nline2\nline3",
+		},
+		{
+			name:     "negative spaces",
+			input:    "line1\nline2\nline3",
+			spaces:   -1,
+			expected: "line1\nline2\nline3",
+		},
+		{
+			name:     "standard indentation",
+			input:    "line1\nline2\nline3",
+			spaces:   2,
+			expected: "  line1\n  line2\n  line3",
+		},
+		{
+			name:     "with empty lines",
+			input:    "line1\n\nline3",
+			spaces:   4,
+			expected: "    line1\n\n    line3",
+		},
+		{
+			name:     "single line",
+			input:    "line1",
+			spaces:   3,
+			expected: "   line1",
+		},
+		{
+			name:     "multi-line with different content",
+			input:    "first line\nsecond line with more text\nthird",
+			spaces:   2,
+			expected: "  first line\n  second line with more text\n  third",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := indent(tc.input, tc.spaces)
+			if result != tc.expected {
+				t.Errorf("Expected:\n%s\nGot:\n%s", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary:
This pull request extends the OpenShift Router (HAProxy-based) to honour the `haproxy-ingress.github.io/backend-config-snippet` annotation on Routes/Ingresses. Named in this PR: `haproxy.router.openshift.io/backend-config-snippet`
With these changes in place, you can inject custom HAProxy directives into a Route’s backend.

### Background:
Steadybit provides a set of Kubernetes extensions that leverage HAProxy annotations to simulate network disruptions at the ingress layer. Our two main actions are:
	•	Block Traffic
[com.steadybit.extension_kubernetes.haproxy-block-traffic](https://hub.steadybit.com/action/com.steadybit.extension_kubernetes.haproxy-block-traffic)
Injects HAProxy directives to drop or reject incoming requests to a given backend.
	•	Delay Traffic
[com.steadybit.extension_kubernetes.haproxy-delay-traffic](https://hub.steadybit.com/action/com.steadybit.extension_kubernetes.haproxy-delay-traffic)
Injects HAProxy directives to introduce artificial latency on requests.

To configure these directives in a HAProxy-based ingress, Steadybit relies on the community-standard annotation:
`haproxy-ingress.github.io/backend-config-snippet`

When present on a Route/Ingress, everything in that annotation will be appended into the generated HAProxy backend section for that host/service.

Until now, OpenShift’s router did not parse or propagate this annotation. With this PR, we introduce support for reading `haproxy.router.openshift.io/backend-config-snippet` on Routes and merging it into the HAProxy configuration at runtime. This allows users to run their ingress/route attacks (block or delay) directly on OpenShift clusters without requiring any sidecar or additional proxies.