### PR TITLE
OCPBUGS-60257: fix extra space in haproxy template

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -209,7 +209,7 @@ listen stats
     {{- end }}
   {{- end }}
 
-{{ if .BindPorts -}}
+  {{- if .BindPorts }}{{"\n"}}
 frontend public
     {{ if eq "v4v6" $router_ip_v4_v6_mode }}
   bind :{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }}{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -209,7 +209,7 @@ listen stats
     {{- end }}
   {{- end }}
 
-  {{ if .BindPorts -}}
+{{ if .BindPorts -}}
 frontend public
     {{ if eq "v4v6" $router_ip_v4_v6_mode }}
   bind :{{ env "ROUTER_SERVICE_HTTP_PORT" "80" }}{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} accept-proxy{{ end }}


### PR DESCRIPTION
As per the bug, there is some extra white space in the template and it shows up before the "frontend public" item as noted