### PR TITLE
OCPBUGS-87082: Use ID when adding backend server dynamically

### DIFF
--- a/pkg/router/template/configmanager/haproxy/backend.go
+++ b/pkg/router/template/configmanager/haproxy/backend.go
@@ -306,8 +306,8 @@ func (b *Backend) FindServer(id string) (*backendServer, error) {
 // AddServer dynamically adds a new backend server. It detects if the server already exists, and if so tries to remove it.
 // It returns a failure in case HAProxy refuses to dynamically add the server for any reason, or if the existing server
 // cannot be removed, e.g., it still have active or steady and established connection(s) to its backend server endpoint.
-func (b *Backend) AddServer(cfg *templaterouter.ServiceAliasConfig, svc *templaterouter.ServiceUnit, ep templaterouter.Endpoint, weight int32, workingDir, defaultDestinationCA string) error {
-	if err := b.innerAddServer(cfg, svc, ep, weight, workingDir, defaultDestinationCA); err != nil {
+func (b *Backend) AddServer(cfg *templaterouter.ServiceAliasConfig, svc *templaterouter.ServiceUnit, ep templaterouter.Endpoint, backendServerID, weight int32, workingDir, defaultDestinationCA string) error {
+	if err := b.innerAddServer(cfg, svc, ep, backendServerID, weight, workingDir, defaultDestinationCA); err != nil {
 		if !strings.Contains(err.Error(), "Already exists a server ") {
 			return err
 		}
@@ -317,7 +317,7 @@ func (b *Backend) AddServer(cfg *templaterouter.ServiceAliasConfig, svc *templat
 			// No way, need to fail which will ask for a fork-and-reload. This will leave the existing connections in the old process.
 			return err
 		}
-		if err := b.innerAddServer(cfg, svc, ep, weight, workingDir, defaultDestinationCA); err != nil {
+		if err := b.innerAddServer(cfg, svc, ep, backendServerID, weight, workingDir, defaultDestinationCA); err != nil {
 			return err
 		}
 	}
@@ -367,7 +367,7 @@ func (b *Backend) DeleteServer(ep templaterouter.Endpoint) (removed bool, err er
 	return true, nil
 }
 
-func (b *Backend) innerAddServer(cfg *templaterouter.ServiceAliasConfig, svc *templaterouter.ServiceUnit, ep templaterouter.Endpoint, weight int32, workingDir, defaultDestinationCA string) error {
+func (b *Backend) innerAddServer(cfg *templaterouter.ServiceAliasConfig, svc *templaterouter.ServiceUnit, ep templaterouter.Endpoint, backendServerID, weight int32, workingDir, defaultDestinationCA string) error {
 	// This should always follow the template, changes here should be reflected there, both regular and passthrough backends
 	//
 	// TODO: either read this configuration from the template, or instead make the template read from here.
@@ -376,7 +376,7 @@ func (b *Backend) innerAddServer(cfg *templaterouter.ServiceAliasConfig, svc *te
 	//
 	// https://redhat.atlassian.net/browse/NE-2646
 
-	cmd := fmt.Sprintf("add server %s/%s %s:%s weight %d", b.name, ep.ID, ep.IP, ep.Port, weight)
+	cmd := fmt.Sprintf("add server %s/%s %s:%s weight %d id %d", b.name, ep.ID, ep.IP, ep.Port, weight, backendServerID)
 
 	switch cfg.TLSTermination {
 	case v1.TLSTerminationReencrypt:

--- a/pkg/router/template/configmanager/haproxy/backend_test.go
+++ b/pkg/router/template/configmanager/haproxy/backend_test.go
@@ -26,6 +26,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 		endpointID      *string                               // default: "server1"
 		ip              *string                               // default: "10.0.1.11"
 		port            *string                               // default: "9000"
+		backendServerID *int32                                // default: 1
 		weight          *int32                                // default: 1
 		workingDir      *string                               // default: "tmp"
 		publicHostname  string
@@ -47,7 +48,15 @@ func TestBackendDynamicUpdate(t *testing.T) {
 		"should add insecure server": {
 			cmd: cmdAdd,
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 1 check inter 5000ms",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 check inter 5000ms",
+				"set server route1/server1 state ready",
+			},
+		},
+		"should add insecure server with custom backend server ID": {
+			cmd:             cmdAdd,
+			backendServerID: ptr.To[int32](1023),
+			cmdExpected: []string{
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1023 check inter 5000ms",
 				"set server route1/server1 state ready",
 			},
 		},
@@ -55,7 +64,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 			cmd:    cmdAdd,
 			weight: ptr.To[int32](0),
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 0 check inter 5000ms",
+				"add server route1/server1 10.0.1.11:9000 weight 0 id 1 check inter 5000ms",
 				"set server route1/server1 state drain",
 			},
 		},
@@ -65,7 +74,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 				"router.openshift.io/haproxy.health.check.interval": "10s",
 			},
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 1 check inter 10s",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 check inter 10s",
 				"set server route1/server1 state ready",
 			},
 		},
@@ -75,7 +84,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 				"router.openshift.io/haproxy.health.check.interval": "1z",
 			},
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 1 check inter 5000ms",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 check inter 5000ms",
 				"set server route1/server1 state ready",
 			},
 		},
@@ -85,7 +94,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 				"haproxy.router.openshift.io/pod-concurrent-connections": "100",
 			},
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 1 check inter 5000ms maxconn 100",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 check inter 5000ms maxconn 100",
 				"set server route1/server1 state ready",
 			},
 		},
@@ -93,7 +102,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 			cmd:            cmdAdd,
 			tlsTermination: routev1.TLSTerminationPassthrough,
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 1 check inter 5000ms",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 check inter 5000ms",
 				"set server route1/server1 state ready",
 			},
 		},
@@ -101,7 +110,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 			cmd:            cmdAdd,
 			tlsTermination: routev1.TLSTerminationEdge,
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 1 check inter 5000ms",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 check inter 5000ms",
 				"set server route1/server1 state ready",
 			},
 		},
@@ -110,7 +119,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 			tlsTermination: routev1.TLSTerminationEdge,
 			appProtocol:    "h2c",
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 1 proto h2 check inter 5000ms",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 proto h2 check inter 5000ms",
 				"set server route1/server1 state ready",
 			},
 		},
@@ -118,7 +127,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 			cmd:            cmdAdd,
 			tlsTermination: routev1.TLSTerminationReencrypt,
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 1 ssl alpn h2,http/1.1 verify none check-ssl check inter 5000ms",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 ssl alpn h2,http/1.1 verify none check-ssl check inter 5000ms",
 				"set server route1/server1 state ready",
 			},
 		},
@@ -128,7 +137,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 			verifyHostname:  true,
 			serviceHostname: "route1.default.svc",
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 1 ssl alpn h2,http/1.1 verifyhost route1.default.svc verify none check-ssl check inter 5000ms",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 ssl alpn h2,http/1.1 verifyhost route1.default.svc verify none check-ssl check inter 5000ms",
 				"set server route1/server1 state ready",
 			},
 		},
@@ -137,7 +146,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 			tlsTermination: routev1.TLSTerminationReencrypt,
 			defaultCA:      "/tmp/default-ca.pem",
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 1 ssl alpn h2,http/1.1 verify required ca-file /tmp/default-ca.pem check-ssl check inter 5000ms",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 ssl alpn h2,http/1.1 verify required ca-file /tmp/default-ca.pem check-ssl check inter 5000ms",
 				"set server route1/server1 state ready",
 			},
 		},
@@ -153,7 +162,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 				},
 			},
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 1 ssl alpn h2,http/1.1 verify required ca-file /tmp/router/cacerts/default:route1.pem check-ssl check inter 5000ms",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 ssl alpn h2,http/1.1 verify required ca-file /tmp/router/cacerts/default:route1.pem check-ssl check inter 5000ms",
 				"set server route1/server1 state ready",
 			},
 		},
@@ -161,9 +170,9 @@ func TestBackendDynamicUpdate(t *testing.T) {
 			cmd:           cmdAdd,
 			cmdCustomResp: []string{"Already exists a server ..."},
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 1 check inter 5000ms",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 check inter 5000ms",
 				"del server route1/server1",
-				"add server route1/server1 10.0.1.11:9000 weight 1 check inter 5000ms",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 check inter 5000ms",
 				"set server route1/server1 state ready",
 			},
 		},
@@ -172,7 +181,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 			cmdCustomResp: []string{"Some unknown adding error."},
 			errExpected:   "unexpected response from haproxy: Some unknown adding error.",
 			cmdExpected: []string{
-				"add server route1/server1 10.0.1.11:9000 weight 1 check inter 5000ms",
+				"add server route1/server1 10.0.1.11:9000 weight 1 id 1 check inter 5000ms",
 			},
 		},
 
@@ -274,6 +283,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 			endpointID := ptr.Deref(test.endpointID, "server1")
 			ip := ptr.Deref(test.ip, "10.0.1.11")
 			port := ptr.Deref(test.port, "9000")
+			backendServerID := ptr.Deref(test.backendServerID, 1)
 			weight := ptr.Deref(test.weight, 1)
 			workingDir := ptr.Deref(test.workingDir, "/tmp")
 
@@ -302,7 +312,7 @@ func TestBackendDynamicUpdate(t *testing.T) {
 			var err error
 			switch test.cmd {
 			case cmdAdd:
-				err = b.AddServer(cfg, svc, ep, weight, workingDir, test.defaultCA)
+				err = b.AddServer(cfg, svc, ep, backendServerID, weight, workingDir, test.defaultCA)
 			case cmdDel:
 				removed, err = b.DeleteServer(ep)
 			case cmdUpdate:

--- a/pkg/router/template/configmanager/haproxy/manager.go
+++ b/pkg/router/template/configmanager/haproxy/manager.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -142,6 +143,14 @@ type haproxyConfigManager struct {
 
 	// commitTimer indicates if a router config commit is pending.
 	commitTimer *time.Timer
+
+	// currentServerID has the last backend server ID used on dynamically added server.
+	// Hardcoding a backend server ID fixes a misbehavior found in HAProxy 2.9 and older,
+	// fixed in HAProxy 3.0.
+	//
+	// https://github.com/haproxy/haproxy/issues/3413
+	// https://redhat.atlassian.net/browse/OCPBUGS-87082
+	currentServerID atomic.Int32
 }
 
 // NewHAProxyConfigManager returns a new haproxyConfigManager.
@@ -498,7 +507,8 @@ func (cm *haproxyConfigManager) ReplaceRouteEndpoints(id templaterouter.ServiceA
 		}
 	}
 	for name, ep := range addedEndpoints {
-		if err := backend.AddServer(entry.backend, svc, ep, weight, cm.workingDir, cm.defaultDestinationCA); err != nil {
+		backendServerID := cm.currentServerID.Add(1)
+		if err := backend.AddServer(entry.backend, svc, ep, backendServerID, weight, cm.workingDir, cm.defaultDestinationCA); err != nil {
 			errs = append(errs, fmt.Errorf("error adding backend server %s: %w", name, err))
 		}
 	}
@@ -732,6 +742,14 @@ func (cm *haproxyConfigManager) reset() {
 
 	// Reset the client - clear its caches.
 	cm.client.Reset()
+
+	// Start/reset backend server ID as 2^24, giving the first 16.7mm to the
+	// automatically assigned ones via configuration file.
+	//
+	// It is loaded behind !r.synced and cm.isReloading(), so it is initialized
+	// before first use, not used during reload, and also it is only reset after
+	// the reload finished successfully.
+	cm.currentServerID.Store(1 << 24)
 }
 
 // findMatchingBlueprint finds a matching blueprint route that can be used


### PR DESCRIPTION
The following scenario is happening on HAProxy 2.8:

* Configure a new route resource, which references a service whose deployment does not have any replica;
* Scale out to 3 replicas;
* Check the balance of the route: only 2 of the 3 replicas are added to the load balance pool.

If scaling one by one, the issue happens adding the third replica, which makes the second one to be removed from the load balance pool.

This is a HAProxy 2.8 only issue, 3.0+ does not have this behavior. It happens due to the missing of the backend server ID, which is being assigned late in this scenario.

This patch declares the backend server ID whenever a new backend server is added dynamically, which circumvents the misbehavior from the HAProxy side. A new state field controls the last backend server ID used, so new ones use newer IDs. The field starts as 2^24 to avoid colision with the automatically generated ones from the backend servers declared in the configuration file. It is also reinitialized after a successful reload, since all the dynamically added servers became part of the configuration file.

Although a DCM related fix, this only impacts 5.0 since this only happens in the add server API call, only added on this version.

https://redhat.atlassian.net/browse/OCPBUGS-87082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HAProxy backend servers now receive explicit, tracked IDs during dynamic endpoint updates, improving reliability and avoiding ID collisions during server add/remove operations.

* **Tests**
  * Test suite updated to validate explicit server ID assignment and ID allocation behavior across backend server operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->