### PR TITLE
OCPBUGS-98255: Tolerate 403 reply on router-reload caused by security posture change to disable 404 reply

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -36,7 +36,7 @@ function haproxyHealthCheck() {
   while true; do
     local httpcode=$(curl $timeout_opts $proxy_opts -s -o /dev/null -I -H "Host: " -w "%{http_code}" ${url})
 
-    if [[ "$httpcode" = 503 || "$httpcode" = 404 ]]; then
+    if [[ "$httpcode" = 503 || "$httpcode" = 404 || "$httpcode" = 403 ]]; then
       echo " - Health check ok : $retries retry attempt(s)."
       return 0
     fi


### PR DESCRIPTION
Addressing [OCPBUGS-98255](https://redhat.atlassian.net/browse/OCPBUGS-98255) - this PR seeks to resolve the impact condition from a restrictive response condition expectation from HAProxy when a proxy is in use for the cluster, and the customer has disabled 404 responses as a security posture update. (Change enforces a 403 instead on all calls that don't otherwise return a valid response code or 503). Because the response will now default to a 403 instead of the expected 404 the call will time out/repeatedly re-probing the port. This may lead to delay during reload execution despite successful configuration mapping.

~~~
    if [[ "$httpcode" = 503 || "$httpcode" = 404 ]]; then
~~~

Logs generated that this PR will alleviate:
~~~
2026-05-26T14:14:35.480260083Z E0526 14:14:35.479914       1 limiter.go:165] error reloading router: exit status 1
2026-05-26T14:14:35.480260083Z  - Checking http://localhost:80 using PROXY protocol ...
2026-05-26T14:14:35.480260083Z  - Exceeded max wait time (30) in health check - 57 retry attempt(s).
2026-05-26T14:15:05.010854562Z E0526 14:15:05.010807       1 limiter.go:165] error reloading router: exit status 1
2026-05-26T14:15:05.010854562Z  - Checking http://localhost:80 using PROXY protocol ...
2026-05-26T14:15:05.010854562Z  - Exceeded max wait time (30) in health check - 55 retry attempt(s).
~~~