### PR TITLE
OCPBUGS-87082: Reload HAProxy when adding the first backend server

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -886,6 +886,32 @@ func (r *templateRouter) dynamicallyReplaceEndpoints(id ServiceUnitKey, service 
 		return false
 	}
 
+	// HAProxy 2.8 is dropping the second added server from the balance when the third one is added,
+	// and all of them were dynamically added into an empty backend. HAProxy 3.2 does not have this issue.
+	// This extra check ensures that the first dynamically added server happens by reloading HAProxy.
+	// This can be removed after dropping support for HAProxy 2.8.
+	//
+	// TODO: make this conditional to HAProxy 2.8 when adding support to HAProxy 3.2.
+	var oldServerCount, newServerCount int
+	for backendKey := range service.ServiceAliasAssociations {
+		if cfg, found := r.state[backendKey]; found {
+			oldEndpoints := cfg.EndpointTable[id]
+			newEndpoints := endpointsForAlias(cfg, service)
+			oldServerCount += len(oldEndpoints)
+			newServerCount += len(newEndpoints)
+		}
+	}
+	if oldServerCount == 0 && newServerCount > 0 {
+		log.V(4).Info("backend is empty, need to add endpoints via reload", "service", id)
+		for backendKey := range service.ServiceAliasAssociations {
+			if cfg, found := r.state[backendKey]; found {
+				// update internal state with the new endpoints
+				cfg.EndpointTable[id] = endpointsForAlias(cfg, service)
+			}
+		}
+		return false
+	}
+
 	log.V(4).Info("replacing endpoints dynamically for service", "service", id)
 
 	// Update each of the routes that reference this service unit.


### PR DESCRIPTION
The following scenario is happening on HAProxy 2.8:

* Configure a new route resource, which references a service whose deployment does not have any replica;
* Scale out to 3 replicas;
* Check the balance of the route: only 2 of the 3 replicas are added to the load balance;
* If scaling one by one, the issue happens adding the third replica, which makes the second one to be removed from the load balance.

This only happens with HAProxy 2.8, even latest (2.8.24). HAProxy 3.2 does not have this issue.

This update circumvents this behavior by requesting a reload in case a backend is being scaled from zero to one or more replicas, this way the first backend servers are added via configuration files. All the other new backend servers can be added dynamically.

https://redhat.atlassian.net/browse/OCPBUGS-87082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compatibility with HAProxy 2.8 by adding safeguards for dynamically added endpoints in empty backends.
  * Improved router behavior to ensure proper reloads when backend services transition from zero to non-zero endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->