### PR TITLE
OCPBUGS-62267: fix forwarded header for IPv6 on IPv4 stack

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -654,7 +654,11 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
   http-request add-header X-Forwarded-Proto http if !{ ssl_fc }
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   http-request add-header X-Forwarded-Proto-Version h2 if { ssl_fc_alpn -i h2 }
-  option forwarded for proto host-expr req.hdr(host)
+  # See the quoting rules in https://tools.ietf.org/html/rfc7239 for IPv6 addresses (v4 addresses get translated to v6 when in hybrid mode)
+            {{- /* Checking for IPv6 address regardless of the router IP family config: an IPv6 could be in place on IPv4 stack if using PROXY protocol and behind a LB with IPv6 stack */}}
+  acl ipv6_addr src -m sub :
+  http-request add-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if ipv6_addr
+  http-request add-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !ipv6_addr
           {{- else if eq $setHeaders "replace" }}
   http-request set-header X-Forwarded-For %[src]
   http-request set-header X-Forwarded-Host %[req.hdr(host)]
@@ -662,8 +666,11 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
   http-request set-header X-Forwarded-Proto http if !{ ssl_fc }
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
   http-request set-header X-Forwarded-Proto-Version h2 if { ssl_fc_alpn -i h2 }
-  http-request del-header Forwarded
-  option forwarded for proto host-expr req.hdr(host)
+  # See the quoting rules in https://tools.ietf.org/html/rfc7239 for IPv6 addresses (v4 addresses get translated to v6 when in hybrid mode)
+            {{- /* Checking for IPv6 address regardless of the router IP family config: an IPv6 could be in place on IPv4 stack if using PROXY protocol and behind a LB with IPv6 stack */}}
+  acl ipv6_addr src -m sub :
+  http-request set-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if ipv6_addr
+  http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !ipv6_addr
           {{- else if eq $setHeaders "if-none" }}
             {{- /* X-Forwarded-For: is handled by "option forwardfor if-none" above.  */}}
   http-request set-header X-Forwarded-Host %[req.hdr(host)] if !{ req.hdr(X-Forwarded-Host) -m found }
@@ -672,10 +679,7 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
   http-request set-header X-Forwarded-Proto https if { ssl_fc } !{ req.hdr(X-Forwarded-Proto) -m found }
   http-request set-header X-Forwarded-Proto-Version h2 if { ssl_fc_alpn -i h2 } !{ req.hdr(X-Forwarded-Proto-Version) -m found }
   # See the quoting rules in https://tools.ietf.org/html/rfc7239 for IPv6 addresses (v4 addresses get translated to v6 when in hybrid mode)
-            {{- /*
-              - Adding header manually: option forwarded does not support adding header conditionally
-              - Checking for IPv6 address despite of the router IP family config: an IPv6 could be in place on IPv4 stack if using PROXY protocol and behind a LB with IPv6 stack
-            */}}
+            {{- /* Checking for IPv6 address regardless of the router IP family config: an IPv6 could be in place on IPv4 stack if using PROXY protocol and behind a LB with IPv6 stack */}}
   acl ipv6_addr src -m sub :
   http-request set-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if ipv6_addr !{ req.hdr(Forwarded) -m found }
   http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !ipv6_addr !{ req.hdr(Forwarded) -m found }

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -654,16 +654,7 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
   http-request add-header X-Forwarded-Proto http if !{ ssl_fc }
   http-request add-header X-Forwarded-Proto https if { ssl_fc }
   http-request add-header X-Forwarded-Proto-Version h2 if { ssl_fc_alpn -i h2 }
-            {{- if eq "v4v6" $router_ip_v4_v6_mode }}
-  # See the quoting rules in https://tools.ietf.org/html/rfc7239 for IPv6 addresses (v4 addresses get translated to v6 when in hybrid mode)
-  acl ipv6_addr src -m sub :
-  http-request add-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if ipv6_addr
-  http-request add-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !ipv6_addr
-            {{- else if eq "v6" $router_ip_v4_v6_mode }}
-  http-request add-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
-            {{- else }}
-  http-request add-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
-            {{- end }}
+  option forwarded for proto host-expr req.hdr(host)
           {{- else if eq $setHeaders "replace" }}
   http-request set-header X-Forwarded-For %[src]
   http-request set-header X-Forwarded-Host %[req.hdr(host)]
@@ -671,16 +662,8 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
   http-request set-header X-Forwarded-Proto http if !{ ssl_fc }
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
   http-request set-header X-Forwarded-Proto-Version h2 if { ssl_fc_alpn -i h2 }
-            {{- if eq "v4v6" $router_ip_v4_v6_mode }}
-  # See the quoting rules in https://tools.ietf.org/html/rfc7239 for IPv6 addresses (v4 addresses get translated to v6 when in hybrid mode)
-  acl ipv6_addr src -m sub :
-  http-request set-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if ipv6_addr
-  http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !ipv6_addr
-            {{- else if eq "v6" $router_ip_v4_v6_mode }}
-  http-request set-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
-            {{- else }}
-  http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
-            {{- end }}
+  http-request del-header Forwarded
+  option forwarded for proto host-expr req.hdr(host)
           {{- else if eq $setHeaders "if-none" }}
             {{- /* X-Forwarded-For: is handled by "option forwardfor if-none" above.  */}}
   http-request set-header X-Forwarded-Host %[req.hdr(host)] if !{ req.hdr(X-Forwarded-Host) -m found }
@@ -688,16 +671,14 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
   http-request set-header X-Forwarded-Proto http if !{ ssl_fc } !{ req.hdr(X-Forwarded-Proto) -m found }
   http-request set-header X-Forwarded-Proto https if { ssl_fc } !{ req.hdr(X-Forwarded-Proto) -m found }
   http-request set-header X-Forwarded-Proto-Version h2 if { ssl_fc_alpn -i h2 } !{ req.hdr(X-Forwarded-Proto-Version) -m found }
-            {{- if eq "v4v6" $router_ip_v4_v6_mode }}
   # See the quoting rules in https://tools.ietf.org/html/rfc7239 for IPv6 addresses (v4 addresses get translated to v6 when in hybrid mode)
+            {{- /*
+              - Adding header manually: option forwarded does not support adding header conditionally
+              - Checking for IPv6 address despite of the router IP family config: an IPv6 could be in place on IPv4 stack if using PROXY protocol and behind a LB with IPv6 stack
+            */}}
   acl ipv6_addr src -m sub :
   http-request set-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if ipv6_addr !{ req.hdr(Forwarded) -m found }
   http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !ipv6_addr !{ req.hdr(Forwarded) -m found }
-            {{- else if eq "v6" $router_ip_v4_v6_mode }}
-  http-request set-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !{ req.hdr(Forwarded) -m found }
-            {{- else }}
-  http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if !{ req.hdr(Forwarded) -m found }
-            {{- end }}
           {{- else if eq $setHeaders "never" }}
             {{- /* No Forward headers set.  */}}
           {{- end }}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -596,6 +596,51 @@ func TestConfigTemplate(t *testing.T) {
 				},
 			},
 		},
+		"Route HTTP Forward header type append": {
+			mustCreateWithConfig{
+				mustCreateRoute: mustCreateRoute{
+					name:        "fwd1",
+					host:        "fwd1.example.com",
+					annotations: map[string]string{"haproxy.router.openshift.io/set-forwarded-headers": "append"},
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: insecureBackendName(h.namespace, "fwd1"),
+					attribute:   "http-request",
+					value:       `add-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if ipv6_addr`,
+				},
+			},
+		},
+		"Route HTTP Forward header type replace": {
+			mustCreateWithConfig{
+				mustCreateRoute: mustCreateRoute{
+					name:        "fwd2",
+					host:        "fwd2.example.com",
+					annotations: map[string]string{"haproxy.router.openshift.io/set-forwarded-headers": "replace"},
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: insecureBackendName(h.namespace, "fwd2"),
+					attribute:   "http-request",
+					value:       `set-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if ipv6_addr`,
+				},
+			},
+		},
+		"Route HTTP Forward header type if-none": {
+			mustCreateWithConfig{
+				mustCreateRoute: mustCreateRoute{
+					name:        "fwd3",
+					host:        "fwd3.example.com",
+					annotations: map[string]string{"haproxy.router.openshift.io/set-forwarded-headers": "if-none"},
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: insecureBackendName(h.namespace, "fwd3"),
+					attribute:   "http-request",
+					value:       `set-header Forwarded for=\"[%[src]]\";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)] if ipv6_addr !{ req.hdr(Forwarded) -m found }`,
+				},
+			},
+		},
 		"two routes with different certificates": {
 			mustCreateWithConfig{
 				mustCreateRoute: mustCreateRoute{


### PR DESCRIPTION
Source IP on Forwarded header is built depending on the configured stack: if IPv4 or IPv6 only, no special handling is done. On dual stack, router checks if the source is IPv6 in order to properly format with brackets and double quotes.

However if a fronting load balancer has IPv6 or dual stack, a client sends a request on IPv6 and router is configured with PROXY protocol, the source IPv6 will be received on the router, but it'll be handled as IPv4, missing brackets and double quotes.

This is being changed in the following way:

* ~`append` or `replace` mode: using `option forwarded` keyword instead, which already handles IPv6 correctly~
* `if-none` mode: `option forwarded` doesn't support acl, so using manual building and always checking if src is IPv6 - EDIT: `append` and `replace` as well.

For an unknown reason, the router deployment on some environments does not render `hdr(host)` correctly from `option forwarded`, neither declaring via `host-expr` nor leaving the default option. It is always empty. Moreover it works when running locally, and also on a local single node OCP deployment. To be investigated and improved in the future, since checking via acl and manually building the header has a small penalty on performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of IPv6 addresses in `Forwarded` header generation across all modes to ensure consistent formatting.

* **Tests**
  * Added comprehensive test coverage for `Forwarded` header generation, validating append, replace, and if-none mode behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->