### PR TITLE
RFE-2924: Return HTTP 429 when route HTTP rate limit is exceeded

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -708,7 +708,9 @@ backend {{ genBackendNamePrefix $cfg.TLSTermination }}:{{ $cfgIdx }}
           {{- end }}
 
           {{- if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-http")) }}
-  tcp-request content reject if { src_http_req_rate ge {{ index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-http" }} }
+  # Return HTTP 429 when the per-source HTTP request rate limit is exceeded (RFE-2924).
+  # TCP connection limits above still use tcp-request reject because no HTTP response is possible there.
+  http-request deny deny_status 429 if { src_http_req_rate ge {{ index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-http" }} }
           {{- else }}
   #HTTP request rate not restricted
           {{- end }}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -976,6 +976,47 @@ func TestConfigTemplate(t *testing.T) {
 				},
 			},
 		},
+		"HTTP rate limit returns 429": {
+			mustCreateWithConfig{
+				mustCreateRoute: mustCreateRoute{
+					name: "rate-limit-http",
+					host: "rate-limit-http.example.com",
+					path: "",
+					time: start,
+					annotations: map[string]string{
+						"haproxy.router.openshift.io/rate-limit-connections":           "true",
+						"haproxy.router.openshift.io/rate-limit-connections.rate-http": "40",
+					},
+					tlsTermination: routev1.TLSTerminationEdge,
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: edgeBackendName(h.namespace, "rate-limit-http"),
+					attribute:   "http-request",
+					value:       `deny deny_status 429 if { src_http_req_rate ge 40 }`,
+				},
+			},
+		},
+		"HTTP rate limit 429 on insecure backend": {
+			mustCreateWithConfig{
+				mustCreateRoute: mustCreateRoute{
+					name: "rate-limit-http-insecure",
+					host: "rate-limit-http-insecure.example.com",
+					path: "",
+					time: start,
+					annotations: map[string]string{
+						"haproxy.router.openshift.io/rate-limit-connections":           "true",
+						"haproxy.router.openshift.io/rate-limit-connections.rate-http": "10",
+					},
+				},
+				mustMatchConfig: mustMatchConfig{
+					section:     "backend",
+					sectionName: insecureBackendName(h.namespace, "rate-limit-http-insecure"),
+					attribute:   "http-request",
+					value:       `deny deny_status 429 if { src_http_req_rate ge 10 }`,
+				},
+			},
+		},
 	}
 
 	defer cleanUpRoutes(t)


### PR DESCRIPTION
## Summary
- When `haproxy.router.openshift.io/rate-limit-connections.rate-http` is exceeded, HAProxy previously used `tcp-request content reject`, which dropped the connection with no HTTP status (clients saw "Empty reply from server").
- Change that path to `http-request deny deny_status 429` so rate-limited HTTP clients receive **HTTP 429 Too Many Requests**.
- Leave `concurrent-tcp` and `rate-tcp` as `tcp-request content reject` (TCP-layer limits; no HTTP response is possible). Passthrough backends are unchanged (no `rate-http` there).
Fixes: https://issues.redhat.com/browse/RFE-2924
## Changes
- `images/router/haproxy/conf/haproxy-config.template`: use `http-request deny deny_status 429` for `rate-http`.
- `pkg/router/router_test.go`: add `TestConfigTemplate` cases for edge and insecure backends.
## Test plan
- [ ] `CGO_ENABLED=1 go test -mod=vendor -count=1 -timeout 120s -v ./pkg/router/ -run 'TestConfigTemplate'`
- [ ] Manual: annotate a route with rate-limit + low `rate-http`, exceed the limit, confirm response is `429` (not empty reply)
- [ ] Confirm `concurrent-tcp` / `rate-tcp` still reject without an HTTP status
- [ ] Confirm passthrough routes with TCP rate limits are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP requests exceeding configured per-route rate limits now receive a clear **429 Too Many Requests** response instead of a generic rejection.
  * TCP connection limits continue to use connection-level rejection behavior.

* **Tests**
  * Added coverage for HTTP rate limiting on secure and non-secure routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->