### PR TITLE
NE-2664: add option to separate router and haproxy containers

### DIFF
--- a/images/router/haproxy/start-haproxy
+++ b/images/router/haproxy/start-haproxy
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -euo pipefail
+
+##
+## This script expects HAProxy running in foreground, do not initialize it in daemon mode!
+## Also, haproxy binary should be in the PATH.
+
+shutdownTimeoutSecs=${HAPROXY_MAX_SHUTDOWN_TIMEOUT:-30}
+if ! [[ "$shutdownTimeoutSecs" =~ ^[0-9]+$ ]]; then
+    echo "Invalid timeout: $shutdownTimeoutSecs"
+    exit 1
+fi
+
+signaled=0
+
+stopHAProxy() {
+    signaled=1
+
+    # HAProxy handles SIGUSR1 by finishing its process as soon as all the current connections,
+    # active or not, are closed by either the client or the backend server.
+    echo "Sending SIGUSR1 to HAProxy process $haproxyPID"
+    kill -s USR1 $haproxyPID
+
+    # Poll the process, retuning as soon as it is not alive anymore.
+    for i in $(seq 1 $shutdownTimeoutSecs); do
+        sleep 1
+        if ! kill -0 $haproxyPID 2>/dev/null; then
+            echo "All connections are closed"
+            return
+        fi
+    done
+
+    # HAProxy handles SIGTERM by closing all the TCP connections and waiting for the full TCP handshake
+    # (FIN / ACK / FIN-ACK) from both sides, and only after that it finishes. `kill` runs asynchronous,
+    # and `wait` maintains this script alive until haproxy finishes.
+    echo "SIGUSR1 timed out, sending SIGTERM to HAProxy process $haproxyPID"
+    kill -s TERM $haproxyPID 2>/dev/null || true
+}
+
+echo "Starting HAProxy. SIGUSR1 timeout is ${shutdownTimeoutSecs}s"
+haproxy "$@" &
+haproxyPID=$!
+
+trap stopHAProxy SIGTERM SIGUSR1 SIGINT
+trap "kill -s HUP $haproxyPID" SIGHUP
+
+exit_code=0
+while kill -0 $haproxyPID 2>/dev/null; do
+    # Start `wait` again in case it returned due to a non terminate signal, e.g. SIGHUP
+    wait $haproxyPID || exit_code=$?
+done
+
+# Received signal (usually SIGTERM) takes precedence during `wait`, overriding with a clean exit
+[ "$signaled" = 1 ] && exit 0
+
+echo "haproxy exited with status code $exit_code"
+exit $exit_code

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/library-go/pkg/route/secretmanager"
 
 	"github.com/openshift/router/pkg/router"
+	"github.com/openshift/router/pkg/router/client"
 	"github.com/openshift/router/pkg/router/controller"
 	"github.com/openshift/router/pkg/router/metrics"
 	"github.com/openshift/router/pkg/router/metrics/haproxy"
@@ -563,6 +564,9 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 
 	var reloadCallbacks []func()
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	adminSocketURL := &url.URL{Scheme: "unix", Path: "/var/lib/haproxy/run/haproxy.sock"}
 	statsPort := o.StatsPort
 	switch {
@@ -606,11 +610,17 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 			}
 		}
 
+		adminUnixSocket := os.Getenv("ROUTER_HAPROXY_ADMIN_UNIX_SOCKET")
+		hasHAProxySidecar := len(adminUnixSocket) > 0
+
+		pidFn := haproxyPidEmbedded
+		if hasHAProxySidecar {
+			pidFn = haproxyPidSidecar(ctx, adminUnixSocket)
+		}
 		collector, err := haproxy.NewPrometheusCollector(haproxy.PrometheusOptions{
 			// Only template router customizers who alter the image should need this
-			ScrapeURI: env("ROUTER_METRICS_HAPROXY_SCRAPE_URI", adminSocketURL.String()),
-			// Only template router customizers who alter the image should need this
-			PidFile:            env("ROUTER_METRICS_HAPROXY_PID_FILE", ""),
+			ScrapeURI:          env("ROUTER_METRICS_HAPROXY_SCRAPE_URI", adminSocketURL.String()),
+			PidFn:              pidFn,
 			Timeout:            timeout,
 			ServerThreshold:    serverThreshold,
 			BaseScrapeInterval: baseScrapeInterval,
@@ -639,7 +649,9 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 		checkController := metrics.ControllerLive()
 		checkSocket := metrics.AdminSocketAvailable(adminSocketURL)
 		liveChecks := []healthz.HealthChecker{checkController}
-		if !(isTrue(env("ROUTER_BIND_PORTS_BEFORE_SYNC", ""))) {
+		if !hasHAProxySidecar && !(isTrue(env("ROUTER_BIND_PORTS_BEFORE_SYNC", ""))) {
+			// Do not configure checkSocket if HAProxy is running on a sidecar,
+			// since its container already has liveness probe.
 			liveChecks = append(liveChecks, checkSocket)
 		}
 
@@ -760,6 +772,7 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 	secretManager := secretmanager.NewManager(kc, nil)
 
 	pluginCfg := templateplugin.TemplatePluginConfig{
+		AppCtx:                        ctx,
 		WorkingDir:                    o.WorkingDir,
 		TemplatePath:                  o.TemplateFile,
 		ReloadScriptPath:              o.ReloadScript,
@@ -841,6 +854,7 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 
 	select {
 	case <-stopCh:
+		cancel()
 		// 45s is the default interval that almost all cloud load balancers require to take an unhealthy
 		// endpoint out of rotation.
 		delay := getIntervalFromEnv("ROUTER_GRACEFUL_SHUTDOWN_DELAY", 45)
@@ -983,4 +997,51 @@ func getStatsAuth(statsUsernameFile, statsPasswordFile, statsUsername, statsPass
 	}
 
 	return statsUsername, statsPassword, nil
+}
+
+func haproxyPidEmbedded() (int, error) {
+	pidFile := env("ROUTER_METRICS_HAPROXY_PID_FILE", "/var/lib/haproxy/run/haproxy.pid")
+	content, err := os.ReadFile(pidFile)
+	if err != nil {
+		return 0, fmt.Errorf("can't read haproxy pid file: %s", err)
+	}
+	value, err := strconv.Atoi(strings.TrimSpace(string(content)))
+	if err != nil {
+		return 0, fmt.Errorf("can't parse haproxy pid file: %s", err)
+	}
+	return value, nil
+}
+
+func haproxyPidSidecar(ctx context.Context, unixSocket string) func() (int, error) {
+
+	// TODO: the `show proc` parsing should be part of the new HAProxy client instead.
+	// https://redhat.atlassian.net/browse/NE-2746
+
+	return func() (int, error) {
+		// `show proc` layout on 2.8+:
+		//
+		// #<PID>          <type>          <reloads>       <uptime>        <version>
+		// 420054          master          0 [failed: 0]   0d00h07m14s     2.8.18-ae90be6
+		// # workers
+		// 420056          worker          0               0d00h07m14s     2.8.18-ae90be6
+		// # programs
+		//
+		output, err := client.RunCommand(ctx, "unix://"+unixSocket, "show proc", client.ClientOpts{})
+		if err != nil {
+			return 0, fmt.Errorf("error reading the current haproxy PID: %w", err)
+		}
+		lines := strings.Split(output, "\n")
+		if len(lines) < 4 {
+			return 0, fmt.Errorf("show proc command returned an unexpected response: %s", output)
+		}
+		workerFields := strings.Fields(lines[3])
+		if len(workerFields) == 0 || strings.HasPrefix(workerFields[0], "#") {
+			return 0, fmt.Errorf("show proc command returned no worker instance: %s", output)
+		}
+		pid, err := strconv.Atoi(workerFields[0])
+		if err != nil {
+			return 0, fmt.Errorf("show proc command returned an invalid PID number: %q: %w", workerFields[0], err)
+		}
+		return pid, nil
+	}
 }

--- a/pkg/router/client/client_testutils/haproxyclient_testutils.go
+++ b/pkg/router/client/client_testutils/haproxyclient_testutils.go
@@ -1,0 +1,63 @@
+package client_testutils
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// clientSockID makes it simple to create concurrent unix socket files
+var clientSockID atomic.Int32
+
+// CreateServerMock creates a server mock and returns its listening unix socket (without the unix:// prefix).
+// Responses is a cmd->output hashmap, and cmd should not add the last trailing line break the client adds
+// when calling HAProxy. defer stopServer() just after creating the mock server to ensure it is properly stopped.
+func CreateServerMock(t *testing.T, responses map[string]string) (unixSocket string, stopServer func()) {
+	unixSocket = path.Join(os.TempDir(), fmt.Sprintf("haproxy-client-%02d.sock", clientSockID.Add(1)))
+	// clean up from old tests that crashed
+	_ = os.RemoveAll(unixSocket)
+	listener, err := net.Listen("unix", unixSocket)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := os.RemoveAll(unixSocket)
+		require.NoError(t, err)
+	})
+
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			conn, err := listener.Accept()
+			if errors.Is(err, net.ErrClosed) || !assert.NoError(t, err) {
+				return
+			}
+			r, err := conn.Read(buf)
+			if !assert.NoError(t, err) {
+				return
+			}
+			cmd := strings.TrimSuffix(string(buf[:r]), "\n")
+			response, found := responses[cmd]
+			if !found {
+				response = "command not found: " + cmd
+			}
+			_, err = conn.Write([]byte(response))
+			if !assert.NoError(t, err) {
+				return
+			}
+			err = conn.Close()
+			if !assert.NoError(t, err) {
+				return
+			}
+		}
+	}()
+
+	return unixSocket, func() { listener.Close() }
+}

--- a/pkg/router/client/haproxyclient.go
+++ b/pkg/router/client/haproxyclient.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// ClientOpts has options for the HAProxy client. All options have a proper
+// default value, so the zero value is also a valid configuration.
+type ClientOpts struct {
+	// Timeout of the API call. The default value is 5s if not declared.
+	Timeout time.Duration
+}
+
+var haproxyEndpointRegex = regexp.MustCompile(`^(tcp|unix)://(.*)$`)
+
+// RunCommand sends the specified `cmd` to the HAProxy endpoint, which could be either
+// the API or the admin/master one. `endpoint` has the "<schema>://<address>" syntax
+// which could be either "tcp://ip-or-name:port-number" or "unix:///path/to/unix-socket".
+func RunCommand(ctx context.Context, endpoint, cmd string, opts ClientOpts) (string, error) {
+
+	// TODO: this is the starting point of a new HAProxy client, managed by the NI&D team.
+	// Further improvements already tracked via https://redhat.atlassian.net/browse/NE-2746
+
+	if opts.Timeout == 0 {
+		opts.Timeout = 5 * time.Second
+	}
+
+	var d net.Dialer
+	endpointParts := haproxyEndpointRegex.FindStringSubmatch(endpoint)
+	if len(endpointParts) != 3 {
+		return "", fmt.Errorf("invalid endpoint: %s", endpoint)
+	}
+	conn, err := d.DialContext(ctx, endpointParts[1], endpointParts[2])
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	rawConn, ok := conn.(interface{ CloseWrite() error })
+	if !ok {
+		// Just a safeguard, since validation enforces TCP and Unix only, and both implements CloseWrite().
+		return "", fmt.Errorf("connection type %T does not implement CloseWrite(), cannot half close the connection", conn)
+	}
+
+	err = conn.SetDeadline(time.Now().Add(opts.Timeout))
+	if err != nil {
+		return "", err
+	}
+	// Immediately cancel the connection in case the context is cancelled.
+	stop := context.AfterFunc(ctx, func() {
+		conn.SetDeadline(time.Now())
+	})
+	defer stop()
+
+	// Adding a line-break if missing, HAProxy expects it to run the command.
+	if !strings.HasSuffix(cmd, "\n") {
+		cmd += "\n"
+	}
+	_, err = conn.Write([]byte(cmd))
+	if err != nil {
+		return "", err
+	}
+
+	// Half close the connection, this tells HAProxy to close its write counterpart
+	// (our read) as soon as it finishes to respond.
+	err = rawConn.CloseWrite()
+	if err != nil {
+		return "", err
+	}
+
+	// Reading response into a loop and populating a buffer with the response chunks.
+	// io.EOF response means the read socket was closed by haproxy after all the data being transmitted.
+	buf := make([]byte, 1024)
+	output := strings.Builder{}
+	for {
+		count, err := conn.Read(buf)
+		output.Write(buf[:count])
+		if err == io.EOF {
+			return strings.TrimSpace(output.String()), nil
+		}
+		if err != nil {
+			return "", err
+		}
+	}
+}

--- a/pkg/router/client/haproxyclient_test.go
+++ b/pkg/router/client/haproxyclient_test.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openshift/router/pkg/router/client/client_testutils"
+)
+
+func TestRunCommand(t *testing.T) {
+
+	// TODO: improve with new scenarios as part of https://redhat.atlassian.net/browse/NE-2746
+	// Non exhaustive list of examples:
+	// - half-closed connection
+	// - timeouts
+	// - read/write failures
+	// - response bigger than the buffer (1024 bytes)
+
+	ctx := context.Background()
+
+	t.Run("should fail on unexpected protocol", func(t *testing.T) {
+		_, err := RunCommand(ctx, "someproto://thecontent", "valid command", ClientOpts{})
+		require.EqualError(t, err, `invalid endpoint: someproto://thecontent`)
+	})
+
+	t.Run("should fail on invalid tcp address", func(t *testing.T) {
+		_, err := RunCommand(ctx, "tcp://missingport", "valid command", ClientOpts{})
+		require.EqualError(t, err, `dial tcp: address missingport: missing port in address`)
+	})
+
+	t.Run("should fail on unix socket not found", func(t *testing.T) {
+		_, err := RunCommand(ctx, "unix:///file/not/found", "valid command", ClientOpts{})
+		require.EqualError(t, err, `dial unix /file/not/found: connect: no such file or directory`)
+	})
+
+	t.Run("should receive expected command and return expected output", func(t *testing.T) {
+		socket, stopServer := client_testutils.CreateServerMock(t, map[string]string{"valid command": "output\n\n"})
+		defer stopServer()
+		output, err := RunCommand(ctx, "unix://"+socket, "valid command", ClientOpts{})
+		require.NoError(t, err)
+		require.Equal(t, "output", output)
+	})
+}

--- a/pkg/router/metrics/haproxy/haproxy.go
+++ b/pkg/router/metrics/haproxy/haproxy.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"net/url"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -700,8 +699,8 @@ func filterMetrics(export []int, available metrics) metrics {
 type PrometheusOptions struct {
 	// ScrapeURI is the URI to access HAProxy under. Defaults to the unix domain socket.
 	ScrapeURI string
-	// PidFile is optional and will collect process metrics.
-	PidFile string
+	// PidFn is optional and will collect process metrics if declared.
+	PidFn func() (int, error)
 	// Timeout is the maximum interval to wait for stats.
 	Timeout time.Duration
 	// BaseScrapeInterval is the minimum time to wait between stat calls per 1000 servers.
@@ -729,20 +728,10 @@ func NewPrometheusCollector(opts PrometheusOptions) (*Exporter, error) {
 
 	// TODO: register a version collector?
 
-	if len(opts.PidFile) > 0 {
+	if opts.PidFn != nil {
 		procExporter := prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{
 			Namespace: namespace,
-			PidFn: func() (int, error) {
-				content, err := os.ReadFile(opts.PidFile)
-				if err != nil {
-					return 0, fmt.Errorf("can't read haproxy pid file: %s", err)
-				}
-				value, err := strconv.Atoi(strings.TrimSpace(string(content)))
-				if err != nil {
-					return 0, fmt.Errorf("can't parse haproxy pid file: %s", err)
-				}
-				return value, nil
-			},
+			PidFn:     opts.PidFn,
 		})
 		if err := prometheus.Register(procExporter); err != nil {
 			return nil, err
@@ -753,9 +742,6 @@ func NewPrometheusCollector(opts PrometheusOptions) (*Exporter, error) {
 }
 
 func defaultOptions(opts PrometheusOptions) PrometheusOptions {
-	if len(opts.PidFile) == 0 {
-		opts.PidFile = "/var/lib/haproxy/run/haproxy.pid"
-	}
 	if opts.Timeout == 0 {
 		opts.Timeout = 5 * time.Second
 	}

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -1,6 +1,7 @@
 package templaterouter
 
 import (
+	"context"
 	"crypto/md5"
 	"fmt"
 	"net"
@@ -42,6 +43,7 @@ func newDefaultTemplatePlugin(router RouterInterface, includeUDP bool, lookupSvc
 }
 
 type TemplatePluginConfig struct {
+	AppCtx                        context.Context
 	WorkingDir                    string
 	TemplatePath                  string
 	ReloadScriptPath              string
@@ -141,7 +143,12 @@ func NewTemplatePlugin(cfg TemplatePluginConfig, lookupSvc ServiceLookup) (*Temp
 		templates[template.Name()] = templateWithHelper
 	}
 
+	ctx := cfg.AppCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	templateRouterCfg := templateRouterCfg{
+		appCtx:                        ctx,
 		dir:                           cfg.WorkingDir,
 		templates:                     templates,
 		reloadScriptPath:              cfg.ReloadScriptPath,

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -2,6 +2,7 @@ package templaterouter
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5"
 	"encoding/pem"
 	"fmt"
@@ -23,6 +24,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 
 	logf "github.com/openshift/router/log"
+	"github.com/openshift/router/pkg/router/client"
 	"github.com/openshift/router/pkg/router/crl"
 	"github.com/openshift/router/pkg/router/template/limiter"
 )
@@ -53,6 +55,7 @@ const (
 // that generates configuration files via a set of templates
 // and manages the backend process with a reload script.
 type templateRouter struct {
+	appCtx context.Context
 	// the directory to write router output to
 	dir              string
 	templates        map[string]*template.Template
@@ -131,6 +134,7 @@ type templateRouter struct {
 
 // templateRouterCfg holds all configuration items required to initialize the template router
 type templateRouterCfg struct {
+	appCtx                        context.Context
 	dir                           string
 	templates                     map[string]*template.Template
 	reloadScriptPath              string
@@ -243,6 +247,7 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 	prometheus.MustRegister(metricWriteConfig)
 
 	router := &templateRouter{
+		appCtx:                        cfg.appCtx,
 		dir:                           dir,
 		templates:                     cfg.templates,
 		reloadScriptPath:              cfg.reloadScriptPath,
@@ -666,8 +671,22 @@ func (r *templateRouter) writeCertificates(cfg *ServiceAliasConfig) error {
 	return nil
 }
 
-// reloadRouter executes the router's reload script.
+// reloadRouter reloads haproxy.
 func (r *templateRouter) reloadRouter(shutdown bool) error {
+	adminSocket := os.Getenv("ROUTER_HAPROXY_ADMIN_UNIX_SOCKET")
+	if adminSocket != "" {
+		if shutdown {
+			// We are in HAProxy's master/worker mode, currently implemented as a sidecar,
+			// so there is no local process to handle and the sidecar one already received SIGTERM.
+			return nil
+		}
+		return reloadRouterSidecar(r.appCtx, "unix://"+adminSocket)
+	}
+	return r.reloadRouterEmbedded(shutdown)
+}
+
+// reloadRouterEmbedded executes the router's reload script.
+func (r *templateRouter) reloadRouterEmbedded(shutdown bool) error {
 	if r.reloadFn != nil {
 		return r.reloadFn(shutdown)
 	}
@@ -679,7 +698,25 @@ func (r *templateRouter) reloadRouter(shutdown bool) error {
 	if err != nil {
 		return fmt.Errorf("error reloading router: %v\n%s", err, string(out))
 	}
-	log.V(0).Info("router reloaded", "output", string(out))
+	log.V(0).Info("router reloaded", "mode", "embedded", "output", string(out))
+	return nil
+}
+
+// reloadRouterSidecar sends a reload command to the haproxy running as sidecar.
+func reloadRouterSidecar(ctx context.Context, adminUnixSocket string) error {
+	// HAProxy runs as a native sidecar, so it should always be up and running
+	// when router is running. A failure here means a legit one.
+	output, err := client.RunCommand(ctx, adminUnixSocket, "reload", client.ClientOpts{Timeout: time.Minute})
+	if err != nil {
+		return fmt.Errorf("error connecting haproxy: %w", err)
+	}
+
+	// `reload` command is synchronous since haproxy 2.7, so it is safe to continue as soon as it returns.
+	// It should return Success=1 in the first line in case everything went well, anything else is considered a failure.
+	if !strings.HasPrefix(output, "Success=1") {
+		return fmt.Errorf("error reloading router: %s", output)
+	}
+	log.Info("router reloaded", "mode", "sidecar")
 	return nil
 }
 

--- a/pkg/router/template/router_test.go
+++ b/pkg/router/template/router_test.go
@@ -2,6 +2,7 @@ package templaterouter
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5"
 	"fmt"
 	"os"
@@ -11,10 +12,13 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift/router/pkg/router/client/client_testutils"
 )
 
 // TestCreateServiceUnit tests creating a service unit and finding it in router state
@@ -1664,4 +1668,23 @@ func TestSecretToPem(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReloadRouterSidecar(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("should succeed on succeeded reload", func(t *testing.T) {
+		serverSocket, stopServer := client_testutils.CreateServerMock(t, map[string]string{"reload": "Success=1"})
+		defer stopServer()
+		err := reloadRouterSidecar(ctx, "unix://"+serverSocket)
+		require.NoError(t, err)
+	})
+
+	t.Run("should fail on non succeeded reload", func(t *testing.T) {
+		serverSocket, stopServer := client_testutils.CreateServerMock(t, map[string]string{"reload": "Success=0"})
+		defer stopServer()
+		err := reloadRouterSidecar(ctx, "unix://"+serverSocket)
+		require.EqualError(t, err, `error reloading router: Success=0`)
+	})
+
 }


### PR DESCRIPTION
Add an opt-in configuration that informs the router that HAProxy runs on a sidecar container, so its process should be managed via its admin socket.

Add also a script that manages signals sent from kubelet to HAProxy. The script should be the entry point of the container in order to capture terminating signals, converting to SIGUSR1, and than into SIGTERM when the timeout expires. The former asks HAProxy to finish as soon as all the current connections close, and the later asks HAProxy to close (FIN) connections and finish just after receiving FIN+ACK from both sides of all connections.

The script should be moved later to a new HAProxy image, separated from the router one.

https://redhat.atlassian.net/browse/NE-2664

## Why

[enhancements#1965](https://github.com/openshift/enhancements/pull/1965/changes) describes a new feature allowing users to choose a HAProxy version from IngressController API. Separating HAProxy on its own container is a simple and secure way to achieve this, with minimal disruption on the topology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graceful HAProxy shutdown with configurable timeout and staged signal handling
  * Supervisor entrypoint that runs HAProxy in foreground, forwards signals, and ensures correct exit semantics
  * Router reload now supports both embedded and external HAProxy control paths
  * New endpoint-aware HAProxy command runner for remote/local control

* **Improvements**
  * Application-wide cancellation context propagated for coordinated shutdowns
  * Metrics collection can determine process PID via a provided function
  * Reloads emit structured success info and stricter success validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->