### PR TITLE
NO-JIRA: Add new team members to OWNERS in Release-4.20 branch

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -14,6 +14,8 @@ approvers:
   - grzpiotrowski
   - Thealisyed
   - rikatz
+  - davidesalerno
+  - bentito
 reviewers:
   - ironcladlou
   - knobunc
@@ -31,4 +33,6 @@ reviewers:
   - grzpiotrowski
   - Thealisyed
   - rikatz
+  - davidesalerno
+  - bentito
 component: Routing


### PR DESCRIPTION
This PR is a manual checcry-pick of #670 

As a new member of the NID team I'm adding my github username to the OWNERS file

Note: this change is adding also @bentito 