### PR TITLE
add route http keep alive timeout

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -606,6 +606,9 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
           {{- end }}
   tcp-request content reject if !allowlist
         {{- end }}
+        {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout-http-keep-alive")) }}
+  timeout http-keep-alive  {{ $value }}
+        {{- end }}
         {{- with $value := clipHAProxyTimeoutValue (firstMatch $timeSpecPattern (index $cfg.Annotations "haproxy.router.openshift.io/timeout")) }}
   timeout server  {{ $value }}
         {{- end }}

--- a/pkg/router/template/configmanager/haproxy/manager.go
+++ b/pkg/router/template/configmanager/haproxy/manager.go
@@ -1112,5 +1112,6 @@ func modAnnotationsList(termination routev1.TLSTerminationType) []string {
 	annotations = append(annotations, "haproxy.router.openshift.io/hsts_header")
 	annotations = append(annotations, "haproxy.router.openshift.io/rewrite-target")
 	annotations = append(annotations, "router.openshift.io/cookie-same-site")
+	annotations = append(annotations, "haproxy.router.openshift.io/timeout-http-keep-alive")
 	return annotations
 }


### PR DESCRIPTION
Adds per route [http keep alive timeout](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#4.2-timeout%20http-keep-alive) annotation.

```
kind: Route
apiVersion: route.openshift.io/v1
metadata:
  name: nginx
  namespace: aiocptools
  annotations:
    haproxy.router.openshift.io/timeout-http-keep-alive: 30m
```

HAproxy config
```
backend be_edge_http:namesapce:nginx
  mode http
  option redispatch
  option forwardfor
  balance random
  timeout http-keep-alive 30m                    <---

  timeout check 5000ms
  http-request add-header X-Forwarded-Host %[req.hdr(host)]
  http-request add-header X-Forwarded-Port %[dst_port]
  http-request add-header X-Forwarded-Proto http if !{ ssl_fc }
  http-request add-header X-Forwarded-Proto https if { ssl_fc }
  http-request add-header X-Forwarded-Proto-Version h2 if { ssl_fc_alpn -i h2 }
  http-request add-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
```