### PR TITLE
[WIP] OCPBUGS-60885: Use HAProxy 2.8.10 with backport upstream fixes. No error reporting funcs.

### DIFF
--- a/images/router/haproxy/Dockerfile.ocp
+++ b/images/router/haproxy/Dockerfile.ocp
@@ -1,5 +1,9 @@
 FROM registry.ci.openshift.org/ocp/4.18:haproxy-router-base
-RUN INSTALL_PKGS="socat haproxy28 rsyslog procps-ng util-linux" && \
+
+RUN yum install -y https://github.com/alebedev87/haproxy-builds/raw/refs/heads/main/rhaos-4.18-rhel-9/2.8.10-backport-no-error-issue3124/haproxy28-2.8.10-1.rhaos4.17.el9.x86_64.rpm
+RUN haproxy -vv
+
+RUN INSTALL_PKGS="socat rsyslog procps-ng util-linux" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
This PR tests the second iteration of the backport patch for OCPBUGS-60885: https://github.com/alebedev87/git-haproxy/pull/3.

RPM diff:
```diff
diff --git a/0001-backport-closed-connections-pending-handshake-try-harder-no-error-report.patch b/0001-backport-closed-connections-pending-handshake-try-harder-no-error-report.patch
new file mode 100644
index 0000000..52bc139
--- /dev/null
+++ b/0001-backport-closed-connections-pending-handshake-try-harder-no-error-report.patch
@@ -0,0 +1,89 @@
+diff --git a/include/haproxy/connection-t.h b/include/haproxy/connection-t.h
+index 39f0d2896..805277fdd 100644
+--- a/include/haproxy/connection-t.h
++++ b/include/haproxy/connection-t.h
+@@ -271,6 +271,7 @@ enum {
+       CO_RFL_READ_ONCE     = 0x0004,    /* don't loop even if the request/response is small */
+       CO_RFL_KEEP_RECV     = 0x0008,    /* Instruct the mux to still wait for read events  */
+       CO_RFL_BUF_NOT_STUCK = 0x0010,    /* Buffer is not stuck. Optims are possible during data copy */
++      CO_RFL_TRY_HARDER    = 0x0040,    /* Try to read till READ0 even on short reads */
+ };
+ 
+ /* flags that can be passed to xprt->snd_buf() and mux->snd_buf() */
+diff --git a/src/raw_sock.c b/src/raw_sock.c
+index 31ca970f1..349216d97 100644
+--- a/src/raw_sock.c
++++ b/src/raw_sock.c
+@@ -282,9 +282,11 @@ static size_t raw_sock_to_buf(struct connection *conn, void *xprt_ctx, struct bu
+                               if (fdtab[conn->handle.fd].state & FD_POLL_HUP)
+                                       goto read0;
+ 
+-                              if (!(fdtab[conn->handle.fd].state & FD_LINGER_RISK) ||
+-                                  (cur_poller.flags & HAP_POLL_F_RDHUP)) {
+-                                      break;
++                              if (!(flags & CO_RFL_TRY_HARDER)) {
++                                      if (!(fdtab[conn->handle.fd].state & FD_LINGER_RISK) ||
++                                          (cur_poller.flags & HAP_POLL_F_RDHUP)) {
++                                              break;
++                                      }
+                               }
+                       }
+                       count -= ret;
+@@ -309,6 +311,28 @@ static size_t raw_sock_to_buf(struct connection *conn, void *xprt_ctx, struct bu
+       if (unlikely(conn->flags & CO_FL_WAIT_L4_CONN) && done)
+               conn->flags &= ~CO_FL_WAIT_L4_CONN;
+ 
++      if (unlikely((flags & CO_RFL_TRY_HARDER) &&
++                   !(conn->flags & CO_FL_SOCK_RD_SH) &&
++                   !count)) {
++              /* we've read exactly what was being asked for, which is loewr
++               * than a full buffer, and the caller wants us to really check
++               * if there's something after. This happens in the context of
++               * SSL where the lib reads in tiny chunks without offering the
++               * ability to detect a pending close. Let's just check using
++               * MSG_PEEK so that we don't pull bytes we shouldn't.
++               */
++              char c;
++
++              ret = recv(conn->handle.fd, &c, 1, MSG_PEEK);
++              if (ret == 0) {
++                      goto read0;
++              }
++              else if (ret < 0 &&
++                       (errno != EAGAIN && errno != EWOULDBLOCK && errno != ENOTCONN && errno != EINTR)) {
++                      conn->flags |= CO_FL_ERROR | CO_FL_SOCK_RD_SH | CO_FL_SOCK_WR_SH;
++              }
++      }
++
+  leave:
+       return done;
+ 
+diff --git a/src/ssl_sock.c b/src/ssl_sock.c
+index d1e133506..83bd6eae2 100644
+--- a/src/ssl_sock.c
++++ b/src/ssl_sock.c
+@@ -249,6 +249,7 @@ static int ha_ssl_read(BIO *h, char *buf, int size)
+ {
+       struct buffer tmpbuf;
+       struct ssl_sock_ctx *ctx;
++      int detect_shutr;
+       int ret;
+ 
+       ctx = BIO_get_data(h);
+@@ -256,7 +257,15 @@ static int ha_ssl_read(BIO *h, char *buf, int size)
+       tmpbuf.area = buf;
+       tmpbuf.data = 0;
+       tmpbuf.head = 0;
+-      ret = ctx->xprt->rcv_buf(ctx->conn, ctx->xprt_ctx, &tmpbuf, size, 0);
++      if (ctx->conn->flags & CO_FL_SSL_WAIT_HS && !conn_is_back(ctx->conn) && ((struct session *)ctx->conn->owner)->fe->options & PR_O_ABRT_CLOSE)
++              detect_shutr = 1;
++      else
++              detect_shutr = 0;
++
++      ret = ctx->xprt->rcv_buf(ctx->conn, ctx->xprt_ctx, &tmpbuf, size, detect_shutr ? CO_RFL_TRY_HARDER : 0);
++      if (detect_shutr && ctx->conn->flags & (CO_FL_ERROR | CO_FL_SOCK_RD_SH)) {
++              ret = -1;
++      }
+       BIO_clear_retry_flags(h);
+       if (ret == 0 && !(ctx->conn->flags & (CO_FL_ERROR | CO_FL_SOCK_RD_SH))) {
+               BIO_set_retry_read(h);
diff --git a/haproxy.spec b/haproxy.spec
index 67126cc..6ba7d46 100644
--- a/haproxy.spec
+++ b/haproxy.spec
@@ -30,6 +30,15 @@ License:        GPLv2+
 URL:            http://www.haproxy.org/
 Source0:        http://www.haproxy.org/download/2.8/src/haproxy-%{version}.tar.gz
 
+# Backport of the following upstream commits into 2.8.10:
+# - http://git.haproxy.org/?p=haproxy.git;a=commit;h=7ea80cc5b66e9a9e8e5618532f1c6deb93385761
+# - http://git.haproxy.org/?p=haproxy.git;a=commit;h=1afaa7b59d6c407d68683b821f3142654a37b17e
+# To fix https://issues.redhat.com/browse/OCPBUGS-60885.
+# Upstream issue: https://github.com/haproxy/haproxy/issues/3124.
+# Usage of `conn_report_term_evt` and `conn_set_errno` was dropped to simplify the backport
+# as suggested by Willy (https://github.com/haproxy/haproxy/issues/3124#issuecomment-3435403861).
+Patch0:         0001-backport-closed-connections-pending-handshake-try-harder-no-error-report.patch
+
 BuildRequires:  gcc
 BuildRequires:  make
 BuildRequires:  openssl-devel
@@ -62,6 +71,7 @@ availability environments. Indeed, it can:
 
 %prep
 %setup -q
+%patch0 -p1
 
 %build
 regparm_opts=
@@ -108,6 +118,9 @@ fi
 %{_sbindir}/%{name}
 
 %changelog
+* Thu Oct 09 2025 Andrey Lebedev <alebedev@redhat.com> - 2.8.10-1.rhaos4.17
+- Backport of fix for https://issues.redhat.com/browse/OCPBUGS-60885.
+
 * Tue Jun 25 2024 Andrew McDermott <amcdermo@redhat.com> - 2.8.10-1.rhaos4.17
 - Resolves https://issues.redhat.com/browse/NE-1761.
 - Drop old carry patches.
```