### PR TITLE
OCPBUGS-87205: Strip X-SSL-Client-* headers for plain HTTP

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -275,7 +275,7 @@ frontend public
 
   # Strip off X-SSL-Client-* headers for plain HTTP if not explicitly disabled.
   # This prevents unauthenticated spoofing of mutual TLS client identities.
-  {{- if isTrue (env "ROUTER_MUTUAL_TLS_AUTH_FILTER" "true") }}
+  {{- if isTrue (env "ROUTER_MUTUAL_TLS_HEADER_FILTER" "true") }}
   http-request del-header X-SSL-Client-DN
   http-request del-header X-SSL-Client-DER
   http-request del-header X-SSL-Client-NotAfter
@@ -403,7 +403,7 @@ frontend fe_sni
 
   # Strip off X-SSL-Client-* headers for plain HTTP if not explicitly disabled.
   # This prevents unauthenticated spoofing of mutual TLS client identities.
-  {{- if isTrue (env "ROUTER_MUTUAL_TLS_AUTH_FILTER" "true") }}
+  {{- if isTrue (env "ROUTER_MUTUAL_TLS_HEADER_FILTER" "true") }}
   http-request del-header X-SSL-Client-DN
   http-request del-header X-SSL-Client-DER
   http-request del-header X-SSL-Client-NotAfter
@@ -529,7 +529,7 @@ frontend fe_no_sni
 
   # Strip off X-SSL-Client-* headers for plain HTTP if not explicitly disabled.
   # This prevents unauthenticated spoofing of mutual TLS client identities.
-  {{- if isTrue (env "ROUTER_MUTUAL_TLS_AUTH_FILTER" "true") }}
+  {{- if isTrue (env "ROUTER_MUTUAL_TLS_HEADER_FILTER" "true") }}
   http-request del-header X-SSL-Client-DN
   http-request del-header X-SSL-Client-DER
   http-request del-header X-SSL-Client-NotAfter

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -276,12 +276,18 @@ frontend public
   # Strip off X-SSL-Client-* headers for plain HTTP if not explicitly disabled.
   # This prevents unauthenticated spoofing of mutual TLS client identities.
   {{- if isTrue (env "ROUTER_MUTUAL_TLS_HEADER_FILTER" "true") }}
-  http-request del-header X-SSL-Client-DN
+  http-request del-header X-SSL
+  http-request del-header X-SSL-Client-CN
   http-request del-header X-SSL-Client-DER
+  http-request del-header X-SSL-Client-DN
   http-request del-header X-SSL-Client-NotAfter
   http-request del-header X-SSL-Client-NotBefore
   http-request del-header X-SSL-Client-SHA1
+  http-request del-header X-SSL-Client-Serial
   http-request del-header X-SSL-Client-Subject
+  http-request del-header X-SSL-Client-Verify
+  http-request del-header X-SSL-Client-Version
+  http-request del-header X-SSL-Issuer
   {{- end }}
 
   # DNS labels are case insensitive (RFC 4343), we need to convert the hostname into lowercase
@@ -404,12 +410,18 @@ frontend fe_sni
   # Strip off X-SSL-Client-* headers for plain HTTP if not explicitly disabled.
   # This prevents unauthenticated spoofing of mutual TLS client identities.
   {{- if isTrue (env "ROUTER_MUTUAL_TLS_HEADER_FILTER" "true") }}
-  http-request del-header X-SSL-Client-DN
+  http-request del-header X-SSL
+  http-request del-header X-SSL-Client-CN
   http-request del-header X-SSL-Client-DER
+  http-request del-header X-SSL-Client-DN
   http-request del-header X-SSL-Client-NotAfter
   http-request del-header X-SSL-Client-NotBefore
   http-request del-header X-SSL-Client-SHA1
+  http-request del-header X-SSL-Client-Serial
   http-request del-header X-SSL-Client-Subject
+  http-request del-header X-SSL-Client-Verify
+  http-request del-header X-SSL-Client-Version
+  http-request del-header X-SSL-Issuer
   {{- end }}
 
   # DNS labels are case insensitive (RFC 4343), we need to convert the hostname into lowercase
@@ -530,12 +542,18 @@ frontend fe_no_sni
   # Strip off X-SSL-Client-* headers for plain HTTP if not explicitly disabled.
   # This prevents unauthenticated spoofing of mutual TLS client identities.
   {{- if isTrue (env "ROUTER_MUTUAL_TLS_HEADER_FILTER" "true") }}
-  http-request del-header X-SSL-Client-DN
+  http-request del-header X-SSL
+  http-request del-header X-SSL-Client-CN
   http-request del-header X-SSL-Client-DER
+  http-request del-header X-SSL-Client-DN
   http-request del-header X-SSL-Client-NotAfter
   http-request del-header X-SSL-Client-NotBefore
   http-request del-header X-SSL-Client-SHA1
+  http-request del-header X-SSL-Client-Serial
   http-request del-header X-SSL-Client-Subject
+  http-request del-header X-SSL-Client-Verify
+  http-request del-header X-SSL-Client-Version
+  http-request del-header X-SSL-Issuer
   {{- end }}
 
   # DNS labels are case insensitive (RFC 4343), we need to convert the hostname into lowercase

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -273,6 +273,17 @@ frontend public
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
 
+  # Strip off X-SSL-Client-* headers for plain HTTP if not explicitly disabled.
+  # This prevents unauthenticated spoofing of mutual TLS client identities.
+  {{- if isTrue (env "ROUTER_MUTUAL_TLS_AUTH_FILTER" "true") }}
+  http-request del-header X-SSL-Client-DN
+  http-request del-header X-SSL-Client-DER
+  http-request del-header X-SSL-Client-NotAfter
+  http-request del-header X-SSL-Client-NotBefore
+  http-request del-header X-SSL-Client-SHA1
+  http-request del-header X-SSL-Client-Subject
+  {{- end }}
+
   # DNS labels are case insensitive (RFC 4343), we need to convert the hostname into lowercase
   # before matching, or any requests containing uppercase characters will never match.
   http-request set-header Host %[req.hdr(Host),lower]
@@ -390,6 +401,17 @@ frontend fe_sni
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
 
+  # Strip off X-SSL-Client-* headers for plain HTTP if not explicitly disabled.
+  # This prevents unauthenticated spoofing of mutual TLS client identities.
+  {{- if isTrue (env "ROUTER_MUTUAL_TLS_AUTH_FILTER" "true") }}
+  http-request del-header X-SSL-Client-DN
+  http-request del-header X-SSL-Client-DER
+  http-request del-header X-SSL-Client-NotAfter
+  http-request del-header X-SSL-Client-NotBefore
+  http-request del-header X-SSL-Client-SHA1
+  http-request del-header X-SSL-Client-Subject
+  {{- end }}
+
   # DNS labels are case insensitive (RFC 4343), we need to convert the hostname into lowercase
   # before matching, or any requests containing uppercase characters will never match.
   http-request set-header Host %[req.hdr(Host),lower]
@@ -504,6 +526,17 @@ frontend fe_no_sni
 
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
+
+  # Strip off X-SSL-Client-* headers for plain HTTP if not explicitly disabled.
+  # This prevents unauthenticated spoofing of mutual TLS client identities.
+  {{- if isTrue (env "ROUTER_MUTUAL_TLS_AUTH_FILTER" "true") }}
+  http-request del-header X-SSL-Client-DN
+  http-request del-header X-SSL-Client-DER
+  http-request del-header X-SSL-Client-NotAfter
+  http-request del-header X-SSL-Client-NotBefore
+  http-request del-header X-SSL-Client-SHA1
+  http-request del-header X-SSL-Client-Subject
+  {{- end }}
 
   # DNS labels are case insensitive (RFC 4343), we need to convert the hostname into lowercase
   # before matching, or any requests containing uppercase characters will never match.

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -273,7 +273,7 @@ frontend public
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
 
-  # Strip off X-SSL-Client-* headers for plain HTTP if not explicitly disabled.
+  # Strip off X-SSL* headers for plain HTTP if not explicitly disabled.
   # This prevents unauthenticated spoofing of mutual TLS client identities.
   {{- if isTrue (env "ROUTER_MUTUAL_TLS_HEADER_FILTER" "true") }}
   http-request del-header X-SSL
@@ -407,7 +407,7 @@ frontend fe_sni
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
 
-  # Strip off X-SSL-Client-* headers if not explicitly disabled.
+  # Strip off X-SSL* headers if not explicitly disabled.
   # This prevents unauthenticated spoofing of mutual TLS client identities
   # when mutual TLS is not enabled and so the headers are not set below.  
   {{- if isTrue (env "ROUTER_MUTUAL_TLS_HEADER_FILTER" "true") }}
@@ -540,8 +540,9 @@ frontend fe_no_sni
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
 
-  # Strip off X-SSL-Client-* headers for plain HTTP if not explicitly disabled.
-  # This prevents unauthenticated spoofing of mutual TLS client identities.
+  # Strip off X-SSL* headers if not explicitly disabled.
+  # This prevents unauthenticated spoofing of mutual TLS client identities
+  # when mutual TLS is not enabled and so the headers are not set below.
   {{- if isTrue (env "ROUTER_MUTUAL_TLS_HEADER_FILTER" "true") }}
   http-request del-header X-SSL
   http-request del-header X-SSL-Client-CN

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -407,8 +407,9 @@ frontend fe_sni
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
 
-  # Strip off X-SSL-Client-* headers for plain HTTP if not explicitly disabled.
-  # This prevents unauthenticated spoofing of mutual TLS client identities.
+  # Strip off X-SSL-Client-* headers if not explicitly disabled.
+  # This prevents unauthenticated spoofing of mutual TLS client identities
+  # when mutual TLS is not enabled and so the headers are not set below.  
   {{- if isTrue (env "ROUTER_MUTUAL_TLS_HEADER_FILTER" "true") }}
   http-request del-header X-SSL
   http-request del-header X-SSL-Client-CN


### PR DESCRIPTION
This prevents unauthenticated spoofing of mutual TLS client identities by deleting X-SSL-Client headers in the fe_http frontend before they can reach the backend.

It introduces a new environment variable `ROUTER_MUTUAL_TLS_AUTH_FILTER`
which defaults to `true`. Setting this to `false` allows external load balancers
to inject these headers.

Joint effort of the author and gemini-pro-3.1-preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strips mutual-TLS client identity headers from requests forwarded over plain HTTP.
  * Applies this header filtering consistently across edge-terminated, SNI, and non-TLS request flows.
  * Adds an environment toggle to enable/disable the header filtering (enabled by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->