### PR TITLE
NO-JIRA: [release-4.19] Add new team members to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -13,6 +13,9 @@ approvers:
   - gcs278
   - grzpiotrowski
   - Thealisyed
+  - rikatz
+  - davidesalerno
+  - bentito
 reviewers:
   - ironcladlou
   - knobunc
@@ -29,4 +32,7 @@ reviewers:
   - gcs278
   - grzpiotrowski
   - Thealisyed
+  - rikatz
+  - davidesalerno
+  - bentito
 component: Routing


### PR DESCRIPTION
This PR is a manual checcry-pick of https://github.com/openshift/router/pull/670

As a new member of the NID team I'm adding my github username to the OWNERS file

The backport is adding also @rikatz to the OWNERS file as well