### PR TITLE
[release-4.18] OCPBUGS-86715: Strip X-SSL-* headers for plain HTTP

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -251,6 +251,23 @@ frontend public
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
 
+  # Strip off X-SSL* headers for plain HTTP if not explicitly disabled.
+  # This prevents unauthenticated spoofing of mutual TLS client identities.
+  {{- if isTrue (env "ROUTER_MUTUAL_TLS_HEADER_FILTER" "true") }}
+  http-request del-header X-SSL
+  http-request del-header X-SSL-Client-CN
+  http-request del-header X-SSL-Client-DER
+  http-request del-header X-SSL-Client-DN
+  http-request del-header X-SSL-Client-NotAfter
+  http-request del-header X-SSL-Client-NotBefore
+  http-request del-header X-SSL-Client-SHA1
+  http-request del-header X-SSL-Client-Serial
+  http-request del-header X-SSL-Client-Subject
+  http-request del-header X-SSL-Client-Verify
+  http-request del-header X-SSL-Client-Version
+  http-request del-header X-SSL-Issuer
+  {{- end }}
+
   # DNS labels are case insensitive (RFC 4343), we need to convert the hostname into lowercase
   # before matching, or any requests containing uppercase characters will never match.
   http-request set-header Host %[req.hdr(Host),lower]
@@ -368,6 +385,24 @@ frontend fe_sni
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
 
+  # Strip off X-SSL* headers if not explicitly disabled.
+  # This prevents unauthenticated spoofing of mutual TLS client identities
+  # when mutual TLS is not enabled and so the headers are not set below.  
+  {{- if isTrue (env "ROUTER_MUTUAL_TLS_HEADER_FILTER" "true") }}
+  http-request del-header X-SSL
+  http-request del-header X-SSL-Client-CN
+  http-request del-header X-SSL-Client-DER
+  http-request del-header X-SSL-Client-DN
+  http-request del-header X-SSL-Client-NotAfter
+  http-request del-header X-SSL-Client-NotBefore
+  http-request del-header X-SSL-Client-SHA1
+  http-request del-header X-SSL-Client-Serial
+  http-request del-header X-SSL-Client-Subject
+  http-request del-header X-SSL-Client-Verify
+  http-request del-header X-SSL-Client-Version
+  http-request del-header X-SSL-Issuer
+  {{- end }}
+
   # DNS labels are case insensitive (RFC 4343), we need to convert the hostname into lowercase
   # before matching, or any requests containing uppercase characters will never match.
   http-request set-header Host %[req.hdr(Host),lower]
@@ -482,6 +517,24 @@ frontend fe_no_sni
 
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
   http-request del-header Proxy
+
+  # Strip off X-SSL* headers if not explicitly disabled.
+  # This prevents unauthenticated spoofing of mutual TLS client identities
+  # when mutual TLS is not enabled and so the headers are not set below.
+  {{- if isTrue (env "ROUTER_MUTUAL_TLS_HEADER_FILTER" "true") }}
+  http-request del-header X-SSL
+  http-request del-header X-SSL-Client-CN
+  http-request del-header X-SSL-Client-DER
+  http-request del-header X-SSL-Client-DN
+  http-request del-header X-SSL-Client-NotAfter
+  http-request del-header X-SSL-Client-NotBefore
+  http-request del-header X-SSL-Client-SHA1
+  http-request del-header X-SSL-Client-Serial
+  http-request del-header X-SSL-Client-Subject
+  http-request del-header X-SSL-Client-Verify
+  http-request del-header X-SSL-Client-Version
+  http-request del-header X-SSL-Issuer
+  {{- end }}
 
   # DNS labels are case insensitive (RFC 4343), we need to convert the hostname into lowercase
   # before matching, or any requests containing uppercase characters will never match.


### PR DESCRIPTION
**Vulnerability**: CVE-2026-46579 - mTLS client certificate spoofing via HTTP header injection

  **Fix**: Prevents unauthenticated spoofing of mutual TLS client identities by stripping X-SSL-Client-* headers from HTTP requests before they reach backends.

  **Changes**:
  - Adds \`ROUTER_MUTUAL_TLS_HEADER_FILTER\` environment variable (default: \`true\`)
  - Strips all 12 X-SSL headers in HTTP frontends: \`public\`, \`fe_sni\`, \`fe_no_sni\`
  - Secure by default - header stripping enabled unless explicitly disabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added header filtering to the router to prevent spoofing of mutual TLS identity claims. This security enhancement automatically filters headers that could be forged by clients, reducing unauthorized access risks. The feature is enabled by default but can be toggled if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->