### PR TITLE
NO-JIRA: Smoke test for HAProxy 2.8 perf run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 openshift-router
 ================
 
+
 This repository contains the OpenShift routers for NGINX, HAProxy, and F5. They read `Route` objects out of the
 OpenShift API and allow ingress to services. HAProxy is currently the reference implementation. See the details
 in each router image.


### PR DESCRIPTION
No-op change to trigger a CI build for HAProxy 2.8 perf testing.

DO NOT MERGE