### PR TITLE
NO-JIRA: [release-4.18] Add new team members to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,6 +12,10 @@ approvers:
   - alebedev87
   - gcs278
   - grzpiotrowski
+  - Thealisyed
+  - rikatz
+  - davidesalerno
+  - bentito
 reviewers:
   - ironcladlou
   - knobunc
@@ -27,4 +31,8 @@ reviewers:
   - alebedev87
   - gcs278
   - grzpiotrowski
+  - Thealisyed
+  - rikatz
+  - davidesalerno
+  - bentito
 component: Routing


### PR DESCRIPTION
This PR is a manual checcry-pick of https://github.com/openshift/router/pull/670

As a new member of the NID team I'm adding my github username to the OWNERS file

The backport is adding also @rikatz and @Thealisyed to the OWNERS file as well