### PR TITLE
OCPBUGS-49738: fix handling of host conflict

### DIFF
--- a/pkg/router/controller/host_admitter.go
+++ b/pkg/router/controller/host_admitter.go
@@ -2,8 +2,10 @@ package controller
 
 import (
 	"fmt"
+	"slices"
 
 	kapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -19,30 +21,17 @@ type RouteAdmissionFunc func(*routev1.Route) error
 type RouteMap map[string][]*routev1.Route
 
 // RemoveRoute removes any existing routes that match the given route's namespace and name for a key
-func (srm RouteMap) RemoveRoute(key string, route *routev1.Route) bool {
-	k := 0
-	removed := false
+func (srm RouteMap) RemoveRoute(key string, route *routev1.Route) {
+	source := srm[key]
+	remaining := slices.DeleteFunc(source, func(r *routev1.Route) bool {
+		return r.Namespace == route.Namespace && r.Name == route.Name
+	})
 
-	m := srm[key]
-	for i, v := range m {
-		if m[i].Namespace == route.Namespace && m[i].Name == route.Name {
-			removed = true
-		} else {
-			m[k] = v
-			k++
-		}
-	}
-
-	// set the slice length to the final size.
-	m = m[:k]
-
-	if len(m) > 0 {
-		srm[key] = m
+	if len(remaining) > 0 {
+		srm[key] = remaining
 	} else {
 		delete(srm, key)
 	}
-
-	return removed
 }
 
 func (srm RouteMap) InsertRoute(key string, route *routev1.Route) {
@@ -94,6 +83,10 @@ type HostAdmitter struct {
 	claimedHosts     RouteMap
 	claimedWildcards RouteMap
 	blockedWildcards RouteMap
+
+	// routeHosts caches the previous host of a route, used to lookup
+	// old entries in the claimed hosts and wildcards hashmaps.
+	routeHosts map[types.UID]string
 }
 
 // NewHostAdmitter creates a plugin wrapper that checks whether or not to
@@ -111,6 +104,7 @@ func NewHostAdmitter(plugin router.Plugin, fn RouteAdmissionFunc, allowWildcards
 		claimedHosts:     RouteMap{},
 		claimedWildcards: RouteMap{},
 		blockedWildcards: RouteMap{},
+		routeHosts:       make(map[types.UID]string),
 	}
 }
 
@@ -149,10 +143,16 @@ func (p *HostAdmitter) HandleRoute(eventType watch.EventType, route *routev1.Rou
 			}
 
 		case watch.Deleted:
-			p.claimedHosts.RemoveRoute(route.Spec.Host, route)
-			wildcardKey := routeapihelpers.GetDomainForHost(route.Spec.Host)
-			p.claimedWildcards.RemoveRoute(wildcardKey, route)
-			p.blockedWildcards.RemoveRoute(wildcardKey, route)
+			// Remove claimed and blocked entries based on the old host and old wildcard key:
+			// the current one (route.Spec.Host) could have been rejected due to a host conflict,
+			// in that case the claimed and blocked maps are not updated.
+			if oldHost, found := p.routeHosts[route.UID]; found {
+				oldWildcardKey := routeapihelpers.GetDomainForHost(oldHost)
+				p.claimedHosts.RemoveRoute(oldHost, route)
+				p.blockedWildcards.RemoveRoute(oldWildcardKey, route)
+				p.claimedWildcards.RemoveRoute(oldWildcardKey, route)
+				delete(p.routeHosts, route.UID)
+			}
 		}
 	}
 
@@ -214,28 +214,31 @@ func (p *HostAdmitter) addRoute(route *routev1.Route) error {
 	// Add the new route
 	wildcardKey := routeapihelpers.GetDomainForHost(route.Spec.Host)
 
+	// Restore the old host and old wildcard key, removing from the previously claimed ones
+	if oldHost, found := p.routeHosts[route.UID]; found {
+		oldWildcardKey := routeapihelpers.GetDomainForHost(oldHost)
+		// ensure the route doesn't exist as a claimed host or blocked wildcard - in case it previously was
+		p.claimedHosts.RemoveRoute(oldHost, route)
+		p.blockedWildcards.RemoveRoute(oldWildcardKey, route)
+		p.claimedWildcards.RemoveRoute(oldWildcardKey, route)
+	}
+
 	switch route.Spec.WildcardPolicy {
 	case routev1.WildcardPolicyNone:
 		// claim the host, block wildcards that would conflict with this host
 		p.claimedHosts.InsertRoute(route.Spec.Host, route)
 		p.blockedWildcards.InsertRoute(wildcardKey, route)
-		// ensure the route doesn't exist as a claimed wildcard (in case it previously was)
-		p.claimedWildcards.RemoveRoute(wildcardKey, route)
-
 	case routev1.WildcardPolicySubdomain:
 		// claim the wildcard
 		p.claimedWildcards.InsertRoute(wildcardKey, route)
-		// ensure the route doesn't exist as a claimed host or blocked wildcard
-		p.claimedHosts.RemoveRoute(route.Spec.Host, route)
-		p.blockedWildcards.RemoveRoute(wildcardKey, route)
 	default:
-		p.claimedHosts.RemoveRoute(route.Spec.Host, route)
-		p.claimedWildcards.RemoveRoute(wildcardKey, route)
-		p.blockedWildcards.RemoveRoute(wildcardKey, route)
 		err := fmt.Errorf("unsupported wildcard policy %s", route.Spec.WildcardPolicy)
 		p.recorder.RecordRouteRejection(route, "RouteNotAdmitted", err.Error())
 		return err
 	}
+
+	// adding/updating host succeeded, update the current host for this route's UID
+	p.routeHosts[route.UID] = route.Spec.Host
 
 	return nil
 }

--- a/pkg/router/controller/host_admitter_test.go
+++ b/pkg/router/controller/host_admitter_test.go
@@ -16,6 +16,7 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/client-go/route/clientset/versioned/fake"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -155,10 +156,11 @@ func TestHostAdmit(t *testing.T) {
 
 func TestWildcardHostDeny(t *testing.T) {
 	p := &fakePlugin{}
-	admitter := NewHostAdmitter(p, wildcardRejecter, false, false, LogRejections)
+	admitter := NewHostAdmitter(p, wildcardAdmitter, true, false, LogRejections)
 	tests := []struct {
 		name   string
 		host   string
+		path   string
 		policy routev1.WildcardPolicyType
 		errors bool
 	}{
@@ -174,6 +176,7 @@ func TestWildcardHostDeny(t *testing.T) {
 		{
 			name:   "allowed2",
 			host:   "www.host.admission.test",
+			path:   "/api",
 			policy: routev1.WildcardPolicyNone,
 			errors: false,
 		},
@@ -241,8 +244,9 @@ func TestWildcardHostDeny(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tc.name,
 				Namespace: "deny",
+				UID:       types.UID(tc.name),
 			},
-			Spec: routev1.RouteSpec{Host: tc.host},
+			Spec: routev1.RouteSpec{Host: tc.host, Path: tc.path, WildcardPolicy: tc.policy},
 		}
 
 		err := admitter.HandleRoute(watch.Added, route)
@@ -255,6 +259,118 @@ func TestWildcardHostDeny(t *testing.T) {
 				t.Fatalf("Test case %s expected no errors, got %v", tc.name, err)
 			}
 		}
+	}
+}
+
+func TestWildcardHostUpdate(t *testing.T) {
+	// This test explores the failure reported in
+	// https://redhat.atlassian.net/browse/OCPBUGS-49738
+	tests := []struct {
+		namePrefix    string
+		oldHostRoute1 string
+		oldHostRoute2 string
+		newHostRoute1 string
+		newHostRoute2 string
+		policy        routev1.WildcardPolicyType
+		expectedErr1  string
+		expectedErr2  string
+	}{
+		{
+			namePrefix:    "wildcard-none",
+			oldHostRoute1: "host1.local",
+			oldHostRoute2: "host2.local",
+			newHostRoute1: "host3.local",
+			newHostRoute2: "host1.local",
+			policy:        routev1.WildcardPolicyNone,
+		},
+		{
+			namePrefix:    "wildcard-subdomain",
+			oldHostRoute1: "host1.local1",
+			oldHostRoute2: "host2.local2",
+			newHostRoute1: "host3.local3",
+			newHostRoute2: "host1.local1",
+			policy:        routev1.WildcardPolicySubdomain,
+		},
+		{
+			namePrefix:    "wildcard-none-conflict",
+			oldHostRoute1: "host1.local",
+			oldHostRoute2: "host2.local",
+			newHostRoute1: "host1.local",
+			newHostRoute2: "host1.local",
+			policy:        routev1.WildcardPolicyNone,
+			expectedErr2:  `route host-update/wildcard-none-conflict-route1 has host host1.local`,
+		},
+		{
+			namePrefix:    "wildcard-subdomain-conflict",
+			oldHostRoute1: "host1.local1",
+			oldHostRoute2: "host2.local2",
+			newHostRoute1: "host1.local1",
+			newHostRoute2: "host1.local1",
+			policy:        routev1.WildcardPolicySubdomain,
+			expectedErr2:  `wildcard route host-update/wildcard-subdomain-conflict-route1 has host *.local1, blocking host1.local1`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.namePrefix, func(t *testing.T) {
+			p := &fakePlugin{}
+			admitter := NewHostAdmitter(p, wildcardAdmitter, true, false, LogRejections)
+
+			// do not change route instances, instead, create new ones with new values
+			createRoute := func(nameSuffix, host string) *routev1.Route {
+				name := tc.namePrefix + "-" + nameSuffix
+				return &routev1.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: "host-update",
+						UID:       types.UID(name),
+					},
+					Spec: routev1.RouteSpec{Host: host, WildcardPolicy: tc.policy},
+				}
+			}
+
+			var err error
+
+			// add routes
+			oldRoute1 := createRoute("route1", tc.oldHostRoute1)
+			oldRoute2 := createRoute("route2", tc.oldHostRoute2)
+			err = admitter.HandleRoute(watch.Added, oldRoute1)
+			require.NoError(t, err)
+			err = admitter.HandleRoute(watch.Added, oldRoute2)
+			require.NoError(t, err)
+
+			newRoute1 := createRoute("route1", tc.newHostRoute1)
+			newRoute2 := createRoute("route2", tc.newHostRoute2)
+			// modify both routes to the new hostname
+			err = admitter.HandleRoute(watch.Modified, newRoute1)
+			if tc.expectedErr1 == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.expectedErr1)
+			}
+			err = admitter.HandleRoute(watch.Modified, newRoute2)
+			if tc.expectedErr2 == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.expectedErr2)
+			}
+
+			// Delete both routes
+			err = admitter.HandleRoute(watch.Deleted, newRoute1)
+			require.NoError(t, err)
+			err = admitter.HandleRoute(watch.Deleted, newRoute2)
+			require.NoError(t, err)
+
+			// all the claimed and blocked host hashmaps should be empty
+			require.Len(t, admitter.claimedHosts, 0)
+			require.Len(t, admitter.blockedWildcards, 0)
+			require.Len(t, admitter.claimedWildcards, 0)
+			require.Len(t, admitter.routeHosts, 0)
+
+			// New route should be able to claim route1's original host
+			err = admitter.HandleRoute(watch.Added, oldRoute1)
+			require.NoError(t, err)
+		})
 	}
 }
 


### PR DESCRIPTION
Routes are grouped by host on three distinct hashmaps when allowWildcardRoutes is enabled. These hashmaps are updated whenever routes are added, modified or deleted, and their content is used to evaluate host conflicts. This hashmaps handling is done using the current host of the route resource, so, if the host value changes, the router does not find the entry on the hashmaps because it is using the current - and still not used - host value as the key.

The approach used on this update is to ignore the host from the router, and remove the resource from all the hosts instead, since the only match on all the hashmaps should be found on the key corresponding to the former host value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale host and wildcard conflicts when routes are updated, removed, or reassigned by ensuring prior host ownership is cleared before reclaiming.

* **Refactor**
  * Centralized and simplified route/host cleanup for more consistent claiming and release behavior.

* **Tests**
  * Added tests covering wildcard host lifecycle (add → modify → delete) to ensure hosts can be reclaimed without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->