### PR TITLE
[WIP] Use HAProxy 2.8.10 with backport upstream fixes

### DIFF
--- a/images/router/haproxy/Dockerfile.ocp
+++ b/images/router/haproxy/Dockerfile.ocp
@@ -1,5 +1,9 @@
 FROM registry.ci.openshift.org/ocp/4.18:haproxy-router-base
-RUN INSTALL_PKGS="socat haproxy28 rsyslog procps-ng util-linux" && \
+
+RUN yum install -y https://github.com/alebedev87/haproxy-builds/raw/refs/heads/main/rhaos-4.18-rhel-9/2.8.10-backport-OCPBUGS-60885/haproxy28-2.8.10-1.rhaos4.17.el9.x86_64.rpm
+RUN haproxy -vv
+
+RUN INSTALL_PKGS="socat rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -147,6 +147,10 @@ defaults
   log global
   {{- end }}
 
+  # Enable the backport patch for https://issues.redhat.com/browse/OCPBUGS-60885
+  # which drops SSL handshakes for dead connections.
+  option abortonclose
+
   # To configure custom default errors, you can either uncomment the
   # line below (server ... 127.0.0.1:8080) and point it to your custom
   # backend service or alternatively, you can send a custom 503 or 404 error.


### PR DESCRIPTION
Test of https://github.com/alebedev87/git-haproxy/pull/1.

RPM diff:
```diff
diff --git a/haproxy.spec b/haproxy.spec
index 67126cc..e6b3439 100644
--- a/haproxy.spec
+++ b/haproxy.spec
@@ -30,6 +30,13 @@ License:        GPLv2+
 URL:            http://www.haproxy.org/
 Source0:        http://www.haproxy.org/download/2.8/src/haproxy-%{version}.tar.gz
 
+# Backport of the following upstream commits into 2.8.10:
+# - http://git.haproxy.org/?p=haproxy.git;a=commit;h=7ea80cc5b66e9a9e8e5618532f1c6deb93385761
+# - http://git.haproxy.org/?p=haproxy.git;a=commit;h=1afaa7b59d6c407d68683b821f3142654a37b17e
+# To fix https://issues.redhat.com/browse/OCPBUGS-60885.
+# Upstream issue: https://github.com/haproxy/haproxy/issues/3124.
+Patch0:         0001-backport-closed-connections-pending-handshake-try-harder.patch
+
 BuildRequires:  gcc
 BuildRequires:  make
 BuildRequires:  openssl-devel
@@ -62,6 +69,7 @@ availability environments. Indeed, it can:
 
 %prep
 %setup -q
+%patch0 -p1
 
 %build
 regparm_opts=
@@ -108,6 +116,9 @@ fi
 %{_sbindir}/%{name}
 
 %changelog
+* Thu Oct 09 2025 Andrey Lebedev <alebedev@redhat.com> - 2.8.10-1.rhaos4.17
+- Backport of fix for https://issues.redhat.com/browse/OCPBUGS-60885.
+
 * Tue Jun 25 2024 Andrew McDermott <amcdermo@redhat.com> - 2.8.10-1.rhaos4.17
 - Resolves https://issues.redhat.com/browse/NE-1761.
 - Drop old carry patches.
```

`0001-backport-closed-connections-pending-handshake-try-harder.patch` == https://github.com/alebedev87/git-haproxy/pull/1.