### PR TITLE
OCPBUGS-84250: Add debug logging when dynamic update fails

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -526,6 +526,7 @@ func (r *templateRouter) Commit() {
 	r.lock.Unlock()
 
 	if needsCommit {
+		log.V(4).Info("queuing reload")
 		r.rateLimitedCommitFunction.RegisterChange()
 	}
 }
@@ -726,6 +727,8 @@ func (r *templateRouter) FilterNamespaces(namespaces sets.String) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
+	previouslyChanged := r.stateChanged
+
 	if len(namespaces) == 0 {
 		r.state = make(map[ServiceAliasConfigKey]ServiceAliasConfig)
 		r.serviceUnits = make(map[ServiceUnitKey]ServiceUnit)
@@ -751,6 +754,9 @@ func (r *templateRouter) FilterNamespaces(namespaces sets.String) {
 	}
 
 	if r.stateChanged {
+		if !previouslyChanged {
+			log.V(4).Info("namespace filter caused state change, reload needed")
+		}
 		r.dynamicallyConfigured = false
 	}
 }
@@ -1272,6 +1278,8 @@ func (r *templateRouter) removeRouteInternal(route *routev1.Route) {
 	for key := range serviceAliasConfig.ServiceUnits {
 		r.removeServiceAliasAssociation(key, backendKey)
 	}
+
+	log.V(4).Info("removing route", "backendKey", backendKey, "dynamicRemoveFailed", !configChanged)
 
 	r.cleanUpServiceAliasConfig(&serviceAliasConfig)
 	delete(r.state, backendKey)


### PR DESCRIPTION
Adding some more logging when a dynamic update fails and router asks HAProxy to reload to apply configuration changes. Those new logs are useful to trace what happened in the router when DCM related tests fail.

https://redhat.atlassian.net/browse/OCPBUGS-84250