### PR TITLE
Limit allowed elliptic curves to X25519MLKEM768

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -131,11 +131,7 @@ global
     {{- end }}
   {{- end }}
 
-  # By default when a ROUTER_CURVES is not defined HAProxy
-  # will use its built-in default supported groups for TLS key exchange.
-  {{- with (env "ROUTER_CURVES") }}
-  ssl-default-bind-curves {{ . }}
-  {{- end }}
+  ssl-default-bind-curves X25519MLKEM768
 
 defaults
   {{- with $value := env "ROUTER_MAX_CONNECTIONS" "50000" }}


### PR DESCRIPTION
Hard-code the list of allowed elliptic curves to just X25519MLKEM768.

This PR is for testing purposes only, namely to collect data on the performance impact of ML-KEM.

* `images/router/haproxy/conf/haproxy-config.template`: Hard-code `ssl-default-bind-curves` to `X25519MLKEM768`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HAProxy TLS configuration to explicitly set the elliptic curve to `X25519MLKEM768` for improved security and consistency. The setting is now applied by default rather than relying on environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->