### PR TITLE
NE-2218: Add HAProxy standalone images for 2.8 and 3.2

### DIFF
--- a/images/router/haproxy28/Dockerfile.ocp
+++ b/images/router/haproxy28/Dockerfile.ocp
@@ -1,0 +1,12 @@
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
+RUN INSTALL_PKGS="socat haproxy28" && \
+    yum install -y --setopt=install_weak_deps=0 $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
+    sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
+LABEL io.k8s.display-name="OpenShift HAProxy 2.8" \
+      io.k8s.description="This component exposes the Ingress and Route rules, running as a sidecar of the Router component." \
+      io.openshift.tags="openshift,haproxy"
+USER 1001
+EXPOSE 80 443

--- a/images/router/haproxy32/Dockerfile.ocp
+++ b/images/router/haproxy32/Dockerfile.ocp
@@ -1,0 +1,12 @@
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
+RUN INSTALL_PKGS="socat haproxy32" && \
+    yum install -y --setopt=install_weak_deps=0 $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
+    sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
+LABEL io.k8s.display-name="OpenShift HAProxy 3.2" \
+      io.k8s.description="This component exposes the Ingress and Route rules, running as a sidecar of the Router component." \
+      io.openshift.tags="openshift,haproxy"
+USER 1001
+EXPOSE 80 443


### PR DESCRIPTION
Adding HAProxy standalone image for the 2.8 and 3.2 branches, without router binary and configurations files. This image is intended to be part of the OCP bundle and should run as a sidecar of the Router pod.

These images are intended to be light weight, without scripts or base configuration. Router pod is responsible to configure one of them via a shared volume instead.

https://redhat.atlassian.net/browse/NE-2218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new OpenShift HAProxy 2.8 container image (RHEL 9–based) with included runtime tooling.
  * Added a new OpenShift HAProxy 3.2 container image.
  * Both images include security hardening measures, run as a non-root user, and expose standard HTTP/HTTPS ports (80, 443).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->