### PR TITLE
OCPBUGS-74947: Adding escapeHAProxySingleQuotes for sanitize [release-4.14]

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -681,9 +681,9 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
         {{- with $pathRewriteTarget := firstMatch $pathRewriteTargetPattern (index $cfg.Annotations "haproxy.router.openshift.io/rewrite-target") }}
   # Path rewrite target
           {{- if eq $pathRewriteTarget "/" }}
-  http-request replace-path ^{{ $cfg.Path }}/?(.*)$ '{{ processRewriteTarget $pathRewriteTarget }}'
+  http-request replace-path '^{{ escapeSingleQuotes $cfg.Path }}/?(.*)$' '{{ processRewriteTarget $pathRewriteTarget }}'
           {{- else }}
-  http-request replace-path ^{{ $cfg.Path }}(.*)$ '{{ processRewriteTarget $pathRewriteTarget }}'
+  http-request replace-path '^{{ escapeSingleQuotes $cfg.Path }}(.*)$' '{{ processRewriteTarget $pathRewriteTarget }}'
           {{- end }}
         {{- end }}{{/* rewrite target */}}
   

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -522,6 +522,63 @@ func TestConfigTemplate(t *testing.T) {
 				},
 			},
 		},
+		"Rewrite target with root path": {
+			mustCreateWithConfig{
+				mustCreate: mustCreate{
+					name: "rewrite-root",
+					host: "rewrite-root.example.com",
+					path: "/app",
+					time: start,
+					annotations: map[string]string{
+						"haproxy.router.openshift.io/rewrite-target": "/",
+					},
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: insecureBackendName(h.namespace, "rewrite-root"),
+					attribute:   "http-request",
+					value:       `replace-path '^/app/?(.*)$' '/\1'`,
+				},
+			},
+		},
+		"Rewrite target with non-root path": {
+			mustCreateWithConfig{
+				mustCreate: mustCreate{
+					name: "rewrite-nonroot",
+					host: "rewrite-nonroot.example.com",
+					path: "/api/v1",
+					time: start,
+					annotations: map[string]string{
+						"haproxy.router.openshift.io/rewrite-target": "/v2",
+					},
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: insecureBackendName(h.namespace, "rewrite-nonroot"),
+					attribute:   "http-request",
+					value:       `replace-path '^/api/v1(.*)$' '/v2\1'`,
+				},
+			},
+		},
+		"Rewrite target with single quote in path": {
+			mustCreateWithConfig{
+				mustCreate: mustCreate{
+					name: "rewrite-single-quote",
+					host: "rewrite-single-quote.example.com",
+					path: "/foo'",
+					time: start,
+					annotations: map[string]string{
+						"haproxy.router.openshift.io/rewrite-target": "/",
+					},
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: insecureBackendName(h.namespace, "rewrite-single-quote"),
+					attribute:   "http-request",
+					value:       `replace-path '^/foo'\''/?(.*)$' '/\1'`,
+				},
+			},
+		},
 	}
 
 	defer cleanUpRoutes(t)

--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -413,5 +413,6 @@ var helperFunctions = template.FuncMap{
 	"clipHAProxyTimeoutValue": clipHAProxyTimeoutValue, //clips extrodinarily high timeout values to be below the maximum allowed timeout value
 	"parseIPList":             parseIPList,             //parses the list of IPs/CIDRs (IPv4/IPv6)
 
-	"processRewriteTarget": rewritetarget.SanitizeInput, //sanitizes `haproxy.router.openshift.io/rewrite-target` annotation
+	"processRewriteTarget": rewritetarget.SanitizeInput,      //sanitizes `haproxy.router.openshift.io/rewrite-target` annotation
+	"escapeSingleQuotes":   rewritetarget.EscapeSingleQuotes, //escapes single quotes for safe use in single-quoted strings
 }

--- a/pkg/router/template/util/rewritetarget/rewritetarget.go
+++ b/pkg/router/template/util/rewritetarget/rewritetarget.go
@@ -157,3 +157,16 @@ func SanitizeInput(val string) string {
 
 	return val
 }
+
+// EscapeSingleQuotes escapes its argument for use within single quotes
+// by escaping single-quote characters "'" as "'\”", following the semantics of
+// Bourne shell, and returns the result. Carriage return and line feed
+// characters are removed from the input. The caller is expected to enclose the
+// returned value in single quotes; this function does not itself add any
+// enclosing quote characters.
+func EscapeSingleQuotes(val string) string {
+	val = strings.ReplaceAll(val, `'`, `'\''`)
+	val = strings.ReplaceAll(val, "\n", "")
+	val = strings.ReplaceAll(val, "\r", "")
+	return val
+}

--- a/pkg/router/template/util/rewritetarget/rewritetarget_test.go
+++ b/pkg/router/template/util/rewritetarget/rewritetarget_test.go
@@ -92,3 +92,76 @@ func Test_SanitizeInput(t *testing.T) {
 		})
 	}
 }
+
+func Test_EscapeSingleQuotes(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+			name:   "valid string",
+			input:  `/foo`,
+			output: `/foo`,
+		},
+		{
+			name:   "valid string with bar",
+			input:  `/foo/bar`,
+			output: `/foo/bar`,
+		},
+		{
+			name:   "escape haproxy single quote string",
+			input:  `/it's`,
+			output: `/it'\''s`,
+		},
+		{
+			name:   "escape haproxy single quote",
+			input:  `'`,
+			output: `'\''`,
+		},
+		{
+			name:   "escape haproxy double quotes",
+			input:  `''`,
+			output: `'\'''\''`,
+		},
+		{
+			name:   "delete haproxy newline",
+			input:  "/foo\nbar",
+			output: `/foobar`,
+		},
+		{
+			name:   "escape haproxy carriage return",
+			input:  "/foo\rbar",
+			output: `/foobar`,
+		},
+		{
+			name:   "escape haproxy carriage return and line feed",
+			input:  "/foo\r\nbar",
+			output: `/foobar`,
+		},
+		{
+			name:   "escape haproxy carriage return and line feed with single quote",
+			input:  "/it's\r\n",
+			output: `/it'\''s`,
+		},
+		{
+			name:   "escape haproxy with multiple newlines",
+			input:  "/foo\n\n\nbar",
+			output: `/foobar`,
+		},
+		{
+			name:   "escape haproxy with carriage return and line feed only",
+			input:  "\r\n",
+			output: ``,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rewritetarget.EscapeSingleQuotes(tc.input)
+			if got != tc.output {
+				t.Errorf("Failure: expected %s, got %s", tc.output, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This function will allow users to include
certain characters and spacing to avoid
any config injection

Adapted router_test.go to use `mustCreate` struct (`mustCreateRoute` does not exist on this branch).