### PR TITLE
[WIP] OCPBUGS-88729: Fix HSTS annotation regex to reject newlines and accept trailing semicolons

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -28,7 +28,7 @@
 {{- /* hsts header in response: */}}
 {{- /* Not fully compliant to RFC6797#6.1 yet: has to accept not conformant directives */}}
 {{- $hstsOptionalTokenPattern := `(?:includeSubDomains|preload)` }}
-{{- $hstsPattern := printf `(?i)(?:%[1]s\s*[;]\s*)*max-age\s*=\s*(?:\d+|"\d+")(?:\s*[;]\s*%[1]s)*`  $hstsOptionalTokenPattern -}}
+{{- $hstsPattern := printf `(?i)(?:%[1]s[ \t]*[;][ \t]*)*max-age[ \t]*=[ \t]*(?:\d+|"\d+")(?:[ \t]*[;][ \t]*%[1]s)*(?:[ \t]*;)?`  $hstsOptionalTokenPattern -}}
 
 {{- /* setForwardedHeadersPattern matches valid options for how and when Forwarded: and X-Forwarded-*: headers are set. */}}
 {{- $setForwardedHeadersPattern := `(?:append|replace|if-none|never)` -}}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -491,6 +491,129 @@ func TestConfigTemplate(t *testing.T) {
 				},
 			},
 		},
+		"HSTS with newline": {
+			mustCreateWithConfig{
+				mustCreateRoute: mustCreateRoute{
+					name: "hsts-nl1",
+					host: "hstsnl1.example.com",
+					path: "",
+					time: start,
+					annotations: map[string]string{
+						"haproxy.router.openshift.io/hsts_header": "max-age=31536000\n;\npreload",
+					},
+					tlsTermination: routev1.TLSTerminationEdge,
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: edgeBackendName(h.namespace, "hsts-nl1"),
+					attribute:   "http-response",
+					value:       `set-header Strict-Transport-Security`,
+					notFound:    true,
+				},
+			},
+		},
+		"HSTS with CRLF": {
+			mustCreateWithConfig{
+				mustCreateRoute: mustCreateRoute{
+					name: "hsts-nl2",
+					host: "hstsnl2.example.com",
+					path: "",
+					time: start,
+					annotations: map[string]string{
+						"haproxy.router.openshift.io/hsts_header": "max-age=31536000\r\n;\r\npreload",
+					},
+					tlsTermination: routev1.TLSTerminationEdge,
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: edgeBackendName(h.namespace, "hsts-nl2"),
+					attribute:   "http-response",
+					value:       `set-header Strict-Transport-Security`,
+					notFound:    true,
+				},
+			},
+		},
+		"HSTS with carriage return": {
+			mustCreateWithConfig{
+				mustCreateRoute: mustCreateRoute{
+					name: "hsts-nl3",
+					host: "hstsnl3.example.com",
+					path: "",
+					time: start,
+					annotations: map[string]string{
+						"haproxy.router.openshift.io/hsts_header": "max-age=31536000\r;\rpreload",
+					},
+					tlsTermination: routev1.TLSTerminationEdge,
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: edgeBackendName(h.namespace, "hsts-nl3"),
+					attribute:   "http-response",
+					value:       `set-header Strict-Transport-Security`,
+					notFound:    true,
+				},
+			},
+		},
+		"HSTS with trailing semicolon": {
+			mustCreateWithConfig{
+				mustCreateRoute: mustCreateRoute{
+					name: "hsts-ts1",
+					host: "hststs1.example.com",
+					path: "",
+					time: start,
+					annotations: map[string]string{
+						"haproxy.router.openshift.io/hsts_header": "max-age=31536000;includeSubDomains;",
+					},
+					tlsTermination: routev1.TLSTerminationEdge,
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: edgeBackendName(h.namespace, "hsts-ts1"),
+					attribute:   "http-response",
+					value:       `set-header Strict-Transport-Security 'max-age=31536000;includeSubDomains;'`,
+				},
+			},
+		},
+		"HSTS with trailing semicolon after preload": {
+			mustCreateWithConfig{
+				mustCreateRoute: mustCreateRoute{
+					name: "hsts-ts2",
+					host: "hststs2.example.com",
+					path: "",
+					time: start,
+					annotations: map[string]string{
+						"haproxy.router.openshift.io/hsts_header": "max-age=31536000;preload;",
+					},
+					tlsTermination: routev1.TLSTerminationEdge,
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: edgeBackendName(h.namespace, "hsts-ts2"),
+					attribute:   "http-response",
+					value:       `set-header Strict-Transport-Security 'max-age=31536000;preload;'`,
+				},
+			},
+		},
+		"HSTS with tab whitespace": {
+			mustCreateWithConfig{
+				mustCreateRoute: mustCreateRoute{
+					name: "hsts-tab1",
+					host: "hststab1.example.com",
+					path: "",
+					time: start,
+					annotations: map[string]string{
+						"haproxy.router.openshift.io/hsts_header": "max-age=31536000\t;\tpreload",
+					},
+					tlsTermination: routev1.TLSTerminationEdge,
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: edgeBackendName(h.namespace, "hsts-tab1"),
+					attribute:   "http-response",
+					value:       "set-header Strict-Transport-Security 'max-age=31536000\t;\tpreload'",
+				},
+			},
+		},
 		"Simple global HTTP request header": {
 			mustCreateWithConfig{
 				mustMatchConfig: mustMatchConfig{


### PR DESCRIPTION
## Summary

- Replace `\s*` with `[ \t]*` in the HSTS regex pattern to reject newline characters (`\n`, `\r`, `\f`) that break HAProxy config on reload and can cause cluster-wide router unavailability
- Allow an optional trailing semicolon in HSTS annotation values, which were previously silently rejected causing the `Strict-Transport-Security` header to not be set
- Add 6 new unit tests covering newline rejection (3 cases) and trailing semicolon acceptance (3 cases)

## The Issue

The HSTS regex in `haproxy-config.template:31` used `\s*` to match whitespace between directives. In Go, `\s` matches `[\t\n\f\r ]` — including newlines. An annotation like `max-age=31536000\n;\npreload` would pass the regex, render literal newlines into the HAProxy config, and cause HAProxy to reject the entire config on reload — taking down all routes cluster-wide.

## Solution

Two changes to the same regex:
1. `\s*` → `[ \t]*` — restricts whitespace matching to horizontal whitespace only (spaces and tabs)
2. Append `(?:[ \t]*;)?` — allows an optional trailing semicolon, fixing a silent failure that has existed since 2018 ([openshift/origin#19860](https://github.com/openshift/origin/issues/19860))