### PR TITLE
NE-2826: Fix staticcheck warnings across multiple packages

### DIFF
--- a/pkg/cmd/infra/router/clientcmd.go
+++ b/pkg/cmd/infra/router/clientcmd.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/pflag"
 
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	kclientcmd "k8s.io/client-go/tools/clientcmd"
 	kclientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
@@ -22,7 +21,7 @@ type Config struct {
 	// Namespace is the namespace to act in
 	Namespace string
 
-	clientConfig clientcmd.ClientConfig
+	clientConfig kclientcmd.ClientConfig
 }
 
 // NewConfig returns a new configuration

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -850,23 +850,21 @@ func (o *TemplateRouterOptions) Run(stopCh <-chan struct{}) error {
 
 	proc.StartReaper(6 * time.Second)
 
-	select {
-	case <-stopCh:
-		cancel()
-		// 45s is the default interval that almost all cloud load balancers require to take an unhealthy
-		// endpoint out of rotation.
-		delay := getIntervalFromEnv("ROUTER_GRACEFUL_SHUTDOWN_DELAY", 45)
-		log.Info(fmt.Sprintf("Shutdown requested, waiting %s for new connections to cease", delay))
-		time.Sleep(delay)
-		log.Info("Instructing the template router to terminate")
-		if err := templatePlugin.Stop(); err != nil {
-			log.Error(err, "Router did not shut down cleanly")
-		} else {
-			log.Info("Shutdown complete, exiting")
-		}
-		// wait one second to let any remaining actions settle
-		time.Sleep(time.Second)
+	<-stopCh
+	cancel()
+	// 45s is the default interval that almost all cloud load balancers require to take an unhealthy
+	// endpoint out of rotation.
+	delay := getIntervalFromEnv("ROUTER_GRACEFUL_SHUTDOWN_DELAY", 45)
+	log.Info(fmt.Sprintf("Shutdown requested, waiting %s for new connections to cease", delay))
+	time.Sleep(delay)
+	log.Info("Instructing the template router to terminate")
+	if err := templatePlugin.Stop(); err != nil {
+		log.Error(err, "Router did not shut down cleanly")
+	} else {
+		log.Info("Shutdown complete, exiting")
 	}
+	// wait one second to let any remaining actions settle
+	time.Sleep(time.Second)
 	return nil
 }
 

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -162,7 +162,7 @@ func (f *RouterControllerFactory) registerInformerEventHandlers(rc *routercontro
 func (f *RouterControllerFactory) aggregateEndpointSlice(namespace, name string) []discoveryv1.EndpointSlice {
 	objType := reflect.TypeOf(&discoveryv1.EndpointSlice{})
 	objs, _ := f.informers[objType].GetIndexer().ByIndex(ServiceNameIndex, path.Join(namespace, name))
-	fullSet := make([]discoveryv1.EndpointSlice, len(objs), len(objs))
+	fullSet := make([]discoveryv1.EndpointSlice, len(objs))
 
 	for i := range objs {
 		eps := objs[i].(*discoveryv1.EndpointSlice)

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -120,11 +119,11 @@ func (a *StatusAdmitter) HandleRoute(eventType watch.EventType, route *routev1.R
 	return a.plugin.HandleRoute(eventType, route)
 }
 
-func (a *StatusAdmitter) HandleNode(eventType watch.EventType, node *kapi.Node) error {
+func (a *StatusAdmitter) HandleNode(eventType watch.EventType, node *corev1.Node) error {
 	return a.plugin.HandleNode(eventType, node)
 }
 
-func (a *StatusAdmitter) HandleEndpoints(eventType watch.EventType, route *kapi.Endpoints) error {
+func (a *StatusAdmitter) HandleEndpoints(eventType watch.EventType, route *corev1.Endpoints) error {
 	return a.plugin.HandleEndpoints(eventType, route)
 }
 

--- a/pkg/router/crl/crl.go
+++ b/pkg/router/crl/crl.go
@@ -147,10 +147,8 @@ func ManageCRLs(caBundleFilename string, caUpdateChannel <-chan struct{}, update
 			updated := false
 			if nextUpdate.IsZero() {
 				log.V(4).Info("no nextUpdate. only watching for CA updates")
-				select {
-				case <-caUpdateChannel:
-					caUpdated = true
-				}
+				<-caUpdateChannel
+				caUpdated = true
 			} else {
 				log.V(4).Info("nextUpdate is at " + nextUpdate.Format(time.RFC3339))
 				select {

--- a/pkg/router/metrics/metrics.go
+++ b/pkg/router/metrics/metrics.go
@@ -65,7 +65,7 @@ func (l Listener) authorizeHandler(protected http.Handler) http.Handler {
 				if u == l.Username && p == l.Password {
 					protected.ServeHTTP(w, req)
 				} else {
-					http.Error(w, fmt.Sprintf("Unauthorized"), http.StatusUnauthorized)
+					http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				}
 				return
 			}


### PR DESCRIPTION
## Description
Address several staticcheck findings across the router codebase:

- **S1039**: Remove unnecessary `fmt.Sprintf` wrapping a plain string (`metrics.go`)
- **S1000**: Simplify single-case `select` to direct channel receive (`template.go`, `crl.go`)
- **S1019**: Remove redundant capacity argument in `make` (`factory.go`)
- **ST1019**: Consolidate duplicate package imports (`clientcmd.go`, `status.go`)

## Changes
- `pkg/router/metrics/metrics.go`: Replace `fmt.Sprintf("Unauthorized")` with string literal
- `pkg/cmd/infra/router/template.go`: Replace single-case `select` with direct `<-stopCh` receive
- `pkg/router/crl/crl.go`: Replace single-case `select` with direct channel receive
- `pkg/router/controller/factory/factory.go`: Remove redundant cap in `make([]T, len, len)`
- `pkg/cmd/infra/router/clientcmd.go`: Remove duplicate import of `k8s.io/client-go/tools/clientcmd`
- `pkg/router/controller/status.go`: Remove duplicate import of `k8s.io/api/core/v1`

All changes are mechanical and do not alter runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved router shutdown flow to reliably wait for the stop signal before starting graceful shutdown.
  * Simplified certificate update watching for more predictable CA update behavior.
  * Standardized BasicAuth failures to return a 401 Unauthorized with body “Unauthorized”.
  * Kept Kubernetes node and endpoint event handling consistent with the expected API types.
* **Refactor**
  * Updated internal Kubernetes config/type usage and optimized endpoint slice allocation without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->