### PR TITLE
NE-2223: Update HAProxy RPM in the router container to 3.2.19

### DIFF
--- a/images/router/haproxy/Dockerfile.ocp
+++ b/images/router/haproxy/Dockerfile.ocp
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/ocp/5.0:haproxy-router-base
-RUN INSTALL_PKGS="socat haproxy28 rsyslog procps-ng util-linux" && \
+RUN INSTALL_PKGS="socat haproxy32 rsyslog procps-ng util-linux" && \
     yum install -y --setopt=install_weak_deps=0 $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
Update the default HAProxy version in the router container from 2.8 to 3.2 for OpenShift 5.0. This decouples the HAProxy 3.2 bump from the multi-version feature gate promotion, giving us earlier CI signal without waiting for the IngressControllerMultipleHAProxyVersions feature to GA.

This also affects components that use the `haproxy-router` image directly (on-prem load balancer, MicroShift). Both teams have been notified and can fall back to `haproxy-router-haproxy28` if needed. The bundled HAProxy in this image will be removed in a future release once all consumers migrate to the sidecar model.

**OKD:** Requires a coordinating openshift/release PR (https://github.com/openshift/release/pull/82170) to bump the OKD router base image to the 5.0 stream. These two PRs should be merged close together to minimize any gap in OKD CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the HAProxy router image to use HAProxy 3.2 instead of HAProxy 2.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->