### PR TITLE
NE-2664: parameterize haproxy version

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -19,7 +19,7 @@ $ make
 * An admin-scoped `KUBECONFIG` for the cluster.
 * Install [imagebuilder](https://github.com/openshift/imagebuilder)
 
-#### Building a Modified Router Image Locally & Deploying to the Cluster
+### Building a Modified Router Image Locally & Deploying to the Cluster
 
 To test Router changes on an available cluster, utilize `Dockerfile.debug` and
 `Makefile.debug` in `hack/`.
@@ -44,6 +44,25 @@ Alternatively, after setting `IMAGE`, you can run `make dwim` (do what I mean) t
 In case OpenShift is deployed as single node, `push` can be changed to `scp` by running `make dwim-single` instead. Node needs sshkey configured. No need to set `IMAGE` envvar.
 
 When done testing, use `make -f hack/Makefile.debug reset` to re-enable the CVO and Ingress Operator.
+
+### Building router image with two or more haproxy versions
+
+WIP, missing some makefile work.
+
+```bash
+make build && \
+  podman build -t localhost/router -f hack/Dockerfile.multi . && \
+  podman save localhost/router | gzip | ssh core@<node> sudo podman load
+```
+
+Defaults to create router with 2.8.18 and 3.2.11, override default using `haproxy_versions` arg, e.g. `--build-arg haproxy_versions=2.8.10,2.8.18,...`
+
+Optionally add the following envvar on router deployment, defaults to use the first one from the `haproxy_versions` arg.
+
+```yaml
+        - name: ROUTER_HAPROXY_VERSION
+          value: 2.8.18 # or any other pre-installed version
+```
 
 ## Tests
 

--- a/hack/Dockerfile.multi
+++ b/hack/Dockerfile.multi
@@ -1,0 +1,40 @@
+ARG haproxy_versions=2.8.18,3.2.11 ## choose one of them to populate ROUTER_HAPROXY_VERSION
+
+FROM registry.access.redhat.com/ubi9/ubi as builder
+ARG haproxy_versions
+RUN yum install -y make pcre2-devel gcc openssl-devel util-linux && yum clean all
+RUN mkdir -p /tmp/haproxy && \
+    cd /tmp/haproxy && \
+    for v in ${haproxy_versions//,/ }; do \
+        curl -LO https://www.haproxy.org/download/${v%.*}/src/haproxy-${v}.tar.gz; \
+        tar xzf haproxy-${v}.tar.gz; \
+    done
+RUN cd /tmp/haproxy && \
+    for v in ${haproxy_versions//,/ }; do \
+        cd haproxy-${v}; \
+        make TARGET=linux-glibc USE_OPENSSL=1 USE_PROMEX=1 USE_PCRE2=1 USE_PCRE2_JIT=1; \
+        ./haproxy -v; \
+        cp haproxy /usr/sbin/haproxy-${v}; \
+        setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy-${v}; \
+        cd ..; \
+    done
+
+FROM registry.access.redhat.com/ubi9/ubi
+ARG haproxy_versions
+COPY --from=builder /usr/sbin/haproxy-* /usr/sbin/
+RUN yum install -y rsyslog procps-ng socat && yum clean all
+RUN mkdir -p /var/lib/haproxy/router/{certs,cacerts,allowlists} && \
+    mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log} && \
+    touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
+    chown -R :0 /var/lib/haproxy && \
+    chmod -R g+w /var/lib/haproxy
+COPY images/router/haproxy/ /var/lib/haproxy/
+COPY openshift-router /usr/bin/openshift-router
+USER 1001
+EXPOSE 80 443 1936
+WORKDIR /var/lib/haproxy/conf
+ENV XDG_CONFIG_HOME=/tmp \
+    TEMPLATE_FILE=/var/lib/haproxy/conf/haproxy-config.template \
+    RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy \
+    ROUTER_HAPROXY_VERSION=${haproxy_versions%%,*}
+ENTRYPOINT ["/usr/bin/openshift-router", "--v=2"]

--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -73,12 +73,17 @@ if [ -n "${ROUTER_SHUTDOWN-}" ]; then
   exit 1
 fi
 
+haproxy_bin=/usr/sbin/haproxy
+if [ -n "${ROUTER_HAPROXY_VERSION-}" ]; then
+  haproxy_bin+="-$ROUTER_HAPROXY_VERSION"
+fi
+
 reload_status=0
 if [ -n "$old_pids" ]; then
-  /usr/sbin/haproxy -f $config_file -p $pid_file -x /var/lib/haproxy/run/haproxy.sock -sf $old_pids
+  $haproxy_bin -f $config_file -p $pid_file -x /var/lib/haproxy/run/haproxy.sock -sf $old_pids
   reload_status=$?
 else
-  /usr/sbin/haproxy -f $config_file -p $pid_file
+  $haproxy_bin -f $config_file -p $pid_file
   reload_status=$?
 fi
 


### PR DESCRIPTION
add two new envvars used to parameterize how to start or reload haproxy.

* `ROUTER_HAPROXY_VERSION`: defines the haproxy version to use. I must be one of the installed versions. If missing, it defaults to not use any suffix, preserving the same behavior before the change.

* `ROUTER_HAPROXY_MASTER_UNIX_SOCKET`: defines the full qualified path of master's unix socket. If provided, a reload command is issued to master instead of using the reload script, so configuring this option makes ROUTER_HAPROXY_VERSION to be ignored. If missing, the previous behavior is used, which is to call the reload script.