### PR TITLE
fix: haproxy: drain connections when disabling endpoints

### DIFF
--- a/pkg/router/template/configmanager/haproxy/backend.go
+++ b/pkg/router/template/configmanager/haproxy/backend.go
@@ -224,7 +224,7 @@ func (b *Backend) EnableServer(name string) error {
 // DisableServer stops serving traffic for a haproxy backend server.
 func (b *Backend) DisableServer(name string) error {
 	log.V(4).Info("disabling server with maint state", "server", name)
-	return b.UpdateServerState(name, BackendServerStateMaint)
+	return b.UpdateServerState(name, BackendServerStateDrain)
 }
 
 // Commit commits all the pending changes made to a haproxy backend.


### PR DESCRIPTION
sending set-server maint will stop sending traffic to endpoints, which will cause traffic to be dropped. This instructs haproxy to gracefully drain an endpoint while sending new connections to other ready endpoints

see [1] for further information on the difference  between drain and maint

[1] https://www.haproxy.com/documentation/haproxy-configuration-manual/new/latest/management/#section-9.3.-set-server


