### PR TITLE
OCPBUGS-77056: Lock DeleteFunc to stop SARCompleted overwriting rejection

### DIFF
--- a/pkg/router/controller/route_secret_manager.go
+++ b/pkg/router/controller/route_secret_manager.go
@@ -309,8 +309,13 @@ func (p *RouteSecretManager) HandleRoute(eventType watch.EventType, route *route
 	// with the secret informer's own DeleteFunc on a different goroutine, so
 	// a watch.Added registration that was already in flight when the secret
 	// got deleted can finish afterward and write this SARCompleted status,
-	// silently overwriting DeleteFunc's rejection. Checking deletedSecrets
-	// here closes that race regardless of which goroutine finishes last.
+	// silently overwriting DeleteFunc's rejection. Two things guard against
+	// that: every registered path still holds the per-route lock here (via
+	// validateAndRegister's deferred unlock), and DeleteFunc takes that same
+	// lock around its deletedSecrets.Store + rejection -- so the Load below
+	// and the Store there can't interleave, and whichever side runs second
+	// observes the other's write. If DeleteFunc ran first, secretDeleted is
+	// true and we skip the write, leaving the rejection authoritative.
 	if err == nil && registered {
 		key := routeKey(route.Namespace, route.Name)
 		if _, secretDeleted := p.deletedSecrets.Load(key); !secretDeleted {
@@ -514,6 +519,20 @@ func (p *RouteSecretManager) generateSecretHandler(namespace, routeName string) 
 			msg := fmt.Sprintf("external certificate validation failed: secret %q deleted for route %q", secret.Name, key)
 			log.V(4).Info(msg)
 			routeapihelpers.InvalidateAsyncSARCache(namespace, secret.Name)
+
+			// Serialize the mark-deleted + reject sequence against a
+			// concurrent registration's SARCompleted write in HandleRoute's
+			// tail, which holds this same per-route lock. Without it, the two
+			// steps here are not atomic relative to that tail's
+			// deletedSecrets.Load() guard and RecordRouteUpdate(SARCompleted)
+			// write: an in-flight registration that loaded deletedSecrets
+			// before this handler stored it can still finish afterward and
+			// overwrite the rejection below with a stale SARCompleted status,
+			// leaving the route admitted with its backing secret already gone.
+			// Holding the lock across both makes the rejection authoritative
+			// regardless of which goroutine runs second (OCPBUGS-77056).
+			unlock := p.lockRoute(key)
+			defer unlock()
 
 			// keep the secret monitor active and mark the secret as deleted for this route.
 			p.deletedSecrets.Store(key, true)

--- a/pkg/router/controller/route_secret_manager_test.go
+++ b/pkg/router/controller/route_secret_manager_test.go
@@ -1769,6 +1769,101 @@ func TestInFlightRegistrationDoesNotReAdmitDeletedSecretRoute(t *testing.T) {
 	}
 }
 
+// TestDeleteFuncSerializesWithRegistrationLock verifies that DeleteFunc takes
+// the per-route lock before marking the secret deleted and rejecting the route.
+//
+// The deletedSecrets guard alone (see TestInFlightRegistrationDoesNotReAdmitDeletedSecretRoute)
+// only covers the ordering where DeleteFunc fully completes before an in-flight
+// registration reaches its SARCompleted write. It does NOT cover the interleaving
+// that actually regressed in CI: the registration's guard reads deletedSecrets
+// (not yet set) first, then DeleteFunc stores + rejects, then the registration
+// overwrites the rejection with SARCompleted. Serializing both sides on the
+// per-route lock is what closes that window; this test asserts DeleteFunc is
+// blocked while that lock is held (OCPBUGS-77056).
+func TestDeleteFuncSerializesWithRegistrationLock(t *testing.T) {
+	routeapihelpers.ClearAsyncSARCacheForTest()
+
+	secret := fakeSecret("sandbox", "tls-secret", corev1.SecretTypeTLS, map[string][]byte{
+		"tls.crt": []byte("my-crt"),
+		"tls.key": []byte("my-key"),
+	})
+
+	route := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route-test",
+			Namespace: "sandbox",
+		},
+		Spec: routev1.RouteSpec{
+			TLS: &routev1.TLSConfig{
+				ExternalCertificate: &routev1.LocalObjectReference{
+					Name: "tls-secret",
+				},
+			},
+		},
+	}
+
+	lister := &routeLister{items: []*routev1.Route{route}}
+	recorder := &statusRecorder{}
+
+	rsm := NewRouteSecretManager(
+		&fakePlugin{},
+		recorder,
+		&fake.SecretManager{
+			Secret:     secret,
+			IsPresent:  true,
+			SecretName: "tls-secret",
+		},
+		testRouterName,
+		&testSecretGetter{namespace: "sandbox", secret: secret},
+		lister,
+		&testSARCreator{allow: true},
+	)
+
+	key := routeKey(route.Namespace, route.Name)
+
+	// Simulate an in-flight registration holding the per-route lock across its
+	// guard-check + SARCompleted write. HandleRoute holds this same lock through
+	// its tail on every registered path (via validateAndRegister's deferred
+	// unlock), so DeleteFunc must block on it here.
+	unlock := rsm.lockRoute(key)
+
+	handler := rsm.generateSecretHandler(route.Namespace, route.Name)
+	done := make(chan struct{})
+	go func() {
+		handler.DeleteFunc(secret)
+		close(done)
+	}()
+
+	// While the lock is held, DeleteFunc must not proceed: no rejection recorded
+	// and deletedSecrets not yet set (both live inside the locked section).
+	select {
+	case <-done:
+		t.Fatal("DeleteFunc completed while the per-route lock was held; it is not serialized against the registration path (OCPBUGS-77056)")
+	case <-time.After(200 * time.Millisecond):
+		// expected: DeleteFunc is blocked on the per-route lock
+	}
+	if _, ok := rsm.deletedSecrets.Load(key); ok {
+		t.Fatal("deletedSecrets was set before the per-route lock was acquired; Store is not inside the locked section")
+	}
+	if r := recorder.GetRejections(); len(r) != 0 {
+		t.Fatalf("rejection recorded before the per-route lock was acquired: %v", r)
+	}
+
+	// Release the lock; DeleteFunc should now proceed and reject the route.
+	unlock()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("DeleteFunc did not complete after the per-route lock was released")
+	}
+
+	rejections := recorder.GetRejections()
+	if len(rejections) != 1 || rejections[0] != "sandbox-route-test:ExternalCertificateValidationFailed" {
+		t.Fatalf("expected one ValidationFailed rejection after lock release, got: %v", rejections)
+	}
+}
+
 func TestSecretDelete(t *testing.T) {
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## What

Fixes a residual race in the merged external-certificate fix (#828) that the Component Readiness / QSE triage bot flagged on OCPBUGS-77056 (re-regression of `OCPFeatureGate:RouteExternalCertificate`, techpreview variants across 4.22/4.23/5.0/5.1).

## The race

On secret deletion, `DeleteFunc` marks the route in `deletedSecrets` and records an `ExternalCertificateValidationFailed` rejection. `HandleRoute`'s tail guards its `SARCompleted` write with a `deletedSecrets.Load()` check — but that check and the `RecordRouteUpdate(SARCompleted)` write are **not atomic** relative to `DeleteFunc`'s `Store` + rejection. Losing interleaving:

1. `HandleRoute` (Added/registered) loads `deletedSecrets` → not deleted
2. `DeleteFunc` stores `deletedSecrets`, records rejection `[ValidationFailed, False]`
3. `HandleRoute` writes `[SARCompleted, True]`, overwriting the rejection

Result: after the backing secret is deleted, the route's ingress condition is stuck at `[ExternalCertificateSARCompleted, True]` instead of flipping to `[ExternalCertificateValidationFailed, False]`, which is what the e2e test (`test/extended/router/external_certificate.go`, "and the secret is deleted → then routes are not reachable") asserts. It surfaces as a race under the parallel conformance suite's concurrency/API load, not in an isolated single-spec run.

## The fix

Every `registered` path in `HandleRoute` already holds the per-route lock (`routeLocks`) through its tail via `validateAndRegister`'s deferred unlock. Having `DeleteFunc` acquire that **same** per-route lock around its `deletedSecrets.Store` + `RecordRouteRejection` serializes the two paths, so whichever runs second observes the other's write and the rejection stays authoritative in both orderings.

## Test

Adds `TestDeleteFuncSerializesWithRegistrationLock`, which asserts `DeleteFunc` blocks while the per-route lock is held (fails before this change, passes after). The existing `TestInFlightRegistrationDoesNotReAdmitDeletedSecretRoute` only covered the fully-sequential ordering the `deletedSecrets` guard already handled; this covers the interleaving that actually regressed. Full `pkg/router/controller` suite passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)