### PR TITLE
[WIP] DO NOT MERGE - testing haproxy rpm build version

### DIFF
--- a/images/router/haproxy/Dockerfile.ocp
+++ b/images/router/haproxy/Dockerfile.ocp
@@ -17,6 +17,7 @@ LABEL io.k8s.display-name="OpenShift HAProxy Router" \
 USER 1001
 EXPOSE 80 443
 WORKDIR /var/lib/haproxy/conf
+RUN exit 1
 ENV TEMPLATE_FILE=/var/lib/haproxy/conf/haproxy-config.template \
     RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy
 ENTRYPOINT ["/usr/bin/openshift-router", "--v=2"]


### PR DESCRIPTION
a quick PR to fail the images job so we can see what RPM is getting installed quickly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified router HAProxy image build configuration, which will now fail during the initialization step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->