### PR TITLE
OCPBUGS-84323: log the reason why dcm failed

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -799,7 +799,7 @@ func (r *templateRouter) dynamicallyAddRoute(backendKey ServiceAliasConfigKey, r
 
 	err := r.dynamicConfigManager.AddRoute(backendKey, backend.RoutingKeyName, route)
 	if err != nil {
-		log.V(4).Info("router will reload as the ConfigManager could not dynamically add route for backend", "backendKey", backendKey, "error", err)
+		log.V(0).Info("router will reload as the ConfigManager could not dynamically add route for backend", "backendKey", backendKey, "error", err)
 		return false
 	}
 
@@ -818,7 +818,7 @@ func (r *templateRouter) dynamicallyAddRoute(backendKey ServiceAliasConfigKey, r
 				weight = 0
 			}
 			if err := r.dynamicConfigManager.ReplaceRouteEndpoints(backendKey, oldEndpoints, newEndpoints, weight); err != nil {
-				log.V(4).Info("router will reload as the ConfigManager could not dynamically replace endpoints for route backend",
+				log.V(0).Info("router will reload as the ConfigManager could not dynamically replace endpoints for route backend",
 					"backendKey", backendKey, "serviceKey", key, "error", err)
 				return false
 			}
@@ -844,7 +844,7 @@ func (r *templateRouter) dynamicallyRemoveRoute(backendKey ServiceAliasConfigKey
 	log.V(4).Info("dynamically removing route backend", "backendKey", backendKey)
 
 	if err := r.dynamicConfigManager.RemoveRoute(backendKey, route); err != nil {
-		log.V(4).Info("router will reload as the ConfigManager could not dynamically remove route backend", "backendKey", backendKey, "error", err)
+		log.V(0).Info("router will reload as the ConfigManager could not dynamically remove route backend", "backendKey", backendKey, "error", err)
 		return false
 	}
 
@@ -923,7 +923,7 @@ func (r *templateRouter) dynamicallyReplaceEndpoints(id ServiceUnitKey, service 
 		log.V(4).Info("dynamically replacing endpoints for associated backend", "backendKey", backendKey, "newEndpoints", newEndpoints)
 		if err := r.dynamicConfigManager.ReplaceRouteEndpoints(backendKey, oldEndpoints, newEndpoints, weight); err != nil {
 			// Error dynamically modifying the config, so return false to cause a reload to happen.
-			log.V(4).Info("router will reload as the ConfigManager could not dynamically replace endpoints for service", "service", id, "backendKey", backendKey, "weight", weight, "error", err)
+			log.V(0).Info("router will reload as the ConfigManager could not dynamically replace endpoints for service", "service", id, "backendKey", backendKey, "weight", weight, "error", err)
 			return false
 		}
 	}
@@ -950,7 +950,7 @@ func (r *templateRouter) dynamicallyRemoveEndpoints(service ServiceUnit, endpoin
 		log.V(4).Info("dynamically removing endpoints for associated backend", "backendKey", backendKey)
 		if err := r.dynamicConfigManager.RemoveRouteEndpoints(backendKey, endpoints); err != nil {
 			// Error dynamically modifying the config, so return false to cause a reload to happen.
-			log.V(4).Info("router will reload as the ConfigManager could not dynamically remove endpoints for backend", "backendKey", backendKey, "error", err)
+			log.V(0).Info("router will reload as the ConfigManager could not dynamically remove endpoints for backend", "backendKey", backendKey, "error", err)
 			return false
 		}
 	}


### PR DESCRIPTION
Template plugin calls DCM to try dynamically update HAProxy state. In case the dynamic update fails, an internal flag is raised to instruct the template plugin to reload the new configuration on a new HAProxy process. The reason of the failure is logged, however its level is above the default log verbosity, making it not to be added in the router logs. Since this is an exception scenario, those failures are being added on the default log verbosity in order to help debug some environment misbehavior.

https://redhat.atlassian.net/browse/OCPBUGS-84323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging visibility for configuration management errors during route operations. Error-related log messages now appear at higher verbosity levels to aid in troubleshooting when dynamic configuration updates fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->