### PR TITLE
TRT-2597: [Revert "NE-2333: Add support for configurable SSL curves in HAProxy configuration"](https://github.com/openshift/router/pull/754#top)

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -131,14 +131,6 @@ global
     {{- end }}
   {{- end }}
 
-  # The user can provide a set of default supported groups using the ROUTER_CURVES variable.
-  # By default X25519MLKEM768, X25519, and P-256 are used.
-  {{- with (env "ROUTER_CURVES") }}
-  ssl-default-bind-curves {{ . }}
-  {{- else }}
-  ssl-default-bind-curves X25519MLKEM768:X25519:P-256
-  {{- end }}
-
 defaults
   {{- with $value := env "ROUTER_MAX_CONNECTIONS" "50000" }}
     {{- if isInteger $value }}


### PR DESCRIPTION
Reverts openshift/router#678

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Multiple fips job failures due to `unable to set SSL curves list`.  Issue is tracked via [TRT-2597](https://redhat.atlassian.net/browse/TRT-2597)

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-aggregate periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-ovn-upgrade-fips 10
```

CC: @richardsonnick
