### PR TITLE
OCPBUGS-74511: remove RouteExternalCertificate feature gate

### DIFF
--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -112,7 +112,7 @@ func (o *RouterSelection) Bind(flag *pflag.FlagSet) {
 	flag.MarkDeprecated("enable-ingress", "Ingress resources are now synchronized to routes automatically.")
 	flag.StringVar(&o.ListenAddr, "listen-addr", env("ROUTER_LISTEN_ADDR", ""), "The name of an interface to listen on to expose metrics and health checking. If not specified, will not listen. Overrides stats port.")
 	flag.BoolVar(&o.WatchEndpoints, "watch-endpoints", isTrue(env("ROUTER_WATCH_ENDPOINTS", "")), "Watch Endpoints instead of the EndpointSlice resource.")
-	flag.BoolVar(&o.AllowExternalCertificates, "allow-external-certificates", isTrue(env("ROUTER_ENABLE_EXTERNAL_CERTIFICATE", "")), "Enable RouteSecretManager plugin and validation of external certificates.")
+	flag.BoolVar(&o.AllowExternalCertificates, "allow-external-certificates", isTrue(env("ROUTER_ENABLE_EXTERNAL_CERTIFICATE", "True")), "Enable RouteSecretManager plugin and validation of external certificates.")
 }
 
 // RouteUpdate updates the route before it is seen by the cache.


### PR DESCRIPTION
RouteExternalCertificate featuregate now is enabled by default. We used to have this option defaulting to False, cluster-ingress-operator is responsible to always configure the correct value, which is now moving to a hardcoded True. Router on the other side continues having it parameterized.

We are changing its behavior as True. This better aligns with the value that is provided by cluster-ingress-operator, in case the router isrunning standalone / development environment, and the option is not configured.

https://issues.redhat.com/browse/OCPBUGS-74511