### PR TITLE
NE-2829: images/router/f5: Delete F5 router Dockerfile

### DIFF
--- a/images/router/f5/.cccp.yml
+++ b/images/router/f5/.cccp.yml
@@ -1,1 +1,0 @@
-job-id: origin-f5-router

--- a/images/router/f5/Dockerfile
+++ b/images/router/f5/Dockerfile
@@ -1,6 +1,0 @@
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base-router
-RUN ln -s /usr/bin/openshift-router /usr/bin/openshift-f5-router
-LABEL io.k8s.display-name="OpenShift F5 Router" \
-      io.k8s.description="This is a component of OpenShift and programs a BigIP F5 router to expose ingress to services within the cluster." \
-      io.openshift.tags="openshift,router,f5"
-ENTRYPOINT ["/usr/bin/openshift-f5-router"]

--- a/images/router/f5/Dockerfile.rhel
+++ b/images/router/f5/Dockerfile.rhel
@@ -1,6 +1,0 @@
-FROM registry.svc.ci.openshift.org/ocp/4.0:base-router
-RUN ln -s /usr/bin/openshift-router /usr/bin/openshift-f5-router
-LABEL io.k8s.display-name="OpenShift F5 Router" \
-      io.k8s.description="This is a component of OpenShift and programs a BigIP F5 router to expose ingress to services within the cluster." \
-      io.openshift.tags="openshift,router,f5"
-ENTRYPOINT ["/usr/bin/openshift-f5-router"]

--- a/images/router/f5/bin/.gitignore
+++ b/images/router/f5/bin/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Delete the `images/router/f5/` directory, which contained the Dockerfile and supporting files for the F5 BIG-IP router plugin image. These are the last remaining artifacts of the F5 router plugin, whose Go implementation was already removed.

The F5 router code was deleted in three stages:

  1. The Go source and tests were removed from this repository in PR #46 (commit 2c04e3a44586f2266879bd9548add0cb5778f38a).

  2. The F5 router image was removed from the Prow CI configuration in openshift/release#74313 (commit https://github.com/openshift/release/commit/7a5d5f1a3cd66a16ae8d28a8c4e7ffdd43f8fde1).

  3. The F5 router image was removed from the ART build configuration in openshift-eng/ocp-build-data (commit https://github.com/openshift-eng/ocp-build-data/commit/ccb97c75b58a1706d2111c396cf6c3437bc6e05e).

This PR completes the cleanup by deleting the four files that remained under `images/router/f5/`:

  - `Dockerfile`           (CentOS-based image definition)
  - `Dockerfile.rhel`      (RHEL-based image definition)
  - `.cccp.yml`            (container build service config)
  - `bin/.gitignore`        (placeholder for copied binary)
