### PR TITLE
NE-2333: Add support for TLS curves in HAProxy configuration

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -131,6 +131,12 @@ global
     {{- end }}
   {{- end }}
 
+  # By default when a ROUTER_CURVES is not defined HAProxy
+  # will use its built-in default supported groups for TLS key exchange.
+  {{- with (env "ROUTER_CURVES") }}
+  ssl-default-bind-curves {{ . }}
+  {{- end }}
+
 defaults
   {{- with $value := env "ROUTER_MAX_CONNECTIONS" "50000" }}
     {{- if isInteger $value }}


### PR DESCRIPTION
Introduces the ROUTER_CURVES environment variable which maps directly to HAProxy's ssl-default-bind-curves directive, allowing operators to configure the TLS key exchange groups used by the router. When ROUTER_CURVES is not set, no directive is emitted and HAProxy uses its built-in defaults.