### PR TITLE
OCPBUGS-67161: Replace HTTP backend liveness check with admin socket check

### DIFF
--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -636,9 +636,11 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 			return err
 		}
 		checkController := metrics.ControllerLive()
+		adminSocketURL := &url.URL{Scheme: "unix", Path: "/var/lib/haproxy/run/haproxy.sock"}
+		checkSocket := metrics.AdminSocketAvailable(adminSocketURL)
 		liveChecks := []healthz.HealthChecker{checkController}
 		if !(isTrue(env("ROUTER_BIND_PORTS_BEFORE_SYNC", ""))) {
-			liveChecks = append(liveChecks, checkBackend)
+			liveChecks = append(liveChecks, checkSocket)
 		}
 
 		kubeconfig, _, err := o.Config.KubeConfig()

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -563,6 +563,7 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 
 	var reloadCallbacks []func()
 
+	adminSocketURL := &url.URL{Scheme: "unix", Path: "/var/lib/haproxy/run/haproxy.sock"}
 	statsPort := o.StatsPort
 	switch {
 	case o.MetricsType == "haproxy" && statsPort != 0:
@@ -607,7 +608,7 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 
 		collector, err := haproxy.NewPrometheusCollector(haproxy.PrometheusOptions{
 			// Only template router customizers who alter the image should need this
-			ScrapeURI: env("ROUTER_METRICS_HAPROXY_SCRAPE_URI", ""),
+			ScrapeURI: env("ROUTER_METRICS_HAPROXY_SCRAPE_URI", adminSocketURL.String()),
 			// Only template router customizers who alter the image should need this
 			PidFile:            env("ROUTER_METRICS_HAPROXY_PID_FILE", ""),
 			Timeout:            timeout,
@@ -636,7 +637,6 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 			return err
 		}
 		checkController := metrics.ControllerLive()
-		adminSocketURL := &url.URL{Scheme: "unix", Path: "/var/lib/haproxy/run/haproxy.sock"}
 		checkSocket := metrics.AdminSocketAvailable(adminSocketURL)
 		liveChecks := []healthz.HealthChecker{checkController}
 		if !(isTrue(env("ROUTER_BIND_PORTS_BEFORE_SYNC", ""))) {
@@ -737,7 +737,7 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 			return err
 		}
 		cmopts := templateplugin.ConfigManagerOptions{
-			ConnectionInfo:         "unix:///var/lib/haproxy/run/haproxy.sock",
+			ConnectionInfo:         adminSocketURL.String(),
 			CommitInterval:         o.CommitInterval,
 			BlueprintRoutes:        blueprintRoutes,
 			BlueprintRoutePoolSize: o.BlueprintRoutePoolSize,

--- a/pkg/router/metrics/haproxy/haproxy.go
+++ b/pkg/router/metrics/haproxy/haproxy.go
@@ -732,9 +732,6 @@ func NewPrometheusCollector(opts PrometheusOptions) (*Exporter, error) {
 }
 
 func defaultOptions(opts PrometheusOptions) PrometheusOptions {
-	if len(opts.ScrapeURI) == 0 {
-		opts.ScrapeURI = "unix:///var/lib/haproxy/run/haproxy.sock"
-	}
 	if len(opts.PidFile) == 0 {
 		opts.PidFile = "/var/lib/haproxy/run/haproxy.pid"
 	}

--- a/pkg/router/metrics/health.go
+++ b/pkg/router/metrics/health.go
@@ -115,3 +115,34 @@ func ProxyProtocolHTTPBackendAvailable(u *url.URL) healthz.HealthChecker {
 		return nil
 	})
 }
+
+// AdminSocketAvailable returns a healthz check that verifies the
+// HAProxy process is alive by sending "show version" to its admin socket and
+// expecting a non-empty response.
+func AdminSocketAvailable(u *url.URL) healthz.HealthChecker {
+	return healthz.NamedCheck("admin-socket", func(_ *http.Request) error {
+		conn, err := net.DialTimeout("unix", u.Path, 2*time.Second)
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		conn.SetDeadline(time.Now().Add(2 * time.Second))
+
+		if _, err := conn.Write([]byte("show version\n")); err != nil {
+			return err
+		}
+
+		buf := make([]byte, 10)
+		n, err := conn.Read(buf)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return fmt.Errorf("empty response from admin socket")
+		}
+
+		log.V(4).Info("probe succeeded", "url", u.String())
+		return nil
+	})
+}


### PR DESCRIPTION
## Summary
- Replace the HTTP-based HAProxy liveness check with an admin socket `show version` command
- The HTTP liveness check counts against HAProxy's `maxconn` limit. When `maxconn` is reached due to client traffic, the probe HTTP request gets queued or rejected, causing probe failures and unnecessary container restarts even though HAProxy is still running
- The admin socket is not subject to `maxconn`, so the liveness probe remains reliable under high connection load
- The readiness probe continues to use the HTTP backend check

## Manual test

Using https://github.com/mparram/test-backend.

Standard router image:
```
# 1 pod sends ~500 req/s
$ oc -n test-client get pods
NAME                           READY   STATUS    RESTARTS   AGE
test-client-58c4687f55-5skdb   1/1     Running   0          9m13s
test-client-58c4687f55-bqffc   1/1     Running   0          9m13s
test-client-58c4687f55-gvsl7   1/1     Running   0          9m13s
test-client-58c4687f55-kpvm9   1/1     Running   0          9m13s
test-client-58c4687f55-wkxpp   1/1     Running   0          9m13s

$ oc -n openshift-ingress get pods router-default-d5db46b5d-p6k9w -o yaml | grep image:
    image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4bdfb4ce97c4391f07c4183b771dab332f311f2d707adb03281b43fd4dc7e196
    image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4bdfb4ce97c4391f07c4183b771dab332f311f2d707adb03281b43fd4dc7e196

$ oc -n openshift-ingress get pods router-default-d5db46b5d-p6k9w -o yaml | grep -A1 MAX_CONN
    - name: ROUTER_MAX_CONNECTIONS
      value: "2000"

# Router pods are restarting
$ oc -n openshift-ingress  get pods
NAME                             READY   STATUS    RESTARTS        AGE
router-default-d5db46b5d-2q7mh   1/1     Running   2 (8m11s ago)   11m
router-default-d5db46b5d-p6k9w   1/1     Running   4 (7m31s ago)   11m

$ oc -n openshift-ingress logs router-default-d5db46b5d-p6k9w -p
. . .
I0224 17:45:24.118761       1 healthz.go:311] backend-proxy-http check failed: healthz
[-]backend-proxy-http failed: dial tcp [::1]:80: connect: connection refused
I0224 17:45:27.608009       1 healthz.go:311] backend-proxy-http check failed: healthz
[-]backend-proxy-http failed: dial tcp [::1]:80: connect: connection refused
I0224 17:45:34.118481       1 healthz.go:311] backend-proxy-http check failed: healthz
[-]backend-proxy-http failed: dial tcp [::1]:80: connect: connection refused
I0224 17:45:37.607969       1 healthz.go:311] backend-proxy-http check failed: healthz
[-]backend-proxy-http failed: dial tcp [::1]:80: connect: connection refused
I0224 17:45:43.161206       1 template.go:844] "msg"="Shutdown requested, waiting 45s for new connections to cease" "logger"="router"
I0224 17:45:44.119374       1 healthz.go:311] backend-proxy-http check failed: healthz
[-]backend-proxy-http failed: read tcp 127.0.0.1:49768->127.0.0.1:80: i/o timeout
I0224 17:45:47.607867       1 healthz.go:311] backend-proxy-http,process-running check failed: healthz
[-]backend-proxy-http failed: read tcp 127.0.0.1:49782->127.0.0.1:80: i/o timeout
[-]process-running failed: process is terminating
```

Router image with the fix (and `show info` logs):
```
$ oc -n openshift-ingress get pods router-default-7fc6b96c5b-thbsm -o yaml | grep -A1 MAX_CONN
    - name: ROUTER_MAX_CONNECTIONS
      value: "2000"

$ oc -n openshift-ingress get pods router-default-7fc6b96c5b-thbsm -o yaml | grep image:
    image: quay.io/alebedev/router:2.24.173
    image: quay.io/alebedev/router:2.24.173

# readiness probe goes on/off
$ oc -n openshift-ingress get pods
NAME                              READY   STATUS    RESTARTS   AGE
router-default-7fc6b96c5b-qbnzp   0/1     Running   0          4m9s
router-default-7fc6b96c5b-thbsm   1/1     Running   0          4m10s

$ oc -n openshift-ingress get pods
NAME                              READY   STATUS    RESTARTS   AGE
router-default-7fc6b96c5b-qbnzp   0/1     Running   0          4m41s
router-default-7fc6b96c5b-thbsm   0/1     Running   0          4m42s

# while liveness probe keeps running ok (no admin-socket healthz failures)
$ oc -n openshift-ingress logs router-default-7fc6b96c5b-qbnzp | grep -c admin-socket
0

$ oc -n openshift-ingress logs router-default-7fc6b96c5b-thbsm | grep CurrConns
CurrConns: 0
CurrConns: 1
CurrConns: 1
CurrConns: 2
CurrConns: 3
CurrConns: 4
CurrConns: 5
CurrConns: 0
CurrConns: 1
CurrConns: 2
CurrConns: 3
CurrConns: 4
CurrConns: 5
CurrConns: 6
CurrConns: 7
CurrConns: 8
CurrConns: 0
CurrConns: 1
CurrConns: 2
CurrConns: 931
CurrConns: 2000
CurrConns: 2000
CurrConns: 1998
CurrConns: 1994
CurrConns: 2000
CurrConns: 2000
CurrConns: 2000
CurrConns: 824
CurrConns: 359
CurrConns: 2000
CurrConns: 2000
CurrConns: 2000
CurrConns: 1810
CurrConns: 9
CurrConns: 10
CurrConns: 11
CurrConns: 12
CurrConns: 13
```

If haproxy process is dead the liveness probe kicks in as expected:
```
$ oc -n openshift-ingress get pods
NAME                              READY   STATUS    RESTARTS       AGE
router-default-66b9cf9587-r7s2b   1/1     Running   1 (2m9s ago)   11m

$ oc -n openshift-ingress logs router-default-66b9cf9587-r7s2b -p | grep admin-socket
I0305 14:18:14.175477       1 healthz.go:311] admin-socket check failed: healthz
[-]admin-socket failed: dial unix /var/lib/haproxy/run/haproxy.sock: connect: connection refused
I0305 14:18:24.175643       1 healthz.go:311] admin-socket check failed: healthz
[-]admin-socket failed: dial unix /var/lib/haproxy/run/haproxy.sock: connect: connection refused
I0305 14:18:34.175771       1 healthz.go:311] admin-socket check failed: healthz
[-]admin-socket failed: dial unix /var/lib/haproxy/run/haproxy.sock: connect: connection refused
```